### PR TITLE
A good chunk of stable patterns for marker

### DIFF
--- a/marker_api/src/ast/common/id.rs
+++ b/marker_api/src/ast/common/id.rs
@@ -65,6 +65,26 @@ new_id! {
 }
 
 new_id! {
+    /// This ID uniquely identifies a variable during linting.
+    ///
+    /// A variable can have several declaration spots. This can happen if they
+    /// originate from an or binding. Like this:
+    /// ```
+    /// # #[allow(dead_code)]
+    /// # enum Helper {
+    /// #     One(&'static str),
+    /// #     Two(&'static str),
+    /// #     Three(&'static str),
+    /// # }
+    /// # let source = Helper::Three("duck");
+    /// if let Helper::One(msg) | Helper::Two(msg) = source {
+    ///     println!("{msg}");
+    /// }
+    /// ```
+    pub VarId: u64
+}
+
+new_id! {
     /// **Unstable**
     ///
     /// This id is used to identify `Span`s. This type is only intended for internal

--- a/marker_api/src/ast/mod.rs
+++ b/marker_api/src/ast/mod.rs
@@ -7,6 +7,7 @@ use self::item::ItemKind;
 
 pub mod generic;
 pub mod item;
+pub mod pat;
 pub mod ty;
 
 #[derive(Debug)]

--- a/marker_api/src/ast/pat.rs
+++ b/marker_api/src/ast/pat.rs
@@ -12,6 +12,10 @@ mod ref_pat;
 pub use ref_pat::*;
 mod struct_pat;
 pub use struct_pat::*;
+mod tuple_pat;
+pub use tuple_pat::*;
+mod slice_pat;
+pub use slice_pat::*;
 
 pub trait PatData<'ast>: Debug {
     /// Returns the span of this pattern.
@@ -29,6 +33,8 @@ pub enum PatKind<'ast> {
     Rest(&'ast RestPat<'ast>),
     Ref(&'ast RefPat<'ast>),
     Struct(&'ast StructPat<'ast>),
+    Tuple(&'ast TuplePat<'ast>),
+    Slice(&'ast SlicePat<'ast>),
 }
 
 #[repr(C)]

--- a/marker_api/src/ast/pat.rs
+++ b/marker_api/src/ast/pat.rs
@@ -4,6 +4,12 @@ use std::{fmt::Debug, marker::PhantomData};
 
 mod ident_pat;
 pub use ident_pat::*;
+mod wildcard_pat;
+pub use wildcard_pat::*;
+mod rest_pat;
+pub use rest_pat::*;
+mod ref_pat;
+pub use ref_pat::*;
 
 pub trait PatData<'ast>: Debug {
     /// Returns the span of this pattern.
@@ -17,6 +23,9 @@ pub trait PatData<'ast>: Debug {
 #[derive(Debug, Copy, Clone)]
 pub enum PatKind<'ast> {
     Ident(&'ast IdentPat<'ast>),
+    Wildcard(&'ast WildcardPat<'ast>),
+    Rest(&'ast RestPat<'ast>),
+    Ref(&'ast RefPat<'ast>),
 }
 
 #[repr(C)]

--- a/marker_api/src/ast/pat.rs
+++ b/marker_api/src/ast/pat.rs
@@ -37,6 +37,28 @@ pub enum PatKind<'ast> {
     Slice(&'ast SlicePat<'ast>),
 }
 
+impl<'ast> PatKind<'ast> {
+    impl_pat_data_fn!(span() -> &Span<'ast>);
+}
+
+macro_rules! impl_pat_data_fn {
+    ($method:ident () -> $return_ty:ty) => {
+        impl_pat_data_fn!(
+            $method() -> $return_ty,
+            Ident, Wildcard, Rest, Ref, Struct, Tuple, Slice
+        );
+    };
+    ($method:ident () -> $return_ty:ty $(, $item:ident)+) => {
+        pub fn $method(&self) -> $return_ty {
+            match self {
+                $(PatKind::$item(data) => data.$method(),)*
+            }
+        }
+    };
+}
+
+use impl_pat_data_fn;
+
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "driver-api", visibility::make(pub))]

