### PR TITLE
Start on expressions and statements, also featuring bodies and some connections between these elements

### DIFF
--- a/marker_api/src/ast/common.rs
+++ b/marker_api/src/ast/common.rs
@@ -19,7 +19,7 @@ pub enum Edition {
     Edition2021,
 }
 
-// FIXME: There will need to be updated according to rust-lang/rustfix#200
+// FIXME: This will need to be updated according to rust-lang/rustfix#200
 #[non_exhaustive]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum Applicability {

--- a/marker_api/src/ast/common.rs
+++ b/marker_api/src/ast/common.rs
@@ -19,6 +19,7 @@ pub enum Edition {
     Edition2021,
 }
 
+// FIXME: There will need to be updated according to rust-lang/rustfix#200
 #[non_exhaustive]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum Applicability {
@@ -54,23 +55,6 @@ pub enum Abi {
     /// FIXME: Remove this variant. See
     /// <https://doc.rust-lang.org/nightly/nightly-rustc/rustc_target/spec/abi/enum.Abi.html>
     Other,
-}
-
-pub struct Spanned<'ast, T> {
-    pub node: T,
-    pub span: &'ast Span<'ast>,
-}
-
-#[cfg(feature = "driver-api")]
-impl<'ast, T> Spanned<'ast, T> {
-    #[must_use]
-    pub fn new(node: T, span: &'ast Span<'ast>) -> Self {
-        Self { node, span }
-    }
-}
-
-pub trait Attribute<'ast>: Debug {
-    // FIXME: Add attribute functions
 }
 
 #[repr(C)]

--- a/marker_api/src/ast/common/id.rs
+++ b/marker_api/src/ast/common/id.rs
@@ -85,6 +85,11 @@ new_id! {
 }
 
 new_id! {
+    /// This ID uniquely identifies an expression during linting.
+    pub ExprId: u64
+}
+
+new_id! {
     /// **Unstable**
     ///
     /// This id is used to identify `Span`s. This type is only intended for internal

--- a/marker_api/src/ast/expr.rs
+++ b/marker_api/src/ast/expr.rs
@@ -1,0 +1,89 @@
+use super::{ty::TyKind, ExprId, Span, SpanId};
+
+use std::{fmt::Debug, marker::PhantomData};
+
+mod unstable_expr;
+pub use unstable_expr::*;
+
+pub trait ExprData<'ast>: Debug {
+    fn id(&self) -> ExprId;
+
+    /// Returns the span of this pattern.
+    fn span(&self) -> &Span<'ast>;
+
+    // This returns the semantic type of this expression
+    fn ty(&self) -> TyKind<'ast>;
+
+    fn precedence(&self) -> ExprPrecedence;
+
+    fn as_expr(&'ast self) -> ExprKind<'ast>;
+}
+
+#[repr(C)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone)]
+pub enum ExprKind<'ast> {
+    Unstable(&'ast UnstableExpr<'ast>),
+}
+
+#[repr(C)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone)]
+pub enum ExprPrecedence {
+    /// The precedents originates from an unstable source. The stored value provides
+    /// the current precedence of this expression. This is open to change
+    Unstable(i32),
+}
+
+#[repr(C)]
+#[derive(Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "driver-api", visibility::make(pub))]
+struct CommonExprData<'ast> {
+    /// The lifetime is not needed right now, but it's safer to include it for
+    /// future additions. Having it in this struct makes it easier for all
+    /// pattern structs, as they will have a valid use for `'ast` even if they
+    /// don't need it. Otherwise, we might need to declare this field in each
+    /// pattern.
+    _lifetime: PhantomData<&'ast ()>,
+    id: ExprId,
+    span: SpanId,
+}
+
+macro_rules! impl_expr_data {
+    ($self_ty:ty, $enum_name:ident) => {
+        impl_expr_data!($self_ty, $enum_name,
+            fn precedence(&self) -> ExprPrecedence {
+                $crate::ast::expr::ExprPrecedence::$enum_name
+            }
+        )
+    };
+    ($self_ty:ty, $enum_name:ident, $precedence_fn:item) => {
+        impl<'ast> super::ExprData<'ast> for $self_ty {
+            fn id(&self) -> crate::ast::ExprId {
+                self.data.id
+            }
+
+            fn span(&self) -> &crate::ast::Span<'ast> {
+                $crate::context::with_cx(self, |cx| cx.get_span(self.data.span))
+            }
+
+            fn ty(&self) -> $crate::ast::ty::TyKind<'ast> {
+                todo!("delegate ty request to driver")
+            }
+
+            $precedence_fn
+
+            fn as_expr(&'ast self) -> crate::ast::expr::ExprKind<'ast> {
+                $crate::ast::expr::ExprKind::$enum_name(self)
+            }
+        }
+
+        impl<'ast> From<&'ast $self_ty> for $crate::ast::expr::ExprKind<'ast> {
+            fn from(from: &'ast $self_ty) -> Self {
+                $crate::ast::expr::ExprKind::$enum_name(from)
+            }
+        }
+    };
+}
+
+use impl_expr_data;

