### PR TITLE
(doc)comment nits

### DIFF
--- a/cargo-marker/src/cli.rs
+++ b/cargo-marker/src/cli.rs
@@ -58,6 +58,6 @@ fn check_command_args() -> impl IntoIterator<Item = impl Into<Arg>> {
             .long("lints")
             .num_args(1..)
             .value_parser(ValueParser::os_string())
-            .help("Defines a set of lints crates that should be used"),
+            .help("Defines a set of lint crates that should be used"),
     ]
 }

--- a/marker_adapter/src/context.rs
+++ b/marker_adapter/src/context.rs
@@ -14,7 +14,7 @@ use marker_api::{
 /// change and calling functions on them would require a stable ABI which Rust
 /// doesn't provide.
 ///
-/// In this case, the `DriverContextWrapper` will be passes as a `*const ()`
+/// In this case, the `DriverContextWrapper` will be passed as a `*const ()`
 /// pointer to [`DriverCallbacks`] which will do nothing with this data other
 /// than giving it back to functions declared in this module. Since the `&dyn`
 /// object is created, only used here and everything is compiled during the same

--- a/marker_api/src/ast/common/ast_path.rs
+++ b/marker_api/src/ast/common/ast_path.rs
@@ -15,7 +15,7 @@ use crate::{
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct AstPath<'ast> {
-    // FIXME: Add optional target ID for values lifetimes etc that is faster to compare
+    // FIXME: Add optional target ID for values, lifetimes, etc that is faster to compare
     //
     // You were last trying to fix the compiler error related to lifetime identification and paths
     segments: FfiSlice<'ast, AstPathSegment<'ast>>,

--- a/marker_api/src/ast/common/callable.rs
+++ b/marker_api/src/ast/common/callable.rs
@@ -74,7 +74,7 @@ impl<'ast> Parameter<'ast> {
 
 impl<'ast> Parameter<'ast> {
     // Function items actually use patterns and not names. Patterns are not yet
-    // implemented though. A pattern should be good enough for now.
+    // implemented though. A name should be good enough for now.
     pub fn name(&self) -> Option<String> {
         self.name.get().map(|sym| with_cx(self, |cx| cx.symbol_str(*sym)))
     }
@@ -131,8 +131,8 @@ impl<'ast> CommonCallableData<'ast> {
     }
 }
 
-/// This macro automatically implements the [`Callable`] trait for structs that
-/// have a [`CallableData`] field called `callable_data`.
+/// This macro automatically implements the [`CallableData`] trait for structs that
+/// have a `callable_data` field.
 macro_rules! impl_callable_data_trait {
     ($self_ty:ty) => {
         impl<'ast> $crate::ast::common::CallableData<'ast> for $self_ty {

--- a/marker_api/src/ast/common/callable.rs
+++ b/marker_api/src/ast/common/callable.rs
@@ -7,7 +7,7 @@ use crate::{
 use super::{Abi, Span, SpanId, SymbolId};
 
 /// This trait provides information about callable items and types. Some
-/// properties might not be available for every callable object. In those
+/// properties might not be available for every callable object. In these
 /// cases the default value will be returned.
 pub trait CallableData<'ast> {
     /// Returns `true`, if this callable is `const`.
@@ -22,12 +22,12 @@ pub trait CallableData<'ast> {
 
     /// Returns `true`, if this callable is marked as `unsafe`.
     ///
-    /// Defaults to `false` if unspecified. Extern functions will
+    /// Defaults to `false` if unspecified. `extern` functions will
     /// also return `false` by default, even if they require `unsafe`
     /// by default.
     fn is_unsafe(&self) -> bool;
 
-    /// Returns `true`, if this callable is marked as extern. Bare functions
+    /// Returns `true`, if this callable is marked as `extern`. Bare functions
     /// only use the `extern` keyword to specify the ABI. These will currently
     /// still return `false` even if the keyword is present. In those cases,
     /// please refer to the ABI instead.

--- a/marker_api/src/ast/common/callable.rs
+++ b/marker_api/src/ast/common/callable.rs
@@ -30,7 +30,7 @@ pub trait CallableData<'ast> {
     /// Returns `true`, if this callable is marked as `extern`. Bare functions
     /// only use the `extern` keyword to specify the ABI. These will currently
     /// still return `false` even if the keyword is present. In those cases,
-    /// please refer to the ABI instead.
+    /// please refer to the [`abi()`](`Self::abi`) instead.
     ///
     /// Defaults to `false` if unspecified.
     fn is_extern(&self) -> bool;
@@ -40,12 +40,12 @@ pub trait CallableData<'ast> {
 
     /// Returns `true`, if this callable has a specified `self` argument. The
     /// type of `self` can be retrieved from the first element of
-    /// [`CallableData::params()`].
+    /// [`params()`](`Self::params`).
     fn has_self(&self) -> bool;
 
     /// Returns the parameters, that this callable accepts. The `self` argument
     /// of methods, will be the first element of this slice. Use
-    /// [`CallableData::has_self`] to determine if the first argument is `self`.
+    /// [`has_self()`](`Self::has_self`) to determine if the first argument is `self`.
     fn params(&self) -> &[Parameter<'ast>];
 
     /// Returns the return type, if specified.

--- a/marker_api/src/ast/common/span.rs
+++ b/marker_api/src/ast/common/span.rs
@@ -61,7 +61,7 @@ impl<'ast> Span<'ast> {
         self.end = end;
     }
 
-    /// Returns the code that this span references or `None` if the code in unavailable
+    /// Returns the code that this span references or [`None`] if the code is unavailable.
     pub fn snippet(&self) -> Option<String> {
         with_cx(self, |cx| cx.span_snipped(self))
     }
@@ -70,7 +70,7 @@ impl<'ast> Span<'ast> {
     ///
     /// This is useful if you want to provide suggestions for your lint or more generally, if you
     /// want to convert a given [`Span`] to a [`String`]. To create suggestions consider using
-    /// [`snippet_with_applicability()`][Self::snippet_with_applicability] to ensure that the
+    /// [`snippet_with_applicability()`](`Self::snippet_with_applicability`) to ensure that the
     /// [`Applicability`] stays correct.
     ///
     /// # Example
@@ -88,12 +88,15 @@ impl<'ast> Span<'ast> {
         self.snippet().unwrap_or_else(|| default.to_string())
     }
 
-    /// Same as [`snippet()`][Self::snippet], but adapts the applicability level by following rules:
+    /// Same as [`snippet()`](`Self::snippet`), but adapts the applicability level by following
+    /// rules:
     ///
-    /// - Applicability level `Unspecified` will never be changed.
-    /// - If the span is inside a macro, change the applicability level to `MaybeIncorrect`.
-    /// - If the default value is used and the applicability level is `MachineApplicable`, change it
-    ///   to `HasPlaceholders`
+    /// - Applicability level [`Unspecified`](`Applicability::Unspecified`) will never be changed.
+    /// - If the span is inside a macro, change the applicability level to
+    ///   [`MaybeIncorrect`](`Applicability::MaybeIncorrect`).
+    /// - If the default value is used and the applicability level is
+    ///   [`MachineApplicable`](`Applicability::MachineApplicable`), change it to
+    ///   [`HasPlaceholders`](`Applicability::HasPlaceholders`)
     pub fn snippet_with_applicability(&self, default: &str, applicability: &mut Applicability) -> String {
         if *applicability != Applicability::Unspecified && self.is_from_macro() {
             *applicability = Applicability::MaybeIncorrect;
@@ -120,16 +123,16 @@ impl<'ast> Span<'ast> {
 
 /// **Unstable**
 ///
-/// This enum is used to request a `Span` instance from the driver context.
-/// it is only an internal type to avoid mapping every `Span`, since they are
+/// This enum is used to request a [`Span`] instance from the driver context.
+/// it is only an internal type to avoid mapping every [`Span`], since they are
 /// most often not needed.
 #[repr(C)]
 #[allow(clippy::exhaustive_enums)]
 #[cfg_attr(feature = "driver-api", visibility::make(pub))]
 pub(crate) enum SpanOwner {
-    /// This requests the `Span` belonging to the [`ItemId`].
+    /// This requests the [`Span`] belonging to the [`ItemId`].
     Item(ItemId),
-    /// This requests the `Span` belonging to a driver generated [`SpanId`]
+    /// This requests the [`Span`] belonging to a driver generated [`SpanId`]
     SpecificSpan(SpanId),
 }
 

--- a/marker_api/src/ast/common/span.rs
+++ b/marker_api/src/ast/common/span.rs
@@ -39,8 +39,8 @@ impl<'ast> Span<'ast> {
         self.start == self.end
     }
 
-    /// Returns true, if both spans originate from the sane source. This can for
-    /// instance be the same source file or macro expansion.
+    /// Returns true, if both spans originate from the same source. For example, this can be the
+    /// same source file or macro expansion.
     pub fn is_same_source(&self, other: &Span<'ast>) -> bool {
         self.source == other.source
     }
@@ -69,8 +69,9 @@ impl<'ast> Span<'ast> {
     /// Converts a span to a code snippet if available, otherwise returns the default.
     ///
     /// This is useful if you want to provide suggestions for your lint or more generally, if you
-    /// want to convert a given `Span` to a `String`. To create suggestions consider using
-    /// [`Span::snippet_with_applicability`] to ensure that the [`Applicability`] stays correct.
+    /// want to convert a given [`Span`] to a [`String`]. To create suggestions consider using
+    /// [`snippet_with_applicability()`][Self::snippet_with_applicability] to ensure that the
+    /// [`Applicability`] stays correct.
     ///
     /// # Example
     /// ```rust,ignore
@@ -87,7 +88,7 @@ impl<'ast> Span<'ast> {
         self.snippet().unwrap_or_else(|| default.to_string())
     }
 
-    /// Same as [`Span::snippet`], but it adapts the applicability level by following rules:
+    /// Same as [`snippet()`][Self::snippet], but adapts the applicability level by following rules:
     ///
     /// - Applicability level `Unspecified` will never be changed.
     /// - If the span is inside a macro, change the applicability level to `MaybeIncorrect`.

--- a/marker_api/src/ast/expr/str_lit_expr.rs
+++ b/marker_api/src/ast/expr/str_lit_expr.rs
@@ -60,11 +60,11 @@ super::impl_expr_data!(
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum StrKind {
-    /// A normal standard string like `"Hello \n world"`
+    /// A normal standard string like `"Hello world!"`
     Str,
     /// A raw string like `r#"Hello World!"#`
     Raw,
-    /// A byte string like `b"Hello world!"\0`. The content of a byte string doesn't
+    /// A byte string like `b"Hello world!\0"`. The content of a byte string doesn't
     /// have to be valid UTF-8
     Byte,
 }

--- a/marker_api/src/ast/generic.rs
+++ b/marker_api/src/ast/generic.rs
@@ -88,7 +88,7 @@ pub enum GenericArgKind<'ast> {
 }
 
 /// This represents the generic parameters of a generic item. The bounds applied
-/// to parameters as the declaration are stored as clauses in this struct.
+/// to the parameters in the declaration are stored as clauses in this struct.
 ///
 /// ```
 /// # use std::fmt::Debug;

--- a/marker_api/src/ast/generic.rs
+++ b/marker_api/src/ast/generic.rs
@@ -29,7 +29,7 @@ pub use clause::*;
 /// }
 /// ```
 ///
-/// See
+/// See:
 /// * [`GenericParams`]
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/marker_api/src/ast/generic/arg.rs
+++ b/marker_api/src/ast/generic/arg.rs
@@ -91,8 +91,8 @@ impl<'ast> Lifetime<'ast> {
     }
 }
 
-/// A generic bound in form `<identifier=type>`. For example `Item=i32` would be
-/// the generic binding for this example:
+/// A generic bound in form `<identifier=type>`. For example, `Item=i32` would be
+/// the generic binding here:
 ///
 /// ```ignore
 /// let _baz: &dyn Iterator<Item=i32> = todo!();

--- a/marker_api/src/ast/generic/arg.rs
+++ b/marker_api/src/ast/generic/arg.rs
@@ -57,8 +57,8 @@ impl<'ast> Lifetime<'ast> {
 }
 
 impl<'ast> Lifetime<'ast> {
-    /// This returns the [`GenericId`] of this lifetime, if it's labeled `None`
-    /// otherwise. `'static` will also return `None`
+    /// This returns the [`GenericId`] of this lifetime, if it's labeled, or [`None`]
+    /// otherwise. `'static` will also return [`None`]
     pub fn id(&self) -> Option<GenericId> {
         match self.kind {
             LifetimeKind::Label(_, id) => Some(id),
@@ -66,7 +66,7 @@ impl<'ast> Lifetime<'ast> {
         }
     }
 
-    /// Note that the `'static` lieftime is not a label and will therefore return `None`
+    /// Note that the `'static` lifetime is not a label and will therefore return [`None`]
     pub fn label(&self) -> Option<String> {
         match self.kind {
             LifetimeKind::Label(sym, _) => Some(with_cx(self, |cx| cx.symbol_str(sym))),
@@ -100,7 +100,7 @@ impl<'ast> Lifetime<'ast> {
 /// ```
 ///
 /// The corresponding instance would provide the name (`Item`), the defined type
-/// (`i32`) and potentially the span if this bound originates from source code.
+/// (`i32`) and potentially the [`Span`] if this bound originates from source code.
 ///
 /// See [paths in expressions](https://doc.rust-lang.org/reference/paths.html#paths-in-expressions)
 /// for more information.

--- a/marker_api/src/ast/generic/clause.rs
+++ b/marker_api/src/ast/generic/clause.rs
@@ -61,7 +61,7 @@ pub struct TyClause<'ast> {
 }
 
 impl<'ast> TyClause<'ast> {
-    /// Additional parameters introduced as part of this where clause with a `for`.
+    /// Additional parameters introduced as a part of this where clause with a `for`.
     pub fn params(&self) -> Option<&GenericParams<'ast>> {
         self.params.get()
     }

--- a/marker_api/src/ast/generic/clause.rs
+++ b/marker_api/src/ast/generic/clause.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use super::{GenericParams, Lifetime, TyParamBound};
 
-/// This represents a single clause in a where statement
+/// This represents a single clause in a [`where`](<https://doc.rust-lang.org/stable/reference/items/generics.html#where-clauses>) statement
 ///
 /// ```
 /// fn foo<'a, T>()

--- a/marker_api/src/ast/generic/clause.rs
+++ b/marker_api/src/ast/generic/clause.rs
@@ -15,8 +15,7 @@ use super::{GenericParams, Lifetime, TyParamBound};
 ///     T::Item: Copy,
 ///     String: PartialEq<T>,
 ///     i32: Default,
-/// {
-/// }
+/// {}
 /// ```
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -67,7 +66,7 @@ impl<'ast> TyClause<'ast> {
         self.params.get()
     }
 
-    /// The type that is bound
+    /// The bound type
     pub fn ty(&self) -> TyKind<'ast> {
         self.ty
     }

--- a/marker_api/src/ast/generic/param.rs
+++ b/marker_api/src/ast/generic/param.rs
@@ -51,8 +51,8 @@ impl<'ast> GenericParamKind<'ast> {
 /// This trait is a collection of common information that is provided by all
 /// generic parameters.
 pub trait GenericParamData<'ast> {
-    /// This returns the span, of the defined parameter, if this parameter is
-    /// part of the code base.
+    /// This returns the span, of the defined parameter, if this parameter originates from source
+    /// code.
     fn span(&self) -> Option<&Span<'ast>>;
     // FIXME: Add `fn attrs(&self) -> &[Attrs<'ast>]` once implemented.
 }

--- a/marker_api/src/ast/generic/param.rs
+++ b/marker_api/src/ast/generic/param.rs
@@ -31,8 +31,8 @@ pub enum GenericParamKind<'ast> {
 }
 
 impl<'ast> GenericParamKind<'ast> {
-    /// This returns the span, of the defined parameter, if this parameter is
-    /// part of the code base.
+    /// This returns the [`Span`], of the defined parameter, if this parameter originates from
+    /// source code.
     pub fn span(&self) -> Option<&Span<'ast>> {
         match self {
             GenericParamKind::Lifetime(lt) => lt.span(),

--- a/marker_api/src/ast/item.rs
+++ b/marker_api/src/ast/item.rs
@@ -95,7 +95,7 @@ impl<'ast> AssocItemKind<'ast> {
     impl_item_type_fn!(AssocItemKind: name() -> Option<String>);
     impl_item_type_fn!(AssocItemKind: attrs() -> ());
     impl_item_type_fn!(AssocItemKind: as_item() -> ItemKind<'ast>);
-    // FIXME: Potentualy add a field to the items to optionally store the owner id
+    // FIXME: Potentially add a field to the items to optionally store the owner id
 }
 
 impl<'ast> From<AssocItemKind<'ast>> for ItemKind<'ast> {
@@ -240,7 +240,7 @@ impl<'ast> CommonItemData<'ast> {
     }
 }
 
-/// FIXME: Add function as  discussed in <https://github.com/rust-marker/design/issues/22>
+/// FIXME: Add function as discussed in <https://github.com/rust-marker/design/issues/22>
 /// this will require new driver callback functions
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/marker_api/src/ast/item.rs
+++ b/marker_api/src/ast/item.rs
@@ -38,10 +38,10 @@ pub trait ItemData<'ast>: Debug {
     /// diagnostics.
     fn span(&self) -> &Span<'ast>;
 
-    /// The visibility of this item.
+    /// The [`Visibility`] of this item.
     fn visibility(&self) -> &Visibility<'ast>;
 
-    /// This function can return `None` if the item was generated and has no real name
+    /// This function can return [`None`] if the item was generated and has no real name
     fn name(&self) -> Option<String>;
 
     /// This returns this [`ItemData`] instance as a [`ItemKind`]. This can be useful for
@@ -159,7 +159,7 @@ impl<'ast> TryFrom<ItemKind<'ast>> for ExternItemKind<'ast> {
 }
 
 /// Until [trait upcasting](https://github.com/rust-lang/rust/issues/65991) has been implemented
-/// and stabalized we need this to call [`ItemData`] functions for [`ItemKind`].
+/// and stabilized we need this to call [`ItemData`] functions for [`ItemKind`].
 macro_rules! impl_item_type_fn {
     (ItemKind: $method:ident () -> $return_ty:ty) => {
         impl_item_type_fn!((ItemKind) $method() -> $return_ty,

--- a/marker_api/src/ast/item/adt_item.rs
+++ b/marker_api/src/ast/item/adt_item.rs
@@ -265,7 +265,7 @@ pub struct Field<'ast> {
 }
 
 impl<'ast> Field<'ast> {
-    /// The visibility of this item.
+    /// The [`Visibility`] of this item.
     pub fn visibility(&self) -> &Visibility<'ast> {
         &self.vis
     }

--- a/marker_api/src/ast/item/adt_item.rs
+++ b/marker_api/src/ast/item/adt_item.rs
@@ -243,7 +243,7 @@ enum AdtKind<'ast> {
 }
 
 impl<'ast> AdtKind<'ast> {
-    // The slice lifetime is here explicitly denoted, as this is used by the
+    // The slice lifetime here is explicitly denoted, as this is used by the
     // driver for convenience and is not part of the public API
     pub fn fields(self) -> &'ast [Field<'ast>] {
         match self {

--- a/marker_api/src/ast/item/const_item.rs
+++ b/marker_api/src/ast/item/const_item.rs
@@ -3,7 +3,7 @@ use crate::ffi::FfiOption;
 
 use super::CommonItemData;
 
-/// A module item like:
+/// A const item like:
 ///
 /// ```
 /// const CONST_ITEM: u32 = 0xcafe;

--- a/marker_api/src/ast/item/extern_block_item.rs
+++ b/marker_api/src/ast/item/extern_block_item.rs
@@ -3,7 +3,7 @@ use crate::ffi::FfiSlice;
 
 use super::{CommonItemData, ExternItemKind};
 
-/// An extern block with items like this:
+/// An `extern` block with items like this:
 ///
 /// ```
 /// extern "C" {

--- a/marker_api/src/ast/item/extern_block_item.rs
+++ b/marker_api/src/ast/item/extern_block_item.rs
@@ -13,7 +13,7 @@ use super::{CommonItemData, ExternItemKind};
 /// }
 /// ```
 ///
-/// * See <https://doc.rust-lang.org/stable/reference/items/modules.html>
+/// * See <https://doc.rust-lang.org/stable/reference/items/external-blocks.html>
 #[repr(C)]
 #[derive(Debug)]
 pub struct ExternBlockItem<'ast> {

--- a/marker_api/src/ast/item/extern_crate_item.rs
+++ b/marker_api/src/ast/item/extern_crate_item.rs
@@ -27,7 +27,7 @@ super::impl_item_data!(ExternCrateItem, ExternCrate);
 impl<'ast> ExternCrateItem<'ast> {
     /// This will return the original name of external crate. This will only differ
     /// with [`ItemData::get_name`](`super::ItemData::name`) if the user has
-    /// declared an alias with as.
+    /// declared an alias with `as`.
     ///
     /// In most cases, you want to use this over the `get_name()` function.
     pub fn crate_name(&self) -> String {

--- a/marker_api/src/ast/item/impl_item.rs
+++ b/marker_api/src/ast/item/impl_item.rs
@@ -29,7 +29,7 @@ use super::{AssocItemKind, CommonItemData};
 /// unsafe impl Send for SomeItem {}
 /// ```
 ///
-/// * See <https://doc.rust-lang.org/stable/reference/items/modules.html>
+/// * See <https://doc.rust-lang.org/stable/reference/items/implementations.html>
 #[repr(C)]
 #[derive(Debug)]
 pub struct ImplItem<'ast> {

--- a/marker_api/src/ast/item/impl_item.rs
+++ b/marker_api/src/ast/item/impl_item.rs
@@ -5,7 +5,7 @@ use crate::ffi::{FfiOption, FfiSlice};
 
 use super::{AssocItemKind, CommonItemData};
 
-/// An impl item like these examples:
+/// An impl item like:
 ///
 /// ```
 /// # use core::ops::Add;

--- a/marker_api/src/ast/item/trait_item.rs
+++ b/marker_api/src/ast/item/trait_item.rs
@@ -15,7 +15,7 @@ use super::{AssocItemKind, CommonItemData};
 /// }
 /// ```
 ///
-/// * See <https://doc.rust-lang.org/stable/reference/items/modules.html>
+/// * See <https://doc.rust-lang.org/stable/reference/items/traits.html>
 #[repr(C)]
 #[derive(Debug)]
 pub struct TraitItem<'ast> {
@@ -41,7 +41,7 @@ impl<'ast> TraitItem<'ast> {
     ///
     /// ```
     /// # trait Supertrait {}
-    /// //            vvvvvvvvvvvv
+    /// //              vvvvvvvvvv
     /// trait Subtrait: Supertrait {
     ///     // ...
     /// }

--- a/marker_api/src/ast/item/ty_alias_item.rs
+++ b/marker_api/src/ast/item/ty_alias_item.rs
@@ -4,7 +4,7 @@ use crate::ffi::{FfiOption, FfiSlice};
 
 use super::CommonItemData;
 
-/// A type alias like
+/// A type alias like:
 ///
 /// ```
 /// type Vec3<T: Copy> = (T, T, T);

--- a/marker_api/src/ast/item/use_decl_item.rs
+++ b/marker_api/src/ast/item/use_decl_item.rs
@@ -2,7 +2,7 @@ use crate::ast::AstPath;
 
 use super::CommonItemData;
 
-/// A use declaration like:
+/// A `use` declaration like:
 ///
 /// ```ignore
 /// pub use foo::bar::*;
@@ -35,7 +35,7 @@ super::impl_item_data!(UseItem, Use);
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(feature = "driver-api", visibility::make(pub))]
 pub(crate) enum UseKind {
-    /// Single usages like `use foo::bar` a list of multiple usages like
+    /// Single usages like `use foo::bar` a list of multiple `use` declarations like
     /// `use foo::{bar, baz}` will be desugured to `use foo::bar; use foo::baz;`
     Single,
     /// A glob import like `use foo::*`

--- a/marker_api/src/ast/ty.rs
+++ b/marker_api/src/ast/ty.rs
@@ -97,26 +97,58 @@ pub enum TyKind<'ast> {
     // ================================
     /// The `bool` type
     Bool(&'ast BoolTy<'ast>),
-    /// A numeric type like `u32`, `i32`, `f64`
+    /// A numeric type like [`u32`], [`i32`], [`f64`]
     Num(&'ast NumTy<'ast>),
-    /// A textual type like `char` or `str`
+    /// A textual type like [`char`] or [`str`]
     Text(&'ast TextTy<'ast>),
-    /// The never type `!`
+    /// The never type [`!`](prim@never)
     Never(&'ast NeverTy<'ast>),
     // ================================
     // Sequence types
     // ================================
-    /// A tuple type like `()`, `(T, U)`
+    /// A tuple type like [`()`](prim@tuple), [`(T, U)`](prim@tuple)
     Tuple(&'ast TupleTy<'ast>),
-    /// An array with a known size like: `[T; n]`
+    /// An array with a known size like: [`[T; N]`](prim@array)
     Array(&'ast ArrayTy<'ast>),
-    /// A variable length slice like `[T]`
+    /// A variable length slice like [`[T]`](prim@slice)
     Slice(&'ast SliceTy<'ast>),
     // ================================
-    // User define types
+    // User defined types
     // ================================
+    /// A struct type like:
+    ///
+    /// ```
+    /// pub struct Foo;
+    /// pub struct Bar(u32, u32);
+    /// pub struct Baz {
+    ///     field_1: u32,
+    ///     field_2: u32,
+    /// }
+    /// ```
     Struct(&'ast StructTy<'ast>),
+    /// An enum type like:
+    ///
+    /// ```
+    /// #[repr(u32)]
+    /// pub enum Foo {
+    ///     Elem1,
+    ///     Elem2 = 1,
+    ///     Elem3(u32),
+    ///     Elem4 {
+    ///         field_1: u32,
+    ///         field_2: u32,
+    ///     }
+    /// }
+    /// ```
     Enum(&'ast EnumTy<'ast>),
+    /// A union type like:
+    ///
+    /// ```
+    /// pub union Foo {
+    ///     a: i32,
+    ///     b: f32,
+    /// }
+    /// ```
     Union(&'ast UnionTy<'ast>),
     // ================================
     // Function types
@@ -126,18 +158,18 @@ pub enum TyKind<'ast> {
     // ================================
     // Pointer types
     // ================================
-    /// A reference like `&T` or `&mut T`
+    /// A reference like [`&T`](prim@reference) or [`&mut T`](prim@reference)
     Ref(&'ast RefTy<'ast>),
-    /// A raw pointer like `*const T` or `*mut T`
+    /// A raw pointer like [`*const T`](prim@pointer) or [`*mut T`](prim@pointer)
     RawPtr(&'ast RawPtrTy<'ast>),
-    /// A function pointer like `fn (T) -> U`
+    /// A function pointer like [`fn (T) -> U`](prim@fn)
     FnPtr(&'ast FnPtrTy<'ast>),
     // ================================
     // Trait types
     // ================================
-    /// A trait object like `dyn Trait`
+    /// A trait object like [`dyn Trait`](<https://doc.rust-lang.org/stable/std/keyword.dyn.html>)
     TraitObj(&'ast TraitObjTy<'ast>),
-    /// An `impl Trait` type like:
+    /// An [`impl Trait`](<https://doc.rust-lang.org/stable/std/keyword.impl.html>) type like:
     ///
     /// ```
     /// trait Trait {}
@@ -161,8 +193,19 @@ pub enum TyKind<'ast> {
     Inferred(&'ast InferredTy<'ast>),
     /// A generic type, that has been specified in a surrounding item
     Generic(&'ast GenericTy<'ast>),
+    /// A type alias like:
+    ///
+    /// ```
+    /// type Vec3<T: Copy> = (T, T, T);
+    ///
+    /// trait TraitItem {
+    ///     type AssocType;
+    /// }
+    /// ```
+    ///
+    /// See: <https://doc.rust-lang.org/reference/items/type-aliases.html>
     Alias(&'ast AliasTy<'ast>),
-    /// The `Self` in impl blocks or trait declarations
+    /// The [`Self`](<https://doc.rust-lang.org/stable/std/keyword.SelfTy.html>) in impl blocks or trait declarations
     SelfTy(&'ast SelfTy<'ast>),
     /// A type declared relative to another type, like `Iterator::Item`
     Relative(&'ast RelativeTy<'ast>),

--- a/marker_api/src/ast/ty.rs
+++ b/marker_api/src/ast/ty.rs
@@ -62,7 +62,7 @@ pub trait TyData<'ast> {
     /// The [`Span`] of the type, if it's written in the source code. Only
     /// syntactic types can have spans attached to them.
     ///
-    /// Currently, every syntactic type will return a valid [`Span`] this can
+    /// Currently, every syntactic type will return a valid [`Span`], but this can
     /// change in the future.
     fn span(&self) -> Option<&Span<'ast>>;
 
@@ -187,7 +187,7 @@ impl<'ast> TyKind<'ast> {
         matches!(self, Self::Struct(..) | Self::Enum(..) | Self::Union(..))
     }
 
-    /// Returns `true` if the ty kind is function type.
+    /// Returns `true` if this is a function type.
     #[must_use]
     pub fn is_fn(&self) -> bool {
         matches!(self, Self::Fn(..) | Self::Closure(..))
@@ -199,13 +199,13 @@ impl<'ast> TyKind<'ast> {
         matches!(self, Self::Ref(..) | Self::RawPtr(..) | Self::FnPtr(..))
     }
 
-    /// Returns `true` if the ty kind is trait type.
+    /// Returns `true` if this is a trait type.
     #[must_use]
     pub fn is_trait_ty(&self) -> bool {
         matches!(self, Self::TraitObj(..) | Self::ImplTrait(..))
     }
 
-    /// Returns `true` if the ty kind is syntactic type, meaning a type that is
+    /// Returns `true` if this is a syntactic type, meaning a type that is
     /// only used in syntax like [`TyKind::Inferred`] and [`TyKind::Generic`].
     ///
     /// See [`TyKind::is_syntactic()`] to check if this type originates from

--- a/marker_api/src/ast/ty/closure_ty.rs
+++ b/marker_api/src/ast/ty/closure_ty.rs
@@ -8,7 +8,7 @@ pub struct ClosureTy<'ast> {
     data: CommonTyData<'ast>,
     callable_data: CommonCallableData<'ast>,
     // FIXME: Add support for `for<'lifetime>` binder
-    // FIXME: Potentualy add functions to check which `Fn` traits this implements
+    // FIXME: Potentially add functions to check which [`Fn`] traits this implements
 }
 
 #[cfg(feature = "driver-api")]

--- a/marker_api/src/ast/ty/self_ty.rs
+++ b/marker_api/src/ast/ty/self_ty.rs
@@ -12,7 +12,7 @@ pub struct SelfTy<'ast> {
 super::impl_ty_data!(SelfTy<'ast>, SelfTy);
 
 impl<'ast> SelfTy<'ast> {
-    /// This returns the [`ItemId`] that this `Self` originates from.
+    /// This returns the [`ItemId`] that this [`Self`](<https://doc.rust-lang.org/stable/std/keyword.SelfTy.html>) originates from.
     pub fn self_source_item_id(&self) -> ItemId {
         self.item
     }

--- a/marker_api/src/context.rs
+++ b/marker_api/src/context.rs
@@ -65,7 +65,7 @@ where
             .borrow()
             .expect("`with_cx` should only be called by nodes once the context has been set");
         // Safety:
-        // This just recreates the lifetimes that were destroyed in [`set_ast_cx`].
+        // This just recreates the lifetimes that were erased in [`set_ast_cx`].
         // See the referenced docs for a full explanation.
         let cx_ast: &'src AstContext<'ast> = unsafe { transmute(cx_static) };
 
@@ -73,7 +73,7 @@ where
     })
 }
 
-/// This context will be passed to each [`super::LintPass`] call to enable the user
+/// This context will be passed to each [`LintPass`][super::LintPass] call to enable the user
 /// to emit lints and to retieve nodes by the given ids.
 #[repr(C)]
 pub struct AstContext<'ast> {
@@ -109,7 +109,7 @@ impl<'ast> AstContext<'ast> {
     /// message and span.
     ///
     /// For rustc the text output will look roughly to this:
-    /// ```txt
+    /// ```text
     /// error: ducks can't talk
     ///  --> $DIR/file.rs:17:5
     ///    |

--- a/marker_api/src/context.rs
+++ b/marker_api/src/context.rs
@@ -160,7 +160,7 @@ impl<'ast> AstContext<'ast> {
 ///     required. These are not part of the stable API and can therefore be changed.
 ///
 /// Any changes to this struct will most likely require changes to the
-/// `DriverContextWrapper` implementation in the `liner_adapter` crate. That
+/// `DriverContextWrapper` implementation in the `marker_adapter` crate. That
 /// type provides a simple wrapper to avoid driver unrelated boilerplate code.
 #[repr(C)]
 #[doc(hidden)]

--- a/marker_api/src/context.rs
+++ b/marker_api/src/context.rs
@@ -73,7 +73,7 @@ where
     })
 }
 
-/// This context will be passed to each [`LintPass`][super::LintPass] call to enable the user
+/// This context will be passed to each [`LintPass`](`super::LintPass`) call to enable the user
 /// to emit lints and to retieve nodes by the given ids.
 #[repr(C)]
 pub struct AstContext<'ast> {

--- a/marker_api/src/ffi.rs
+++ b/marker_api/src/ffi.rs
@@ -7,7 +7,7 @@
 //! focus on ABI safety, conversion, and simplicity by expecting that both
 //! sides use these types.
 //!
-//! All of these types are naturally not part of the stable API
+//! All of these types are naturally not a part of the stable API
 #![allow(clippy::exhaustive_enums)]
 
 use std::{marker::PhantomData, slice};
@@ -47,7 +47,7 @@ impl<'a> ToString for Str<'a> {
     }
 }
 
-/// This is an FFI save option. In most cases it's better to pass a pointer and
+/// This is an FFI safe option. In most cases it's better to pass a pointer and
 /// then use `as_ref()` but this doesn't work for owned return values.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]

--- a/marker_api/src/interface.rs
+++ b/marker_api/src/interface.rs
@@ -16,7 +16,7 @@
 /// marker_api::interface::export_lint_pass!(LintPassCustomValue, LintPassCustomValue(3));
 /// ```
 ///
-/// This macro will create some hidden items prefixed with two underscored. These
+/// This macro will create some hidden items prefixed with two underscores. These
 /// are unstable and can change in the future.
 ///
 /// ### Additional notes
@@ -60,9 +60,9 @@ pub use export_lint_pass;
 
 /// **!Unstable!**
 ///
-/// This function is used to generate external functions which can be used to
+/// This macro is used to generate external functions which can be used to
 /// transfer data safely over the C ABI. The counterpart passing the information
-/// to here is implemented in `liner_adapter`
+/// to here is implemented in `marker_adapter`
 #[macro_export]
 #[doc(hidden)]
 macro_rules! export_lint_pass_fn {

--- a/marker_api/src/lib.rs
+++ b/marker_api/src/lib.rs
@@ -31,7 +31,7 @@ pub mod ffi;
 /// 1. Informative functions used to retrieve information from the [`LintPass`]
 ///    implementation. These functions take an unmutable reference to self and
 ///    require a manual implementation
-/// 2. Check functions, which can be implemented to check specific nodes from the
+/// 2. `check_*` functions, which can be implemented to check specific nodes from the
 ///    AST. All of these are optional and have no return type. For us, they are
 ///    *fire and forget*.
 ///

--- a/marker_api/src/lib.rs
+++ b/marker_api/src/lib.rs
@@ -29,7 +29,7 @@ pub mod ffi;
 /// The functions can be categorized as follows:
 ///
 /// 1. Informative functions used to retrieve information from the [`LintPass`]
-///    implementation. These functions take an unmutable reference to self and
+///    implementation. These functions take an immutable reference to self and
 ///    require a manual implementation
 /// 2. `check_*` functions, which can be implemented to check specific nodes from the
 ///    AST. All of these are optional and have no return type. For us, they are
@@ -134,7 +134,7 @@ pub trait LintPass<'ast> {
     for_each_lint_pass_fn!(crate::decl_lint_pass_fn);
 }
 
-/// This macro currently expects that all declarations taken `&self` have to be
+/// This macro currently expects that all declarations taking `&self` have to be
 /// implemented while all taking `&mut self` have an empty default implementation.
 #[doc(hidden)]
 macro_rules! decl_lint_pass_fn {

--- a/marker_api/src/lint.rs
+++ b/marker_api/src/lint.rs
@@ -7,7 +7,7 @@ pub struct Lint {
     ///
     /// This identifies the lint in attributes and in command-line arguments.
     /// In those contexts it is always lowercase. This allows
-    /// `declare_lint!()` invocations to follow the convention of upper-case
+    /// [`declare_lint!`] macro invocations to follow the convention of upper-case
     /// statics without repeating the name.
     ///
     /// The name is written with underscores, e.g., "unused_imports".
@@ -15,6 +15,8 @@ pub struct Lint {
     ///
     /// See <https://rustc-dev-guide.rust-lang.org/diagnostics.html#lint-naming>
     /// for naming guidelines.
+    ///
+    /// [`declare_lint!`]: declare_lint
     pub name: &'static str,
 
     /// Default level for the lint.
@@ -83,7 +85,7 @@ pub enum Applicability {
 #[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
 #[non_exhaustive]
 pub enum Level {
-    /// The lint is allowed. A created diagnostic will not be emitted to the user.
+    /// The lint is allowed. A created diagnostic will not be emitted to the user by default.
     /// This level can be overridden. It's useful for rather strict lints.
     Allow,
     /// The `warn` level will produce a warning if the lint was violated, however the

--- a/marker_api/src/lint.rs
+++ b/marker_api/src/lint.rs
@@ -32,7 +32,7 @@ pub struct Lint {
 
     /// The level of macro reporting.
     ///
-    /// See `MacroReport` for the possible levels.
+    /// See [`MacroReport`] for the possible levels.
     pub report_in_macro: MacroReport,
     // TODO: do we want these
     // pub edition_lint_opts: Option<(Edition, Level)>,
@@ -98,7 +98,15 @@ pub enum Level {
     /// The `deny` level will produce an error and stop further execution after the lint
     /// pass is complete.
     Deny,
-    /// The `forbid` level will produce an error, see `Deny`.
+    /// The `forbid` level will produce an error and cannot be overriden by the user.
+    ///
+    /// Choosing this diagnostic level should require heavy consideration, because should a lint
+    /// with this level produce a false-positive, the user won't have an option to `allow` the lint
+    /// for this particular case, and will be forced to either:
+    /// - Write wrong code just to satisfy the lint
+    /// - Remove the whole lint crate
+    ///
+    /// To produce an error, but make the lint possible to override see [`Deny`](`Self::Deny`).
     Forbid,
 }
 

--- a/marker_api/src/lint.rs
+++ b/marker_api/src/lint.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, PartialEq, Eq, Hash)]
-// This can sadly not be marked as #[non_exhaustive] as the struct construction
+// This sadly cannot be marked as #[non_exhaustive] as the struct construction
 // has to be possible in a static context.
 #[doc(hidden)]
 pub struct Lint {

--- a/marker_driver_rustc/src/context.rs
+++ b/marker_driver_rustc/src/context.rs
@@ -60,7 +60,7 @@ impl<'ast, 'tcx> RustcContext<'ast, 'tcx> {
     }
 
     pub fn ast_cx(&self) -> &'ast AstContext<'ast> {
-        // The `OnceCell` is filled in the new function and can never not be set.
+        // The `OnceCell` is filled in the new function and can never be not set.
         self.ast_cx.get().unwrap()
     }
 }

--- a/marker_driver_rustc/src/conversion/common/span.rs
+++ b/marker_driver_rustc/src/conversion/common/span.rs
@@ -41,7 +41,7 @@ fn to_api_src_info<'ast, 'tcx>(
         | rustc_span::FileName::Custom(_)
         | rustc_span::FileName::DocTest(_, _)
         | rustc_span::FileName::InlineAsm(_) => {
-            unimplemented!("the api should only receive an request spans from files and macros")
+            unimplemented!("the api should only receive and request spans from files and macros")
         },
     };
     let api_info = SpanSourceInfo {

--- a/marker_driver_rustc/src/conversion/common/unstable.rs
+++ b/marker_driver_rustc/src/conversion/common/unstable.rs
@@ -9,7 +9,7 @@ use super::to_rustc_lint_level;
 
 pub fn to_rustc_lint<'ast, 'tcx>(cx: &RustcContext<'ast, 'tcx>, api_lint: &'static Lint) -> &'static rustc_lint::Lint {
     cx.storage.lint_or_insert(api_lint, || {
-        // Not extracted to an extra function, as its very specific
+        // Not extracted to an extra function, as it's very specific
         let report_in_external_macro = match api_lint.report_in_macro {
             MacroReport::No | MacroReport::Local => false,
             MacroReport::All => true,

--- a/marker_driver_rustc/src/conversion/item.rs
+++ b/marker_driver_rustc/src/conversion/item.rs
@@ -19,8 +19,8 @@ use super::{
 };
 
 /// This converter combines a bunch of functions used to convert rustc items into
-/// api items. This is mainly used to group functions together and to not always
-/// pass the context around as an argument.
+/// api items. This is mainly used to group functions together and to avoid always
+/// passing the context around as an argument.
 pub struct ItemConverter<'ast, 'tcx> {
     cx: &'ast RustcContext<'ast, 'tcx>,
 }

--- a/marker_driver_rustc/src/main.rs
+++ b/marker_driver_rustc/src/main.rs
@@ -60,7 +60,7 @@ impl rustc_driver::Callbacks for MarkerCallback {
 }
 
 /// If a command-line option matches `find_arg`, then apply the predicate `pred` on its value. If
-/// true, then return it. The parameter is assumed to be either `--arg=value` or `--arg value`.
+/// `true`, then return it. The parameter is assumed to be either `--arg=value` or `--arg value`.
 fn arg_value<'a, T: Deref<Target = str>>(
     args: &'a [T],
     find_arg: &str,


### PR DESCRIPTION
@xFrednet

![image](https://user-images.githubusercontent.com/66798058/210443643-bf71b49a-3d71-4f88-89a1-d5131136cfac.png)

Whew, that turned out way bigger than I thought it would be, feel free to take your time on this one, or just ignore until exams pass :sweat_smile: 

Even though this changes a lot of files, the changes themselves are very small (and mostly affect only (doc)comments).

I tried to touch only the (doc)comments, and not the actual code, but I think there is some weirdness with function names in `marker_api/src/ast/item/adt_item.rs`, and that *might be a little bit of a breaking change to the public API*, but I don't think we care yet?

Some of these are just my personal nits, so feel free to disagree or just not accept them.