--- a/marker_api/src/ast/pat.rs
+++ b/marker_api/src/ast/pat.rs
@@ -10,6 +10,8 @@ mod rest_pat;
 pub use rest_pat::*;
 mod ref_pat;
 pub use ref_pat::*;
+mod struct_pat;
+pub use struct_pat::*;
 
 pub trait PatData<'ast>: Debug {
     /// Returns the span of this pattern.
@@ -20,12 +22,13 @@ pub trait PatData<'ast>: Debug {
 
 #[repr(C)]
 #[non_exhaustive]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum PatKind<'ast> {
     Ident(&'ast IdentPat<'ast>),
     Wildcard(&'ast WildcardPat<'ast>),
     Rest(&'ast RestPat<'ast>),
     Ref(&'ast RefPat<'ast>),
+    Struct(&'ast StructPat<'ast>),
 }
 
 #[repr(C)]

--- a/marker_api/src/ast/pat.rs
+++ b/marker_api/src/ast/pat.rs
@@ -1,0 +1,65 @@
+use super::{Span, SpanId};
+
+use std::{fmt::Debug, marker::PhantomData};
+
+mod ident_pat;
+pub use ident_pat::*;
+
+pub trait PatData<'ast>: Debug {
+    /// Returns the span of this pattern.
+    fn span(&self) -> &Span<'ast>;
+
+    fn as_pat(&'ast self) -> PatKind<'ast>;
+}
+
+#[repr(C)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone)]
+pub enum PatKind<'ast> {
+    Ident(&'ast IdentPat<'ast>),
+}
+
+#[repr(C)]
+#[derive(Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "driver-api", visibility::make(pub))]
+struct CommonPatData<'ast> {
+    /// The lifetime is not needed right now, but it's safer to include it for
+    /// future additions. Having it in this struct makes it easier for all
+    /// pattern structs, as they will have a valid use for `'ast` even if they
+    /// don't need it. Otherwise, we might need to declare this field in each
+    /// pattern.
+    _lifetime: PhantomData<&'ast ()>,
+    span: SpanId,
+}
+
+#[cfg(feature = "driver-api")]
+impl<'ast> CommonPatData<'ast> {
+    pub fn new(span: SpanId) -> Self {
+        Self {
+            _lifetime: PhantomData,
+            span,
+        }
+    }
+}
+
+macro_rules! impl_pat_data {
+    ($self_ty:ty, $enum_name:ident) => {
+        impl<'ast> super::PatData<'ast> for $self_ty {
+            fn span(&self) -> &crate::ast::Span<'ast> {
+                $crate::context::with_cx(self, |cx| cx.get_span(self.data.span))
+            }
+
+            fn as_pat(&'ast self) -> crate::ast::pat::PatKind<'ast> {
+                $crate::ast::pat::PatKind::$enum_name(self)
+            }
+        }
+
+        impl<'ast> From<&'ast $self_ty> for $crate::ast::pat::PatKind<'ast> {
+            fn from(from: &'ast $self_ty) -> Self {
+                $crate::ast::pat::PatKind::$enum_name(from)
+            }
+        }
+    };
+}
+
+use impl_pat_data;

--- a/marker_api/src/ast/pat.rs
+++ b/marker_api/src/ast/pat.rs
@@ -16,6 +16,8 @@ mod tuple_pat;
 pub use tuple_pat::*;
 mod slice_pat;
 pub use slice_pat::*;
+mod or_pat;
+pub use or_pat::*;
 
 pub trait PatData<'ast>: Debug {
     /// Returns the span of this pattern.
@@ -35,6 +37,7 @@ pub enum PatKind<'ast> {
     Struct(&'ast StructPat<'ast>),
     Tuple(&'ast TuplePat<'ast>),
     Slice(&'ast SlicePat<'ast>),