--- a/marker_api/src/ast/expr.rs
+++ b/marker_api/src/ast/expr.rs
@@ -22,7 +22,7 @@ pub use unstable_expr::*;
 pub trait ExprData<'ast>: Debug {
     fn id(&self) -> ExprId;
 
-    /// Returns the span of this pattern.
+    /// Returns the span of this expression.
     fn span(&self) -> &Span<'ast>;
 
     // This returns the semantic type of this expression
@@ -52,8 +52,8 @@ pub enum ExprKind<'ast> {
 pub enum ExprPrecedence {
     Block,
     Lit,
-    /// The precedents originates from an unstable source. The stored value provides
-    /// the current precedence of this expression. This is open to change
+    /// The precedence originates from an unstable source. The stored value provides
+    /// the current precedence of this expression. This might change in the future
     Unstable(i32),
 }
 

--- a/marker_api/src/ast/expr.rs
+++ b/marker_api/src/ast/expr.rs
@@ -2,6 +2,16 @@ use super::{ty::TyKind, ExprId, Span, SpanId};
 
 use std::{fmt::Debug, marker::PhantomData};
 
+mod int_lit_expr;
+pub use int_lit_expr::*;
+mod float_lit_expr;
+pub use float_lit_expr::*;
+mod str_lit_expr;
+pub use str_lit_expr::*;
+mod char_lit_expr;
+pub use char_lit_expr::*;
+mod bool_lit_expr;
+pub use bool_lit_expr::*;
 mod unstable_expr;
 pub use unstable_expr::*;
 
@@ -23,6 +33,11 @@ pub trait ExprData<'ast>: Debug {
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone)]
 pub enum ExprKind<'ast> {
+    IntLit(&'ast IntLitExpr<'ast>),
+    FloatLit(&'ast FloatLitExpr<'ast>),
+    StrLit(&'ast StrLitExpr<'ast>),
+    CharLit(&'ast CharLitExpr<'ast>),
+    BoolLit(&'ast BoolLitExpr<'ast>),
     Unstable(&'ast UnstableExpr<'ast>),
 }
 
@@ -30,6 +45,7 @@ pub enum ExprKind<'ast> {
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone)]
 pub enum ExprPrecedence {
+    Lit,
     /// The precedents originates from an unstable source. The stored value provides
     /// the current precedence of this expression. This is open to change
     Unstable(i32),

--- a/marker_api/src/ast/expr/block_expr.rs
+++ b/marker_api/src/ast/expr/block_expr.rs
@@ -1,0 +1,28 @@
+use crate::{ast::stmt::StmtKind, ffi::FfiSlice};
+
+use super::CommonExprData;
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct BlockExpr<'ast> {
+    data: CommonExprData<'ast>,
+    stmts: FfiSlice<'ast, StmtKind<'ast>>,
+}
+
+impl<'ast> BlockExpr<'ast> {
+    pub fn stmts(&self) -> &[StmtKind<'ast>] {
+        self.stmts.get()
+    }
+}
+
+super::impl_expr_data!(BlockExpr<'ast>, Block);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> BlockExpr<'ast> {
+    pub fn new(data: CommonExprData<'ast>, stmts: &'ast [StmtKind<'ast>]) -> Self {
+        Self {
+            data,
+            stmts: stmts.into(),
+        }
+    }
+}

--- a/marker_api/src/ast/expr/bool_lit_expr.rs
+++ b/marker_api/src/ast/expr/bool_lit_expr.rs
@@ -1,0 +1,29 @@
+use super::{CommonExprData, ExprPrecedence};
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct BoolLitExpr<'ast> {
+    data: CommonExprData<'ast>,
+    value: bool,
+}
+
+impl<'ast> BoolLitExpr<'ast> {
+    pub fn value(&self) -> bool {
+        self.value
+    }
+}
+
+super::impl_expr_data!(
+    BoolLitExpr<'ast>,
+    BoolLit,
+    fn precedence(&self) -> ExprPrecedence {
+        ExprPrecedence::Lit
+    }
+);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> BoolLitExpr<'ast> {
+    pub fn new(data: CommonExprData<'ast>, value: bool) -> Self {
+        Self { data, value }
+    }
+}

