### PR TITLE
Add simple rustc backend for patterns

### DIFF
--- a/marker_api/src/ast/pat.rs
+++ b/marker_api/src/ast/pat.rs
@@ -18,6 +18,8 @@ mod slice_pat;
 pub use slice_pat::*;
 mod or_pat;
 pub use or_pat::*;
+mod unstable_pat;
+pub use unstable_pat::*;
 
 pub trait PatData<'ast>: Debug {
     /// Returns the span of this pattern.
@@ -38,6 +40,7 @@ pub enum PatKind<'ast> {
     Tuple(&'ast TuplePat<'ast>),
     Slice(&'ast SlicePat<'ast>),
     Or(&'ast OrPat<'ast>),
+    Unstable(&'ast UnstablePat<'ast>),
 }
 
 impl<'ast> PatKind<'ast> {
@@ -48,7 +51,7 @@ macro_rules! impl_pat_data_fn {
     ($method:ident () -> $return_ty:ty) => {
         impl_pat_data_fn!(
             $method() -> $return_ty,
-            Ident, Wildcard, Rest, Ref, Struct, Tuple, Slice, Or
+            Ident, Wildcard, Rest, Ref, Struct, Tuple, Slice, Or, Unstable
         );
     };
     ($method:ident () -> $return_ty:ty $(, $item:ident)+) => {

--- a/marker_api/src/ast/pat/ref_pat.rs
+++ b/marker_api/src/ast/pat/ref_pat.rs
@@ -5,6 +5,7 @@ use super::{CommonPatData, PatKind};
 pub struct RefPat<'ast> {
     data: CommonPatData<'ast>,
     pattern: PatKind<'ast>,
+    is_mut: bool,
 }
 
 impl<'ast> RefPat<'ast> {
@@ -12,13 +13,17 @@ impl<'ast> RefPat<'ast> {
     pub fn pattern(&self) -> PatKind<'ast> {
         self.pattern
     }
+
+    pub fn is_mut(&self) -> bool {
+        self.is_mut
+    }
 }
 
 super::impl_pat_data!(RefPat<'ast>, Ref);
 
 #[cfg(feature = "driver-api")]
 impl<'ast> RefPat<'ast> {
-    pub fn new(data: CommonPatData<'ast>, pattern: PatKind<'ast>) -> Self {
-        Self { data, pattern }
+    pub fn new(data: CommonPatData<'ast>, pattern: PatKind<'ast>, is_mut: bool) -> Self {
+        Self { data, pattern, is_mut }
     }
 }

--- a/marker_api/src/ast/pat/unstable_pat.rs
+++ b/marker_api/src/ast/pat/unstable_pat.rs
@@ -1,0 +1,16 @@
+use super::CommonPatData;
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct UnstablePat<'ast> {
+    data: CommonPatData<'ast>,
+}
+
+super::impl_pat_data!(UnstablePat<'ast>, Unstable);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> UnstablePat<'ast> {
+    pub fn new(data: CommonPatData<'ast>) -> Self {
+        Self { data }
+    }
+}

--- a/marker_driver_rustc/src/conversion/common.rs
+++ b/marker_driver_rustc/src/conversion/common.rs
@@ -38,3 +38,9 @@ pub struct SpanSourceInfo {
     pub rustc_span_cx: rustc_span::hygiene::SyntaxContext,
     pub rustc_start_offset: usize,
 }
+
+#[repr(C)]
+pub struct VarIdLayout {
+    pub owner: u32,
+    pub index: u32,
+}

--- a/marker_driver_rustc/src/conversion/marker.rs
+++ b/marker_driver_rustc/src/conversion/marker.rs
@@ -6,12 +6,13 @@
 mod common;
 mod generics;
 mod item;
+mod pat;
 mod ty;
 
 use std::cell::RefCell;
 
 use crate::context::storage::Storage;
-use marker_api::ast::{item::ItemKind, Crate, ItemId};
+use marker_api::ast::{item::ItemKind, Crate, ItemId, SymbolId};
 use rustc_hash::FxHashMap;
 use rustc_hir as hir;
 
@@ -19,6 +20,7 @@ pub struct MarkerConversionContext<'ast, 'tcx> {
     rustc_cx: rustc_middle::ty::TyCtxt<'tcx>,
     storage: &'ast Storage<'ast>,
     items: RefCell<FxHashMap<ItemId, ItemKind<'ast>>>,
+    num_symbols: RefCell<FxHashMap<u32, SymbolId>>,
 }
 
 // General util functions
@@ -28,6 +30,7 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
             rustc_cx,
             storage,
             items: RefCell::default(),
+            num_symbols: RefCell::default(),
         }
     }
 

--- a/marker_driver_rustc/src/conversion/marker/item.rs
+++ b/marker_driver_rustc/src/conversion/marker/item.rs
@@ -45,7 +45,7 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
                     hir::UseKind::Glob => UseKind::Glob,
                     hir::UseKind::ListStem => return None,
                 };
-                ItemKind::Use(self.alloc(|| UseItem::new(data, self.to_api_path(path), use_kind)))
+                ItemKind::Use(self.alloc(|| UseItem::new(data, self.to_path(path), use_kind)))
             },
             hir::ItemKind::Static(rustc_ty, rustc_mut, rustc_body_id) => ItemKind::Static(self.alloc(|| {
                 StaticItem::new(

--- a/marker_driver_rustc/src/conversion/marker/pat.rs
+++ b/marker_driver_rustc/src/conversion/marker/pat.rs
@@ -106,8 +106,7 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
 
     fn new_rest_pat(&self) -> PatKind<'ast> {
         // This is a dummy span, it's dirty, but at least works for the mean time :)
-        let span = rustc_span::Span::default();
-        let data = CommonPatData::new(self.to_span_id(span));
+        let data = CommonPatData::new(self.to_span_id(rustc_span::DUMMY_SP));
         PatKind::Rest(self.alloc(|| RestPat::new(data)))
     }
 }

--- a/marker_driver_rustc/src/conversion/marker/pat.rs
+++ b/marker_driver_rustc/src/conversion/marker/pat.rs
@@ -1,0 +1,113 @@
+use marker_api::ast::pat::{
+    CommonPatData, IdentPat, OrPat, PatKind, RefPat, RestPat, SlicePat, StructFieldPat, StructPat, TuplePat,
+    UnstablePat, WildcardPat,
+};
+use rustc_hir as hir;
+
+use super::MarkerConversionContext;
+
+impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
+    #[must_use]
+    pub fn to_pat(&self, pat: &hir::Pat<'tcx>) -> PatKind<'ast> {
+        // Here we don't need to take special care for caching, as marker patterns
+        // don't have IDs and can't be requested individually. Instead patterns are
+        // stored as part of their parent expressions or items. Not needing to deal
+        // with caching makes this implementation simpler.
+        let data = CommonPatData::new(self.to_span_id(pat.span));
+
+        match &pat.kind {
+            hir::PatKind::Wild => PatKind::Wildcard(self.alloc(|| WildcardPat::new(data))),
+            hir::PatKind::Binding(hir::BindingAnnotation(by_ref, mutab), id, ident, pat) => {
+                PatKind::Ident(self.alloc(|| {
+                    IdentPat::new(
+                        data,
+                        self.to_symbol_id(ident.name),
+                        self.to_var_id(*id),
+                        matches!(mutab, rustc_ast::Mutability::Mut),
+                        matches!(by_ref, hir::ByRef::Yes),
+                        pat.map(|rustc_pat| self.to_pat(rustc_pat)),
+                    )
+                }))
+            },
+            hir::PatKind::Struct(qpath, fields, has_rest) => {
+                let api_fields = self.alloc_slice_iter(fields.iter().map(|field| {
+                    StructFieldPat::new(
+                        self.to_span_id(field.span),
+                        self.to_symbol_id(field.ident.name),
+                        self.to_pat(field.pat),
+                    )
+                }));
+                PatKind::Struct(
+                    self.alloc(|| StructPat::new(data, self.to_path_from_qpath(qpath), api_fields, *has_rest)),
+                )
+            },
+            hir::PatKind::TupleStruct(qpath, pats, dotdot) => {
+                let ddpos = dotdot.as_opt_usize();
+                let offset_pos = ddpos.unwrap_or(usize::MAX);
+                let api_fields = self.alloc_slice_iter(pats.iter().enumerate().map(|(mut index, pat)| {
+                    if index >= offset_pos {
+                        index += offset_pos;
+                    }
+                    StructFieldPat::new(
+                        self.to_span_id(pat.span),
+                        self.to_symbol_id_for_num(u32::try_from(index).expect("a index over 2^32 us unexpected")),
+                        self.to_pat(pat),
+                    )
+                }));
+                PatKind::Struct(
+                    self.alloc(|| StructPat::new(data, self.to_path_from_qpath(qpath), api_fields, ddpos.is_some())),
+                )
+            },
+            hir::PatKind::Or(pats) => PatKind::Or(
+                self.alloc(|| OrPat::new(data, self.alloc_slice_iter(pats.iter().map(|rpat| self.to_pat(rpat))))),
+            ),
+            hir::PatKind::Tuple(pats, dotdot) => {
+                let pats = if let Some(rest_pos) = dotdot.as_opt_usize() {
+                    let (start, end) = pats.split_at(rest_pos);
+                    self.chain_pats(start, self.new_rest_pat(), end)
+                } else {
+                    self.alloc_slice_iter(pats.iter().map(|pat| self.to_pat(pat)))
+                };
+                PatKind::Tuple(self.alloc(|| TuplePat::new(data, pats)))
+            },
+            hir::PatKind::Box(_) => PatKind::Unstable(self.alloc(|| UnstablePat::new(data))),
+            hir::PatKind::Ref(pat, muta) => {
+                PatKind::Ref(self.alloc(|| RefPat::new(data, self.to_pat(pat), matches!(muta, hir::Mutability::Mut))))
+            },
+            hir::PatKind::Slice(start, wild, end) => {
+                let elements = if let Some(wild) = wild {
+                    self.chain_pats(start, self.to_pat(wild), end)
+                } else {
+                    assert!(end.is_empty());
+                    self.alloc_slice_iter(start.iter().map(|pat| self.to_pat(pat)))
+                };
+                PatKind::Slice(self.alloc(|| SlicePat::new(data, elements)))
+            },
+            // These haven't been implemented yet, as they require expressions.
+            // The pattern creation is tracked in #50
+            hir::PatKind::Path(_) => todo!("{pat:#?}"),
+            hir::PatKind::Lit(_) => todo!("{pat:#?}"),
+            hir::PatKind::Range(_, _, _) => todo!("{pat:#?}"),
+        }
+    }
+
+    fn chain_pats(
+        &self,
+        start: &[hir::Pat<'tcx>],
+        ast_wild: PatKind<'ast>,
+        end: &[hir::Pat<'tcx>],
+    ) -> &'ast [PatKind<'ast>] {
+        let start = start.iter().map(|pat| self.to_pat(pat));
+        let middle = std::iter::once(ast_wild);
+        let end = end.iter().map(|pat| self.to_pat(pat));
+        let api_pats: Vec<_> = start.chain(middle).chain(end).collect();
+        self.alloc_slice_iter(api_pats.into_iter())
+    }
+
+    fn new_rest_pat(&self) -> PatKind<'ast> {
+        // This is a dummy span, it's dirty, but at least works for the mean time :)
+        let span = rustc_span::Span::default();
+        let data = CommonPatData::new(self.to_span_id(span));
+        PatKind::Rest(self.alloc(|| RestPat::new(data)))
+    }
+}


### PR DESCRIPTION
This PR adds the \`Unstable\` pattern and a basic rustc backend. Sadly, it's not yet testable, as it first requires bodies and expressions to be implemented. I still wanted to get most of this out of the way while I was still in the context of patterns. Most of this code has been copied from a different dev branch and adjusted to the recent refactorings.

Not too much more to say. I'd prefer to merge this now, but we could wait until expressions and bodies have been implemented to test this first. Though, it might take a while until we reach an expression with refutable patterns.

r? @Niki4tap ^^ So much for me saying that the next PR will take some time to implement :sweat_smile:. As always, feel free to skip it or do the review when you have time :).

Otherwise, to everyone reading this, have a wonderful day.

---

CC: #50 

Closes: #69 