+    Or(&'ast OrPat<'ast>),
 }
 
 impl<'ast> PatKind<'ast> {
@@ -45,7 +48,7 @@ macro_rules! impl_pat_data_fn {
     ($method:ident () -> $return_ty:ty) => {
         impl_pat_data_fn!(
             $method() -> $return_ty,
-            Ident, Wildcard, Rest, Ref, Struct, Tuple, Slice
+            Ident, Wildcard, Rest, Ref, Struct, Tuple, Slice, Or
         );
     };
     ($method:ident () -> $return_ty:ty $(, $item:ident)+) => {

--- a/marker_api/src/ast/pat/ident_pat.rs
+++ b/marker_api/src/ast/pat/ident_pat.rs
@@ -42,7 +42,7 @@ impl<'ast> IdentPat<'ast> {
     /// //  ^   ^^^
     /// //  |     +-- The pattern, that the variable is bound to
     /// //  |
-    /// //  +-------- The variable which is bound
+    /// //  +-------- The bound variable
     ///     _ => println!("x is most likely negative"),
     /// }
     /// ```

--- a/marker_api/src/ast/pat/ident_pat.rs
+++ b/marker_api/src/ast/pat/ident_pat.rs
@@ -1,0 +1,75 @@
+use crate::{
+    ast::{SymbolId, VarId},
+    context::with_cx,
+    ffi::FfiOption,
+};
+
+use super::{CommonPatData, PatKind};
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct IdentPat<'ast> {
+    data: CommonPatData<'ast>,
+    name: SymbolId,
+    var: VarId,
+    is_mut: bool,
+    is_ref: bool,
+    binding_pat: FfiOption<PatKind<'ast>>,
+}
+
+impl<'ast> IdentPat<'ast> {
+    pub fn name(&self) -> String {
+        with_cx(self, |cx| cx.symbol_str(self.name))
+    }
+
+    pub fn var_id(&self) -> VarId {
+        self.var
+    }
+
+    pub fn is_mut(&self) -> bool {
+        self.is_mut
+    }
+
+    pub fn is_ref(&self) -> bool {
+        self.is_ref
+    }
+
+    /// The pattern, if the variable originates from a binding to a pattern.
+    /// ```
+    /// # let expr = 10;
+    /// match expr {
+    ///     x @ 0.. => println!("{x} is positive"),
+    /// //  ^   ^^^
+    /// //  |     +-- The pattern, that the variable is bound to
+    /// //  |
+    /// //  +-------- The variable which is bound
+    ///     _ => println!("x is most likely negative"),
+    /// }
+    /// ```
+    pub fn binding_pat(&self) -> Option<PatKind<'ast>> {
+        self.binding_pat.copy()
+    }
+}
+
+super::impl_pat_data!(IdentPat<'ast>, Ident);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> IdentPat<'ast> {
+    pub fn new(
+        data: CommonPatData<'ast>,
+        name: SymbolId,
+        var: VarId,
+        is_mut: bool,
+        is_ref: bool,
+        binding_pat: Option<PatKind<'ast>>,
+    ) -> Self {
+        Self {
+            data,
+            name,
+            var,
+            is_mut,
+            is_ref,
+            binding_pat: binding_pat.into(),
+        }
+    }
+}

--- a/marker_api/src/ast/pat/or_pat.rs
+++ b/marker_api/src/ast/pat/or_pat.rs
@@ -1,0 +1,28 @@
+use crate::ffi::FfiSlice;
+
+use super::{CommonPatData, PatKind};
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct OrPat<'ast> {
+    data: CommonPatData<'ast>,
+    patterns: FfiSlice<'ast, PatKind<'ast>>,
+}
+
+impl<'ast> OrPat<'ast> {
+    pub fn patterns(&self) -> &[PatKind<'ast>] {
+        (&self.patterns).into()
+    }
+}
+
+super::impl_pat_data!(OrPat<'ast>, Or);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> OrPat<'ast> {
+    pub fn new(data: CommonPatData<'ast>, patterns: &'ast [PatKind<'ast>]) -> Self {
+        Self {
+            data,
+            patterns: patterns.into(),
+        }
+    }
+}

--- a/marker_api/src/ast/pat/ref_pat.rs
+++ b/marker_api/src/ast/pat/ref_pat.rs
@@ -1,0 +1,16 @@
+use super::CommonPatData;
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct RefPat<'ast> {
+    data: CommonPatData<'ast>,
+}
+
+super::impl_pat_data!(RefPat<'ast>, Ref);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> RefPat<'ast> {
+    pub fn new(data: CommonPatData<'ast>) -> Self {
+        Self { data }
+    }
+}

--- a/marker_api/src/ast/pat/ref_pat.rs
+++ b/marker_api/src/ast/pat/ref_pat.rs
@@ -1,16 +1,24 @@
-use super::CommonPatData;
+use super::{CommonPatData, PatKind};
 
 #[repr(C)]
 #[derive(Debug)]
 pub struct RefPat<'ast> {
     data: CommonPatData<'ast>,
+    pattern: PatKind<'ast>,
+}
+
+impl<'ast> RefPat<'ast> {
+    /// Returns the pattern, that is behind this reference pattern.
+    pub fn pattern(&self) -> PatKind<'ast> {
+        self.pattern
+    }
 }
 
 super::impl_pat_data!(RefPat<'ast>, Ref);
 
 #[cfg(feature = "driver-api")]
 impl<'ast> RefPat<'ast> {
-    pub fn new(data: CommonPatData<'ast>) -> Self {
-        Self { data }
+    pub fn new(data: CommonPatData<'ast>, pattern: PatKind<'ast>) -> Self {
+        Self { data, pattern }
     }
 }

--- a/marker_api/src/ast/pat/rest_pat.rs
+++ b/marker_api/src/ast/pat/rest_pat.rs
@@ -1,0 +1,16 @@
+use super::CommonPatData;
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct RestPat<'ast> {
+    data: CommonPatData<'ast>,
+}
+
+super::impl_pat_data!(RestPat<'ast>, Rest);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> RestPat<'ast> {
+    pub fn new(data: CommonPatData<'ast>) -> Self {
+        Self { data }
+    }
+}

--- a/marker_api/src/ast/pat/slice_pat.rs
+++ b/marker_api/src/ast/pat/slice_pat.rs
@@ -1,0 +1,28 @@
+use crate::ffi::FfiSlice;
+
+use super::{CommonPatData, PatKind};
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct SlicePat<'ast> {
+    data: CommonPatData<'ast>,
+    elements: FfiSlice<'ast, PatKind<'ast>>,
+}
+
+impl<'ast> SlicePat<'ast> {
+    pub fn elements(&self) -> &[PatKind<'ast>] {
+        (&self.elements).into()
+    }
+}
+
+super::impl_pat_data!(SlicePat<'ast>, Slice);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> SlicePat<'ast> {
+    pub fn new(data: CommonPatData<'ast>, elements: &'ast [PatKind<'ast>]) -> Self {
+        Self {
+            data,
+            elements: elements.into(),
+        }
+    }
+}

--- a/marker_api/src/ast/pat/struct_pat.rs
+++ b/marker_api/src/ast/pat/struct_pat.rs
@@ -1,0 +1,111 @@
+use crate::{
+    ast::{AstPath, Span, SpanId, SymbolId, VarId},
+    context::with_cx,
+    ffi::{FfiOption, FfiSlice},
+};
+
+use super::{CommonPatData, PatKind};
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct StructPat<'ast> {
+    data: CommonPatData<'ast>,
+    path: AstPath<'ast>,
+    fields: FfiSlice<'ast, StructFieldPat<'ast>>,
+    is_exhaustive: bool,
+}
+
+impl<'ast> StructPat<'ast> {
+    pub fn path(&self) -> &AstPath<'ast> {
+        &self.path
+    }
+
+    pub fn fields(&self) -> &[StructFieldPat<'ast>] {
+        self.fields.get()
+    }
+
+    /// Returns `true` if the pattern is non exhaustive. The pattern might still
+    /// cover all fields, but have a rest pattern (`..`) to map for potential new
+    /// fields or if the struct has been marked as `non_exhaustive`.
+    pub fn is_non_exhaustive(&self) -> bool {
+        self.is_exhaustive
+    }
+}
+
+super::impl_pat_data!(StructPat<'ast>, Struct);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> StructPat<'ast> {
+    pub fn new(
+        data: CommonPatData<'ast>,
+        path: AstPath<'ast>,
+        fields: &'ast [StructFieldPat<'ast>],
+        is_exhaustive: bool,
+    ) -> Self {
+        Self {
+            data,
+            path,
+            fields: fields.into(),
+            is_exhaustive,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct StructFieldPat<'ast> {
+    span: SpanId,
+    ident: SymbolId,
+    var_id: FfiOption<VarId>,
+    is_mut: bool,
+    is_ref: bool,
+    pat: FfiOption<PatKind<'ast>>,
+}
+
+impl<'ast> StructFieldPat<'ast> {
+    pub fn span(&self) -> &Span<'ast> {
+        with_cx(self, |cx| cx.get_span(self.span))
+    }
+
+    pub fn ident(&self) -> String {
+        with_cx(self, |cx| cx.symbol_str(self.ident))
+    }
+
+    /// The [`VarId`] if this field pattern binds the field.
+    pub fn var_id(&self) -> Option<VarId> {
+        self.var_id.copy()
+    }
+
+    pub fn is_mut(&self) -> bool {
+        self.is_mut
+    }
+
+    pub fn is_ref(&self) -> bool {
+        self.is_ref
+    }
+
+    pub fn pat(&self) -> Option<PatKind<'ast>> {
+        self.pat.copy()
+    }
+}
+
+#[cfg(feature = "driver-api")]
+impl<'ast> StructFieldPat<'ast> {
+    pub fn new(
+        span: SpanId,
+        ident: SymbolId,
+        var_id: Option<VarId>,
+        is_mut: bool,
+        is_ref: bool,
+        pat: Option<PatKind<'ast>>,
+    ) -> Self {
+        Self {
+            span,
+            ident,
+            var_id: var_id.into(),
+            is_mut,
+            is_ref,
+            pat: pat.into(),
+        }
+    }
+}

--- a/marker_api/src/ast/pat/struct_pat.rs
+++ b/marker_api/src/ast/pat/struct_pat.rs
@@ -12,7 +12,7 @@ pub struct StructPat<'ast> {
     data: CommonPatData<'ast>,
     path: AstPath<'ast>,
     fields: FfiSlice<'ast, StructFieldPat<'ast>>,
-    is_exhaustive: bool,
+    is_non_exhaustive: bool,
 }
 
 impl<'ast> StructPat<'ast> {
@@ -28,7 +28,7 @@ impl<'ast> StructPat<'ast> {
     /// cover all fields, but have a rest pattern (`..`) to map for potential new
     /// fields or if the struct has been marked as `non_exhaustive`.
     pub fn is_non_exhaustive(&self) -> bool {
-        self.is_exhaustive
+        self.is_non_exhaustive
     }
 }
 
@@ -40,13 +40,13 @@ impl<'ast> StructPat<'ast> {
         data: CommonPatData<'ast>,
         path: AstPath<'ast>,
         fields: &'ast [StructFieldPat<'ast>],
-        is_exhaustive: bool,
+        is_non_exhaustive: bool,
     ) -> Self {
         Self {
             data,
             path,
             fields: fields.into(),
-            is_exhaustive,
+            is_non_exhaustive,
         }
     }
 }

--- a/marker_api/src/ast/pat/struct_pat.rs
+++ b/marker_api/src/ast/pat/struct_pat.rs
@@ -1,7 +1,7 @@
 use crate::{
-    ast::{AstPath, Span, SpanId, SymbolId, VarId},
+    ast::{AstPath, Span, SpanId, SymbolId},
     context::with_cx,
-    ffi::{FfiOption, FfiSlice},
+    ffi::FfiSlice,
 };
 
 use super::{CommonPatData, PatKind};
@@ -51,15 +51,17 @@ impl<'ast> StructPat<'ast> {
     }
 }
 