--- a/marker_api/src/ast/expr/char_lit_expr.rs
+++ b/marker_api/src/ast/expr/char_lit_expr.rs
@@ -1,0 +1,29 @@
+use super::{CommonExprData, ExprPrecedence};
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct CharLitExpr<'ast> {
+    data: CommonExprData<'ast>,
+    value: char,
+}
+
+impl<'ast> CharLitExpr<'ast> {
+    pub fn value(&self) -> char {
+        self.value
+    }
+}
+
+super::impl_expr_data!(
+    CharLitExpr<'ast>,
+    CharLit,
+    fn precedence(&self) -> ExprPrecedence {
+        ExprPrecedence::Lit
+    }
+);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> CharLitExpr<'ast> {
+    pub fn new(data: CommonExprData<'ast>, value: char) -> Self {
+        Self { data, value }
+    }
+}

--- a/marker_api/src/ast/expr/float_lit_expr.rs
+++ b/marker_api/src/ast/expr/float_lit_expr.rs
@@ -4,7 +4,10 @@ use super::{CommonExprData, ExprPrecedence};
 
 /// A float literal like `1.0`, `2e-2`, `2_f32`. The results of float operations
 /// can be hardware-dependent. For exact value checks, it might be better to check
-/// the written float literal or check for a range around the value in question.
+/// the written float literal by getting the code snipped from the expression span.
+/// See:
+/// * [`ExprData::span()`](`super::ExprData::span`)
+/// * [`Span::snippet()`](`crate::ast::Span::snippet`)
 ///
 /// All integer literals are unsigned, negative numbers have a unary negation
 /// operation as their parent.
@@ -29,7 +32,7 @@ impl<'ast> FloatLitExpr<'ast> {
     }
 
     /// The suffix if it has been defined by the user. Use the
