### PR TITLE
New `check_*` `fn`s

### DIFF
--- a/marker_adapter/src/lib.rs
+++ b/marker_adapter/src/lib.rs
@@ -33,16 +33,40 @@ impl<'ast> Adapter<'ast> {
 
         for item in krate.items() {
             self.external_lint_crates.check_item(cx, *item);
+            self.process_item(cx, item);
         }
+    }
 
-        for item in krate.items() {
-            match item {
-                ItemKind::Mod(data) => self.external_lint_crates.check_mod(cx, data),
-                ItemKind::ExternCrate(data) => self.external_lint_crates.check_extern_crate(cx, data),
-                ItemKind::Use(data) => self.external_lint_crates.check_use_decl(cx, data),
-                ItemKind::Static(data) => self.external_lint_crates.check_static_item(cx, data),
-                _ => {},
-            }
+    fn process_item(&mut self, cx: &'ast AstContext<'ast>, item: &ItemKind<'ast>) {
+        match item {
+            ItemKind::Mod(data) => {
+                self.external_lint_crates.check_mod(cx, data);
+                for item in data.items() {
+                    self.process_item(cx, item);
+                }
+            },
+            ItemKind::ExternCrate(data) => self.external_lint_crates.check_extern_crate(cx, data),
+            ItemKind::Use(data) => self.external_lint_crates.check_use_decl(cx, data),
+            ItemKind::Static(data) => self.external_lint_crates.check_static_item(cx, data),
+            ItemKind::Const(data) => self.external_lint_crates.check_const_item(cx, data),
+            // FIXME: Function-local items are not yet processed
+            ItemKind::Fn(data) => self.external_lint_crates.check_fn(cx, data),
+            ItemKind::Struct(data) => {
+                self.external_lint_crates.check_struct(cx, data);
+                for field in data.fields() {
+                    self.external_lint_crates.check_field(cx, field);
+                }
+            },
+            ItemKind::Enum(data) => {
+                self.external_lint_crates.check_enum(cx, data);
+                for variant in data.elements() {
+                    self.external_lint_crates.check_variant(cx, variant);
+                    for field in variant.fields() {
+                        self.external_lint_crates.check_field(cx, field);
+                    }
+                }
+            },
+            _ => {},
         }
     }
 

--- a/marker_adapter/src/lib.rs
+++ b/marker_adapter/src/lib.rs
@@ -59,7 +59,7 @@ impl<'ast> Adapter<'ast> {
             },
             ItemKind::Enum(data) => {
                 self.external_lint_crates.check_enum(cx, data);
-                for variant in data.elements() {
+                for variant in data.variants() {
                     self.external_lint_crates.check_variant(cx, variant);
                     for field in variant.fields() {
                         self.external_lint_crates.check_field(cx, field);

--- a/marker_api/src/ast/item/adt_item.rs
+++ b/marker_api/src/ast/item/adt_item.rs
@@ -64,7 +64,7 @@ impl<'ast> UnionItem<'ast> {
 pub struct EnumItem<'ast> {
     data: CommonItemData<'ast>,
     generics: GenericParams<'ast>,
-    elements: FfiSlice<'ast, EnumVariant<'ast>>,
+    variants: FfiSlice<'ast, EnumVariant<'ast>>,
 }
 
 super::impl_item_data!(EnumItem, Enum);
@@ -74,18 +74,18 @@ impl<'ast> EnumItem<'ast> {
         &self.generics
     }
 
-    pub fn elements(&self) -> &[EnumVariant<'ast>] {
-        self.elements.get()
+    pub fn variants(&self) -> &[EnumVariant<'ast>] {
+        self.variants.get()
     }
 }
 
 #[cfg(feature = "driver-api")]
 impl<'ast> EnumItem<'ast> {
-    pub fn new(data: CommonItemData<'ast>, generics: GenericParams<'ast>, elements: &'ast [EnumVariant<'ast>]) -> Self {
+    pub fn new(data: CommonItemData<'ast>, generics: GenericParams<'ast>, variants: &'ast [EnumVariant<'ast>]) -> Self {
         Self {
             data,
             generics,
-            elements: elements.into(),
+            variants: variants.into(),
         }
     }
 }
@@ -106,29 +106,29 @@ impl<'ast> EnumVariant<'ast> {
 
     // FIXME: Add `fn attrs() -> ??? {}`
 
-    /// Returns `true` if this is a union element like:
+    /// Returns `true` if this is a unit variant like:
     ///
     /// ```
     /// pub enum Foo {
     ///     Bar,
     /// }
     /// ```
-    pub fn is_union_struct(&self) -> bool {
+    pub fn is_unit_variant(&self) -> bool {
         matches!(self.kind, AdtKind::Unit)
     }
 
-    /// Returns `true` if this is a tuple element like:
+    /// Returns `true` if this is a tuple variant like:
     ///
     /// ```
     /// pub enum Foo {
     ///     Bar(u32, u32)
     /// }
     /// ```
-    pub fn is_tuple_element(&self) -> bool {
+    pub fn is_tuple_variant(&self) -> bool {
         matches!(self.kind, AdtKind::Tuple(..))
     }
 
-    /// Returns `true` if this is an element with fields like:
+    /// Returns `true` if this is an variant with fields like:
     ///
     /// ```
     /// pub enum Foo {
@@ -138,7 +138,7 @@ impl<'ast> EnumVariant<'ast> {
     ///    }
     /// }
     /// ```
-    pub fn is_field_element(&self) -> bool {
+    pub fn is_field_variant(&self) -> bool {
         matches!(self.kind, AdtKind::Field(..))
     }
 
@@ -188,13 +188,13 @@ impl<'ast> StructItem<'ast> {
         &self.generics
     }
 
-    /// Returns `true` if this is a union struct like:
+    /// Returns `true` if this is a unit struct like:
     ///
     /// ```
     /// struct Name1;
     /// struct Name2 {};
     /// ```
-    pub fn is_union_struct(&self) -> bool {
+    pub fn is_unit_struct(&self) -> bool {
         matches!(self.kind, AdtKind::Unit)
     }
 

--- a/marker_api/src/lib.rs
+++ b/marker_api/src/lib.rs
@@ -67,6 +67,26 @@ macro_rules! lint_pass_fns {
                 &(mut) self,
                 _cx: &'ast $crate::context::AstContext<'ast>,
                 _item: &'ast $crate::ast::item::ConstItem<'ast>) -> ();
+            fn check_fn(
+                &(mut) self,
+                _cx: &'ast $crate::context::AstContext<'ast>,
+                _item: &'ast $crate::ast::item::FnItem<'ast>) -> ();
+            fn check_struct(
+                &(mut) self,
+                _cx: &'ast $crate::context::AstContext<'ast>,
+                _item: &'ast $crate::ast::item::StructItem<'ast>) -> ();
+            fn check_enum(
+                &(mut) self,
+                _cx: &'ast $crate::context::AstContext<'ast>,
+                _item: &'ast $crate::ast::item::EnumItem<'ast>) -> ();
+            fn check_field(
+                &(mut) self,
+                _cx: &'ast $crate::context::AstContext<'ast>,
+                _field: &'ast $crate::ast::item::Field<'ast>) -> ();
+            fn check_variant(
+                &(mut) self,
+                _cx: &'ast $crate::context::AstContext<'ast>,
+                _variant: &'ast $crate::ast::item::EnumVariant<'ast>) -> ();
         );
     };
 }

--- a/marker_lints/src/lib.rs
+++ b/marker_lints/src/lib.rs
@@ -2,7 +2,13 @@
 #![warn(clippy::pedantic)]
 
 use marker_api::{
-    ast::item::{ItemData, StaticItem},
+    ast::{
+        item::{
+            ConstItem, EnumItem, EnumVariant, ExternCrateItem, Field, FnItem, ItemData, ModItem, StaticItem,
+            StructItem, UseItem,
+        },
+        Span,
+    },
     context::AstContext,
     lint::Lint,
     LintPass,
@@ -11,6 +17,15 @@ use marker_api::{
 marker_api::interface::export_lint_pass!(TestLintPass);
 
 marker_api::lint::declare_lint!(TEST_LINT, Warn, "test lint warning");
+
+// this ideally should use only specific `check_*` functions
+// to test them, think `check_struct` instead of `check_item`
+marker_api::lint::declare_lint!(FOO_ITEMS, Warn, "non-descriptive item names");
+
+fn emit_foo_lint<'ast, S: Into<String>>(cx: &'ast AstContext<'ast>, description: S, span: &'ast Span) {
+    let msg = description.into() + " named `foo`, consider using a more meaningful name";
+    cx.emit_lint(FOO_ITEMS, &msg, span);
+}
 
 #[derive(Default)]
 struct TestLintPass {}
@@ -21,12 +36,72 @@ impl<'ast> LintPass<'ast> for TestLintPass {
     }
 
     fn check_static_item(&mut self, cx: &'ast AstContext<'ast>, item: &'ast StaticItem<'ast>) {
-        let name = item.name().unwrap_or_default();
-        if name.starts_with("PRINT_TYPE") {
-            cx.emit_lint(TEST_LINT, "Printing type for", item.ty().span().unwrap());
-            eprintln!("{:#?}\n\n", item.ty());
-        } else if name.starts_with("FIND_ITEM") {
-            cx.emit_lint(TEST_LINT, "hey there is a static item here", item.span());
+        if let Some(name) = item.name() {
+            if name.starts_with("PRINT_TYPE") {
+                cx.emit_lint(TEST_LINT, "Printing type for", item.ty().span().unwrap());
+                eprintln!("{:#?}\n\n", item.ty());
+            } else if name.starts_with("FIND_ITEM") {
+                cx.emit_lint(TEST_LINT, "hey there is a static item here", item.span());
+            } else if name == "FOO" {
+                emit_foo_lint(cx, "a static item", item.span());
+            }
+        }
+    }
+
+    fn check_const_item(&mut self, cx: &'ast AstContext<'ast>, item: &'ast ConstItem<'ast>) {
+        if matches!(item.name(), Some(name) if name == "FOO") {
+            emit_foo_lint(cx, "a constant item", item.span());
+        }
+    }
+
+    fn check_extern_crate(&mut self, cx: &'ast AstContext<'ast>, item: &'ast ExternCrateItem<'ast>) {
+        if matches!(item.name(), Some(name) if name == "foo") {
+            emit_foo_lint(cx, "an `extern` crate", item.span());
+        }
+    }
+
+    fn check_use_decl(&mut self, cx: &'ast AstContext<'ast>, item: &'ast UseItem<'ast>) {
+        if item.is_glob() {
+            return;
+        }
+        if matches!(item.name(), Some(name) if name == "foo") {
+            emit_foo_lint(cx, "a `use` binding", item.span());
+        }
+    }
+
+    fn check_field(&mut self, cx: &'ast AstContext<'ast>, field: &'ast Field<'ast>) {
+        if field.ident() == "foo" {
+            emit_foo_lint(cx, "a field", field.span());
+        }
+    }
+
+    fn check_variant(&mut self, cx: &'ast AstContext<'ast>, variant: &'ast EnumVariant<'ast>) {
+        if variant.ident() == "Foo" {
+            emit_foo_lint(cx, "an enum variant", variant.span());
+        }
+    }
+
+    fn check_mod(&mut self, cx: &'ast AstContext<'ast>, item: &'ast ModItem<'ast>) {
+        if matches!(item.name(), Some(name) if name == "foo") {
+            emit_foo_lint(cx, "a module", item.span());
+        }
+    }
+
+    fn check_enum(&mut self, cx: &'ast AstContext<'ast>, item: &'ast EnumItem<'ast>) {
+        if matches!(item.name(), Some(name) if name == "Foo") {
+            emit_foo_lint(cx, "an enum", item.span());
+        }
+    }
+
+    fn check_struct(&mut self, cx: &'ast AstContext<'ast>, item: &'ast StructItem<'ast>) {
+        if matches!(item.name(), Some(name) if name == "Foo") {
+            emit_foo_lint(cx, "a struct", item.span());
+        }
+    }
+
+    fn check_fn(&mut self, cx: &'ast AstContext<'ast>, item: &'ast FnItem<'ast>) {
+        if matches!(item.name(), Some(name) if name == "foo") {
+            emit_foo_lint(cx, "a function", item.span());
         }
     }
 }

--- a/marker_lints/tests/ui/foo_items.rs
+++ b/marker_lints/tests/ui/foo_items.rs
@@ -1,0 +1,21 @@
+mod good {
+    fn foo() {}
+
+    static FOO: i32 = 0;
+
+    struct Foo {
+        foo: i32
+    }
+}
+
+mod foo {
+    use crate::good as foo;
+
+    const FOO: i32 = 0;
+
+    enum Foo {
+        Foo
+    }
+}
+
+fn main() {}

--- a/marker_lints/tests/ui/foo_items.stderr
+++ b/marker_lints/tests/ui/foo_items.stderr
@@ -1,0 +1,68 @@
+warning: a function named `foo`, consider using a more meaningful name
+ --> $DIR/foo_items.rs:2:5
+  |
+2 |     fn foo() {}
+  |     ^^^^^^^^^^^
+  |
+  = note: `#[warn(marker::foo_items)]` on by default
+
+warning: a static item named `foo`, consider using a more meaningful name
+ --> $DIR/foo_items.rs:4:5
+  |
+4 |     static FOO: i32 = 0;
+  |     ^^^^^^^^^^^^^^^^^^^^
+
+warning: a struct named `foo`, consider using a more meaningful name
+ --> $DIR/foo_items.rs:6:5
+  |
+6 | /     struct Foo {
+7 | |         foo: i32
+8 | |     }
+  | |_____^
+
+warning: a field named `foo`, consider using a more meaningful name
+ --> $DIR/foo_items.rs:7:9
+  |
+7 |         foo: i32
+  |         ^^^^^^^^
+
+warning: a module named `foo`, consider using a more meaningful name
+  --> $DIR/foo_items.rs:11:1
+   |
+11 | / mod foo {
+12 | |     use crate::good as foo;
+13 | |
+14 | |     const FOO: i32 = 0;
+...  |
+18 | |     }
+19 | | }
+   | |_^
+
+warning: a `use` binding named `foo`, consider using a more meaningful name
+  --> $DIR/foo_items.rs:12:5
+   |
+12 |     use crate::good as foo;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: a constant item named `foo`, consider using a more meaningful name
+  --> $DIR/foo_items.rs:14:5
+   |
+14 |     const FOO: i32 = 0;
+   |     ^^^^^^^^^^^^^^^^^^^
+
+warning: an enum named `foo`, consider using a more meaningful name
+  --> $DIR/foo_items.rs:16:5
+   |
+16 | /     enum Foo {
+17 | |         Foo
+18 | |     }
+   | |_____^
+
+warning: an enum variant named `foo`, consider using a more meaningful name
+  --> $DIR/foo_items.rs:17:9
+   |
+17 |         Foo
+   |         ^^^
+
+warning: 9 warnings emitted
+


### PR DESCRIPTION
#### This PR extends `LintPass` trait with:
- `check_fn` for `FnItem`s
- `check_struct` for `StructItem`s
- `check_enum` for `EnumItem`s
- `check_field` for every field def (struct, enum variant)
- `check_variant` for every enum variant def

Also adds implementation for all of them (and `check_const_item`) in `marker_adapter`.

And a test `foo` lint, to ensure they are working :)