### PR TITLE
Fix ICE for `-> impl Trait`

### DIFF
--- a/cargo-marker/src/driver.rs
+++ b/cargo-marker/src/driver.rs
@@ -41,7 +41,7 @@ pub fn print_driver_version() {
 }
 
 /// This tries to install the rustc driver specified in [`DEFAULT_DRIVER_INFO`].
-pub fn install_driver(verbose: bool) -> Result<(), ExitStatus> {
+pub fn install_driver(verbose: bool, dev_build: bool) -> Result<(), ExitStatus> {
     // The toolchain, driver version and api version should ideally be configurable.
     // However, that will require more prototyping and has a low priority rn.
     // See #60
@@ -50,12 +50,7 @@ pub fn install_driver(verbose: bool) -> Result<(), ExitStatus> {
     let toolchain = &DEFAULT_DRIVER_INFO.toolchain;
     check_toolchain(toolchain)?;
 
-    build_driver(
-        toolchain,
-        &DEFAULT_DRIVER_INFO.version,
-        verbose,
-        cfg!(feature = "dev-build"),
-    )?;
+    build_driver(toolchain, &DEFAULT_DRIVER_INFO.version, verbose, dev_build)?;
 
     // We don't want to advice the user, to install the driver again.
     check_driver(verbose, false)

--- a/cargo-marker/src/main.rs
+++ b/cargo-marker/src/main.rs
@@ -78,6 +78,7 @@ fn main() -> Result<(), ExitStatus> {
     );
 
     let verbose = matches.get_flag("verbose");
+    let dev_build = cfg!(feature = "dev-build");
 
     if matches.get_flag("version") {
         print_version(verbose);
@@ -85,14 +86,19 @@ fn main() -> Result<(), ExitStatus> {
     }
 
     match matches.subcommand() {
-        Some(("setup", _args)) => driver::install_driver(verbose),
-        Some(("check", args)) => run_check(args, verbose),
-        None => run_check(&matches, verbose),
+        Some(("setup", _args)) => driver::install_driver(verbose, dev_build),
+        Some(("check", args)) => run_check(args, verbose, dev_build),
+        None => run_check(&matches, verbose, dev_build),
         _ => unreachable!(),
     }
 }
 
-fn run_check(matches: &clap::ArgMatches, verbose: bool) -> Result<(), ExitStatus> {
+fn run_check(matches: &clap::ArgMatches, verbose: bool, dev_build: bool) -> Result<(), ExitStatus> {
+    // If this is a dev build, we want to recompile the driver before checking
+    if dev_build {
+        driver::install_driver(verbose, dev_build)?;
+    }
+
     let mut lint_crates = vec![];
     if let Some(cmd_lint_crates) = matches.get_many::<OsString>("lints") {
         println!();


### PR DESCRIPTION
This fixes an ICE for `-> impl Trait` representations. It doesn't work with `-> impl Trait<T>` yet, where `T` is a generic of the item.

I'm not a 100% happy with how the rustc backend is structured, as it feels messy and hard to follow. I'm sadly not sure how to structure it better, as I've never worked on a translation layer like this in rust. My guess is that these things are always a bit messy, but I still hope to find a cleaner solution. For now, I hope that this is good enough.

I also found a small bug with the refactoring from #66 that `cargo dogfood` didn't recompile the driver. It should now do that again :)

r? @Niki4tap 