-    /// [`ExprData::ty`][`super::ExprData::ty`] method to determine the type,
+    /// [`ExprData::ty`](`super::ExprData::ty`) method to determine the type,
     /// if it hasn't been specified in the suffix
     pub fn suffix(&self) -> Option<FloatSuffix> {
         self.suffix.copy()

--- a/marker_api/src/ast/expr/float_lit_expr.rs
+++ b/marker_api/src/ast/expr/float_lit_expr.rs
@@ -1,0 +1,63 @@
+use crate::ffi::FfiOption;
+
+use super::{CommonExprData, ExprPrecedence};
+
+/// A float literal like `1.0`, `2e-2`, `2_f32`. The results of float operations
+/// can be hardware-dependent. For exact value checks, it might be better to check
+/// the written float literal or check for a range around the value in question.
+///
+/// All integer literals are unsigned, negative numbers have a unary negation
+/// operation as their parent.
+#[repr(C)]
+#[derive(Debug)]
+pub struct FloatLitExpr<'ast> {
+    data: CommonExprData<'ast>,
+    value: f64,
+    suffix: FfiOption<FloatSuffix>,
+}
+
+impl<'ast> FloatLitExpr<'ast> {
+    /// The semantic value of the written literal. The results of float operations
+    /// can be hardware-dependent. For exact value checks, it might be better to check
+    /// the written float literal from the span snippet or check for a range around the
+    /// value in question.
+    ///
+    /// All integer literals are unsigned, negative numbers have a unary negation
+    /// operation as their parent.
+    pub fn value(&self) -> f64 {
+        self.value
+    }
+
+    /// The suffix if it has been defined by the user. Use the
+    /// [`ExprData::ty`][`super::ExprData::ty`] method to determine the type,
+    /// if it hasn't been specified in the suffix
+    pub fn suffix(&self) -> Option<FloatSuffix> {
+        self.suffix.copy()
+    }
+}
+
+super::impl_expr_data!(
+    FloatLitExpr<'ast>,
+    FloatLit,
+    fn precedence(&self) -> ExprPrecedence {
+        ExprPrecedence::Lit
+    }
+);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> FloatLitExpr<'ast> {
+    pub fn new(data: CommonExprData<'ast>, value: f64, suffix: Option<FloatSuffix>) -> Self {
+        Self {
+            data,
+            value,
+            suffix: suffix.into(),
+        }
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum FloatSuffix {
+    F32,
+    F64,
+}

--- a/marker_api/src/ast/expr/int_lit_expr.rs
+++ b/marker_api/src/ast/expr/int_lit_expr.rs
@@ -1,0 +1,67 @@
+use crate::ffi::FfiOption;
+
+use super::{CommonExprData, ExprPrecedence};
+
+/// A integer literal like `16` or `8_u8`. All integer literals in Rust are unsigned
+/// numbers < 2^128. Negative numbers have a unary negation operation as their parent.
+///
+/// Values are casts into their respective type, the literal `300_u8` will have a value
+/// 300 in the value field, but have the semantic value of `300 as u8` which is `44`.
+#[repr(C)]
+#[derive(Debug)]
+pub struct IntLitExpr<'ast> {
+    data: CommonExprData<'ast>,
+    value: u128,
+    suffix: FfiOption<IntSuffix>,
+}
+
+impl<'ast> IntLitExpr<'ast> {
+    /// The value as a `u128`. Higher int literals are not allowed by rusts syntax.
+    /// Negative numbers have a unary negation operation as their parent.
+    pub fn value(&self) -> u128 {
+        self.value
+    }
+
+    /// The suffix if it has been defined by the user. Use the
+    /// [`ExprData::ty`][`super::ExprData::ty`] method to determine the type,
+    /// if it hasn't been specified in the suffix
+    pub fn suffix(&self) -> Option<IntSuffix> {
+        self.suffix.copy()
+    }
+}
+
+super::impl_expr_data!(
+    IntLitExpr<'ast>,
+    IntLit,
+    fn precedence(&self) -> ExprPrecedence {
+        ExprPrecedence::Lit
+    }
+);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> IntLitExpr<'ast> {
+    pub fn new(data: CommonExprData<'ast>, value: u128, suffix: Option<IntSuffix>) -> Self {
+        Self {
+            data,
+            value,
+            suffix: suffix.into(),
+        }
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum IntSuffix {
+    Isize,
+    I8,
+    I16,
+    I32,
+    I64,
+    I128,
+    Usize,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+}

--- a/marker_api/src/ast/expr/int_lit_expr.rs
+++ b/marker_api/src/ast/expr/int_lit_expr.rs
@@ -23,7 +23,7 @@ impl<'ast> IntLitExpr<'ast> {
     }
 
     /// The suffix if it has been defined by the user. Use the
-    /// [`ExprData::ty`][`super::ExprData::ty`] method to determine the type,
+    /// [`ExprData::ty`](`super::ExprData::ty`) method to determine the type,
     /// if it hasn't been specified in the suffix
     pub fn suffix(&self) -> Option<IntSuffix> {
         self.suffix.copy()

--- a/marker_api/src/ast/expr/str_lit_expr.rs
+++ b/marker_api/src/ast/expr/str_lit_expr.rs
@@ -60,11 +60,11 @@ super::impl_expr_data!(
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum StrKind {
-    /// A normal standard string like `Hello \n world`
+    /// A normal standard string like `"Hello \n world"`
     Str,
     /// A raw string like `r#"Hello World!"#`
     Raw,
-    /// A byte string like b`Hello world\0`. The content of a byte string doesn't
+    /// A byte string like `b"Hello world!"\0`. The content of a byte string doesn't
     /// have to be valid UTF-8
     Byte,
 }

--- a/marker_api/src/ast/expr/str_lit_expr.rs
+++ b/marker_api/src/ast/expr/str_lit_expr.rs
@@ -1,0 +1,80 @@
+use crate::{ast::SymbolId, context::with_cx, ffi::FfiSlice};
+
+use super::{CommonExprData, ExprPrecedence};
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct StrLitExpr<'ast> {
+    data: CommonExprData<'ast>,
+    str_data: StrKindWithData<'ast>,
+}
+
+impl<'ast> StrLitExpr<'ast> {
+    pub fn str_kind(&self) -> StrKind {
+        match &self.str_data {
+            StrKindWithData::Str(_) => StrKind::Str,
+            StrKindWithData::Raw(_) => StrKind::Raw,
+            StrKindWithData::Byte(_) => StrKind::Byte,
+        }
+    }
+
+    /// This returns the UTF-8 string value of the string, if possible. Normal
+    /// and raw strings in Rust are required to be UTF-8. Byte strings will be
+    /// converted to UTF-8 if possible, otherwise `None` will be returned
+    pub fn str_value(&self) -> Option<String> {
+        match &self.str_data {
+            StrKindWithData::Str(sym) | StrKindWithData::Raw(sym) => Some(with_cx(self, |cx| cx.symbol_str(*sym))),
+            StrKindWithData::Byte(bytes) => std::str::from_utf8(bytes.get()).map(ToString::to_string).ok(),
+        }
+    }
+
+    /// Returns the value of the string as bytes.
+    pub fn byte_value(&self) -> Box<[u8]> {
+        // The context currently returns symbols as a `String` which makes it
+        // difficult to return the bytes as a byte slice. This could be improved
+        // if the `symbol_str` returns `&'ast str`. But that's a larger todo for
+        // another time :)
+        fn box_slice(bytes: &[u8]) -> Box<[u8]> {
+            let mut vec = Vec::with_capacity(bytes.len());
+            vec.extend_from_slice(bytes);
+            vec.into_boxed_slice()
+        }
+        match &self.str_data {
+            StrKindWithData::Str(sym) | StrKindWithData::Raw(sym) => {
+                let str_value = with_cx(self, |cx| cx.symbol_str(*sym));
+                box_slice(str_value.as_bytes())
+            },
+            StrKindWithData::Byte(bytes) => box_slice(bytes.get()),
+        }
+    }
+}
+
+super::impl_expr_data!(
+    StrLitExpr<'ast>,
+    StrLit,
+    fn precedence(&self) -> ExprPrecedence {
+        ExprPrecedence::Lit
+    }
+);
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum StrKind {
+    /// A normal standard string like `Hello \n world`
+    Str,
+    /// A raw string like `r#"Hello World!"#`
+    Raw,
+    /// A byte string like b`Hello world\0`. The content of a byte string doesn't
+    /// have to be valid UTF-8
+    Byte,
+}
+
+#[derive(Debug)]
+#[allow(clippy::exhaustive_enums)]
+#[cfg_attr(feature = "driver-api", visibility::make(pub))]
+enum StrKindWithData<'ast> {
+    Str(SymbolId),
+    Raw(SymbolId),
+    /// A byte string doesn't have to be valid UTF-8
+    Byte(FfiSlice<'ast, u8>),
+}

--- a/marker_api/src/ast/expr/unstable_expr.rs
+++ b/marker_api/src/ast/expr/unstable_expr.rs
@@ -5,7 +5,7 @@ use super::{CommonExprData, ExprPrecedence};
 pub struct UnstableExpr<'ast> {
     data: CommonExprData<'ast>,
     /// For this expression, we need to specifically store the precedence, as
-    /// this could represent different expressions with different precedents.
+    /// this could represent different expressions with different precedence.
     precedence: ExprPrecedence,
 }
 

--- a/marker_api/src/ast/expr/unstable_expr.rs
+++ b/marker_api/src/ast/expr/unstable_expr.rs
@@ -1,0 +1,25 @@
+use super::{CommonExprData, ExprPrecedence};
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct UnstableExpr<'ast> {
+    data: CommonExprData<'ast>,
+    /// For this expression, we need to specifically store the precedence, as
+    /// this could represent different expressions with different precedents.
+    precedence: ExprPrecedence,
+}
+
+super::impl_expr_data!(
+    UnstableExpr<'ast>,
+    Unstable,
+    fn precedence(&self) -> ExprPrecedence {
+        self.precedence
+    }
+);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> UnstableExpr<'ast> {
+    pub fn new(data: CommonExprData<'ast>, precedence: ExprPrecedence) -> Self {
+        Self { data, precedence }
+    }
+}