+/// A pattern matching a field inside a [`StructPat`] instance.
+///
+/// Patterns that bind values directly to fields like `Struct {ref mut x}` are
+/// expressed as `Struct {x: ref mut x}`. This allows a uniform view of all field
+/// patterns. (This representation was inspired by rustc)
 #[repr(C)]
 #[derive(Debug)]
 pub struct StructFieldPat<'ast> {
     span: SpanId,
     ident: SymbolId,
-    var_id: FfiOption<VarId>,
-    is_mut: bool,
-    is_ref: bool,
-    pat: FfiOption<PatKind<'ast>>,
+    pat: PatKind<'ast>,
 }
 
 impl<'ast> StructFieldPat<'ast> {
@@ -71,41 +73,14 @@ impl<'ast> StructFieldPat<'ast> {
         with_cx(self, |cx| cx.symbol_str(self.ident))
     }
 
-    /// The [`VarId`] if this field pattern binds the field.
-    pub fn var_id(&self) -> Option<VarId> {
-        self.var_id.copy()
-    }
-
-    pub fn is_mut(&self) -> bool {
-        self.is_mut
-    }
-
-    pub fn is_ref(&self) -> bool {
-        self.is_ref
-    }
-
-    pub fn pat(&self) -> Option<PatKind<'ast>> {
-        self.pat.copy()
+    pub fn pat(&self) -> PatKind<'ast> {
+        self.pat
     }
 }
 
 #[cfg(feature = "driver-api")]
 impl<'ast> StructFieldPat<'ast> {
-    pub fn new(
-        span: SpanId,
-        ident: SymbolId,
-        var_id: Option<VarId>,
-        is_mut: bool,
-        is_ref: bool,
-        pat: Option<PatKind<'ast>>,
-    ) -> Self {
-        Self {
-            span,
-            ident,
-            var_id: var_id.into(),
-            is_mut,
-            is_ref,
-            pat: pat.into(),
-        }
+    pub fn new(span: SpanId, ident: SymbolId, pat: PatKind<'ast>) -> Self {
+        Self { span, ident, pat }
     }
 }

--- a/marker_api/src/ast/pat/tuple_pat.rs
+++ b/marker_api/src/ast/pat/tuple_pat.rs
@@ -1,0 +1,28 @@
+use crate::ffi::FfiSlice;
+
+use super::{CommonPatData, PatKind};
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct TuplePat<'ast> {
+    data: CommonPatData<'ast>,
+    elements: FfiSlice<'ast, PatKind<'ast>>,
+}
+
+impl<'ast> TuplePat<'ast> {
+    pub fn elements(&self) -> &[PatKind<'ast>] {
+        (&self.elements).into()
+    }
+}
+
+super::impl_pat_data!(TuplePat<'ast>, Tuple);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> TuplePat<'ast> {
+    pub fn new(data: CommonPatData<'ast>, elements: &'ast [PatKind<'ast>]) -> Self {
+        Self {
+            data,
+            elements: elements.into(),
+        }
+    }
+}

--- a/marker_api/src/ast/pat/wildcard_pat.rs
+++ b/marker_api/src/ast/pat/wildcard_pat.rs
@@ -1,0 +1,16 @@
+use super::CommonPatData;
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct WildcardPat<'ast> {
+    data: CommonPatData<'ast>,
+}
+
+super::impl_pat_data!(WildcardPat<'ast>, Wildcard);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> WildcardPat<'ast> {
+    pub fn new(data: CommonPatData<'ast>) -> Self {
+        Self { data }
+    }
+}


### PR DESCRIPTION
It's interesting to see how important patterns are to Rust. We use them all the time, often without noticing them. This adds the first few patterns, that can be expressed without expressions. Most of these can't be tested, but I'll try to add the rustc backend for them next.

CC: #50

---

As per usual, I'll merge this, if there has been no outside interaction, by the time I have the next PR ready. And reviews and feedback is very welcome!