--- a/marker_api/src/ast/generic/param.rs
+++ b/marker_api/src/ast/generic/param.rs
@@ -17,7 +17,7 @@ use crate::ffi::FfiOption;
 /// ```
 ///
 /// Bounds declared with the parameter, like the `: Copy` in the example above,
-/// are stored in the [`GenericParams`][`super::GenericParams`] of the item, that
+/// are stored in the [`GenericParams`](`super::GenericParams`) of the item, that
 /// introduced this parameter.
 ///
 /// See: <https://doc.rust-lang.org/reference/items/generics.html>

--- a/marker_api/src/ast/item.rs
+++ b/marker_api/src/ast/item.rs
@@ -31,7 +31,7 @@ pub use unstable_item::*;
 
 pub trait ItemData<'ast>: Debug {
     /// Returns the [`ItemId`] of this item. This is a unique identifier used for comparison
-    /// and to request items from the [`AstContext`][`crate::context::AstContext`].
+    /// and to request items from the [`AstContext`](`crate::context::AstContext`).
     fn id(&self) -> ItemId;
 
     /// The [`Span`] of the entire item. This span should be used for general item related

--- a/marker_api/src/ast/item.rs
+++ b/marker_api/src/ast/item.rs
@@ -1,5 +1,6 @@
 use std::{fmt::Debug, marker::PhantomData};
 
+use super::expr::ExprKind;
 use super::{ItemId, Span, SymbolId};
 
 // Item implementations
@@ -255,5 +256,30 @@ impl<'ast> Visibility<'ast> {
             _lifetime: PhantomData,
             _item_id: item_id,
         }
+    }
+}
+
+/// A body represents the expression of items.
+///
+/// Bodies act like a barrier between the item and expression level. When items
+/// are requested, only the item information is retrieved and converted. Any
+/// expression parts of these items are wrapped into a body, identified via a
+/// [`BodyId`](`super::BodyId`). The body and its content will only be converted
+/// request.
+#[repr(C)]
+#[derive(Debug)]
+pub struct Body<'ast> {
+    owner: ItemId,
+    expr: ExprKind<'ast>,
+}
+
+impl<'ast> Body<'ast> {
+    pub fn owner(&self) -> ItemId {
+        self.owner
+    }
+
+    /// The expression wrapped by this body.
+    pub fn expr(&self) -> ExprKind<'ast> {
+        self.expr
     }
 }

--- a/marker_api/src/ast/item.rs
+++ b/marker_api/src/ast/item.rs
@@ -278,7 +278,9 @@ impl<'ast> Body<'ast> {
         self.owner
     }
 
-    /// The expression wrapped by this body.
+    /// The expression wrapped by this body. In some cases, like for functions
+    /// this expression is guaranteed to be a
+    /// [block expression](`crate::ast::expr::BlockExpr`).
     pub fn expr(&self) -> ExprKind<'ast> {
         self.expr
     }

--- a/marker_api/src/ast/item/extern_crate_item.rs
+++ b/marker_api/src/ast/item/extern_crate_item.rs
@@ -26,7 +26,7 @@ super::impl_item_data!(ExternCrateItem, ExternCrate);
 
 impl<'ast> ExternCrateItem<'ast> {
     /// This will return the original name of external crate. This will only differ
-    /// with [`ItemData::get_name`][`super::ItemData::name`] if the user has
+    /// with [`ItemData::get_name`](`super::ItemData::name`) if the user has
     /// declared an alias with as.
     ///
     /// In most cases, you want to use this over the `get_name()` function.

--- a/marker_api/src/ast/item/ty_alias_item.rs
+++ b/marker_api/src/ast/item/ty_alias_item.rs
@@ -31,7 +31,7 @@ impl<'ast> TyAliasItem<'ast> {
         &self.generics
     }
 
-    /// Type aliases in [`TraitItem`][`super::TraitItem`]s can declare bounds on
+    /// Type aliases in [`TraitItem`](`super::TraitItem`)s can declare bounds on
     /// their types, which implementors needs to follow. This method returns these
     /// bounds. It'll return an empty slice, for type aliases which don't have any
     /// bounds declared.

--- a/marker_api/src/ast/mod.rs
+++ b/marker_api/src/ast/mod.rs
@@ -5,11 +5,12 @@ use crate::ffi::FfiSlice;
 
 use self::item::ItemKind;
 
+pub mod expr;
 pub mod generic;
 pub mod item;
 pub mod pat;
-pub mod ty;
 pub mod stmt;
+pub mod ty;
 
 #[derive(Debug)]
 pub struct Crate<'ast> {

--- a/marker_api/src/ast/mod.rs
+++ b/marker_api/src/ast/mod.rs
@@ -9,6 +9,7 @@ pub mod generic;
 pub mod item;
 pub mod pat;
 pub mod ty;
+pub mod stmt;
 
 #[derive(Debug)]
 pub struct Crate<'ast> {

--- a/marker_api/src/ast/stmt.rs
+++ b/marker_api/src/ast/stmt.rs
@@ -1,6 +1,6 @@
 use crate::ffi::FfiOption;
 
-use super::{item::ItemKind, pat::PatKind, ty::TyKind};
+use super::{expr::ExprKind, item::ItemKind, pat::PatKind, ty::TyKind};
 
 #[repr(C)]
 #[non_exhaustive]
@@ -8,7 +8,7 @@ use super::{item::ItemKind, pat::PatKind, ty::TyKind};
 pub enum StmtKind<'ast> {
     Item(&'ast ItemKind<'ast>),
     Let(&'ast LetStmt<'ast>),
-    // FIXME: Add expression variant
+    Expr(&'ast ExprKind<'ast>),
 }
 
 #[repr(C)]
@@ -16,8 +16,8 @@ pub enum StmtKind<'ast> {
 pub struct LetStmt<'ast> {
     pat: PatKind<'ast>,
     ty: FfiOption<TyKind<'ast>>,
-    // TODO add optional init expression
-    // TODO add optional else expression
+    init_expr: ExprKind<'ast>,
+    else_expr: FfiOption<ExprKind<'ast>>,
 }
 
 impl<'ast> LetStmt<'ast> {
@@ -30,5 +30,28 @@ impl<'ast> LetStmt<'ast> {
         self.ty.copy()
     }
 
-    // FIXME: Add new method once expressions kind of exist.
+    pub fn init_expr(&self) -> ExprKind<'ast> {
+        self.init_expr
+    }
+
+    pub fn else_expr(&self) -> FfiOption<ExprKind> {
+        self.else_expr
+    }
+}
+
+#[cfg(feature = "driver-api")]
+impl<'ast> LetStmt<'ast> {
+    pub fn new(
+        pat: PatKind<'ast>,
+        ty: Option<TyKind<'ast>>,
+        init_expr: ExprKind<'ast>,
+        else_expr: Option<ExprKind<'ast>>,
+    ) -> Self {
+        Self {
+            pat,
+            ty: ty.into(),
+            init_expr,
+            else_expr: else_expr.into(),
+        }
+    }
 }

--- a/marker_api/src/ast/stmt.rs
+++ b/marker_api/src/ast/stmt.rs
@@ -1,6 +1,6 @@
 use crate::ffi::FfiOption;
 
-use super::{item::ItemKind, ty::TyKind, pat::PatKind};
+use super::{item::ItemKind, pat::PatKind, ty::TyKind};
 
 #[repr(C)]
 #[non_exhaustive]
@@ -32,4 +32,3 @@ impl<'ast> LetStmt<'ast> {
 
     // FIXME: Add new method once expressions kind of exist.
 }
-

--- a/marker_api/src/ast/stmt.rs
+++ b/marker_api/src/ast/stmt.rs
@@ -1,0 +1,35 @@
+use crate::ffi::FfiOption;
+
+use super::{item::ItemKind, ty::TyKind, pat::PatKind};
+
+#[repr(C)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone)]
+pub enum StmtKind<'ast> {
+    Item(&'ast ItemKind<'ast>),
+    Let(&'ast LetStmt<'ast>),
+    // FIXME: Add expression variant
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct LetStmt<'ast> {
+    pat: PatKind<'ast>,
+    ty: FfiOption<TyKind<'ast>>,
+    // TODO add optional init expression
+    // TODO add optional else expression
+}
+
+impl<'ast> LetStmt<'ast> {
+    pub fn pat(&self) -> PatKind<'ast> {
+        self.pat
+    }
+
+    /// Returns the syntactic type, if it has been specified.
+    pub fn ty(&self) -> Option<TyKind<'ast>> {
+        self.ty.copy()
+    }
+
+    // FIXME: Add new method once expressions kind of exist.
+}
+

--- a/marker_api/src/ast/ty.rs
+++ b/marker_api/src/ast/ty.rs
@@ -84,7 +84,7 @@ pub trait TyData<'ast> {
     /// Returns `true`, if this type instance is a semantic type, which was
     /// determined by the driver during translation.
     ///
-    /// See [`is_syntactic`][`TyData::is_syntactic`] for an example.
+    /// See [`is_syntactic`](`TyData::is_syntactic`) for an example.
     fn is_semantic(&self) -> bool;
 }
 

--- a/marker_api/src/ast/ty/alias_ty.rs
+++ b/marker_api/src/ast/ty/alias_ty.rs
@@ -13,7 +13,7 @@ super::impl_ty_data!(AliasTy<'ast>, Alias);
 
 impl<'ast> AliasTy<'ast> {
     /// This returns the [`ItemId`] belonging to the
-    /// [`TyAliasItem`][`super::super::item::TyAliasItem`] that declared this item.
+    /// [`TyAliasItem`](`super::super::item::TyAliasItem`) that declared this item.
     pub fn alias_item_id(&self) -> ItemId {
         self.item
     }

--- a/marker_api/src/interface.rs
+++ b/marker_api/src/interface.rs
@@ -1,4 +1,4 @@
-/// This macro marks the given struct as the main [`LintPass`][`crate::LintPass`]
+/// This macro marks the given struct as the main [`LintPass`](`crate::LintPass`)
 /// for the lint crate. For structs implementing [`Default`] it's enough to only
 /// pass in the type. Otherwise, a second argument is required to initialize an
 /// instance.
@@ -25,7 +25,7 @@
 /// that this can change in the future.
 ///
 /// The instance is created and stored in a [`thread_local!`]
-/// [`RefCell`][`std::cell::RefCell`]. One lint crate will always be called by the
+/// [`RefCell`](`std::cell::RefCell`). One lint crate will always be called by the
 /// same thread.
 #[macro_export]
 macro_rules! export_lint_pass {

--- a/marker_driver_rustc/src/context.rs
+++ b/marker_driver_rustc/src/context.rs
@@ -82,7 +82,7 @@ impl<'ast, 'tcx: 'ast> DriverContext<'ast> for RustcContext<'ast, 'tcx> {
     }
 
     fn body(&'ast self, id: BodyId) -> &'ast Body<'ast> {
-        // This comment sounds kind of ominous xD
+        // This message sounds kind of ominous xD
         todo!("a body was requested {id:#?}");
     }
 

--- a/marker_driver_rustc/src/context.rs
+++ b/marker_driver_rustc/src/context.rs
@@ -22,10 +22,10 @@ use self::storage::Storage;
 pub mod storage;
 
 /// This is the central context for the rustc driver and the struct providing the
-/// callback implementation for [`AstContext`][`marker_api::context::AstContext`].
+/// callback implementation for [`AstContext`](`marker_api::context::AstContext`).
 ///
 /// The struct intentionally only stores the [`TyCtxt`] and [`LintStore`] and not
-/// a [`LateContext`][`rustc_lint::LateContext`] as the late context operates on
+/// a [`LateContext`](`rustc_lint::LateContext`) as the late context operates on
 /// the assumption that every AST node is only checked in the specific `check_`
 /// function. This will in contrast convert the entire crate at once and might
 /// also jump around inside the AST if a lint crate requests that. This also has

--- a/marker_driver_rustc/src/context.rs
+++ b/marker_driver_rustc/src/context.rs
@@ -2,7 +2,10 @@ use std::cell::OnceCell;
 
 use marker_adapter::context::{DriverContext, DriverContextWrapper};
 use marker_api::{
-    ast::{item::ItemKind, ItemId, Span, SpanOwner, SymbolId},
+    ast::{
+        item::{Body, ItemKind},
+        BodyId, ItemId, Span, SpanOwner, SymbolId,
+    },
     context::AstContext,
     lint::Lint,
 };
@@ -76,6 +79,11 @@ impl<'ast, 'tcx: 'ast> DriverContext<'ast> for RustcContext<'ast, 'tcx> {
 
     fn item(&'ast self, id: ItemId) -> Option<ItemKind<'ast>> {
         ItemConverter::new(self).conv_item_from_id(id)
+    }
+
+    fn body(&'ast self, id: BodyId) -> &'ast Body<'ast> {
+        // This comment sounds kind of ominous xD
+        todo!("a body was requested {id:#?}");
     }
 
     fn get_span(&'ast self, owner: &SpanOwner) -> &'ast Span<'ast> {


### PR DESCRIPTION
This PR adds a basic statement, expression, and body representation to the API. With this, it's possible to represent simple literal expressions and more importantly, use `ExprKind` and `StmtKind` where needed. Merging this allows resolving several TODOs around the API as well as some parallelization.

This PR only includes the API frontend, the rustc backend will be added in a separate PR. As said, I'm not 100% happy with the rustc conversion code and want to focus on that part individually in a separate branch. Sadly, this means that this on its own is not testable. However, I trust rusts type system, and we can always adjust these structs later if needed.

---

cc: https://github.com/rust-marker/marker/issues/52

---

@Niki4tap Would you like to review this? If you don't have the time, I'll merge this once the next step is ready, which will probably take a week or two. 