### PR TITLE
Adjust `StrLitExpr` node and add util and check methods

### DIFF
--- a/marker_adapter/src/lib.rs
+++ b/marker_adapter/src/lib.rs
@@ -94,6 +94,9 @@ impl<'ast> Adapter<'ast> {
                 for stmt in block.stmts() {
                     self.external_lint_crates.check_stmt(cx, *stmt)
                 }
+                if let Some(expr) = block.expr() {
+                    self.process_expr(cx, expr)
+                }
             },
             _ => {},
         }

--- a/marker_adapter/src/lib.rs
+++ b/marker_adapter/src/lib.rs
@@ -9,7 +9,7 @@ mod loader;
 
 use loader::LintCrateRegistry;
 use marker_api::{
-    ast::{item::ItemKind, Crate},
+    ast::{expr::ExprKind, item::ItemKind, BodyId, Crate},
     context::AstContext,
     lint::Lint,
     LintPass,
@@ -26,6 +26,11 @@ impl<'ast> Adapter<'ast> {
     pub fn new_from_env() -> Self {
         let external_lint_crates = LintCrateRegistry::new_from_env();
         Self { external_lint_crates }
+    }
+
+    #[must_use]
+    pub fn registered_lints(&self) -> Box<[&'static Lint]> {
+        self.external_lint_crates.registered_lints()
     }
 
     pub fn process_krate(&mut self, cx: &'ast AstContext<'ast>, krate: &Crate<'ast>) {
@@ -50,7 +55,12 @@ impl<'ast> Adapter<'ast> {
             ItemKind::Static(data) => self.external_lint_crates.check_static_item(cx, data),
             ItemKind::Const(data) => self.external_lint_crates.check_const_item(cx, data),
             // FIXME: Function-local items are not yet processed
-            ItemKind::Fn(data) => self.external_lint_crates.check_fn(cx, data),
+            ItemKind::Fn(data) => {
+                self.external_lint_crates.check_fn(cx, data);
+                if let Some(id) = data.body() {
+                    self.process_body(cx, id)
+                }
+            },
             ItemKind::Struct(data) => {
                 self.external_lint_crates.check_struct(cx, data);
                 for field in data.fields() {
@@ -70,8 +80,22 @@ impl<'ast> Adapter<'ast> {
         }
     }
 
-    #[must_use]
-    pub fn registered_lints(&self) -> Box<[&'static Lint]> {
-        self.external_lint_crates.registered_lints()
+    fn process_body(&mut self, cx: &'ast AstContext<'ast>, id: BodyId) {
+        let body = cx.body(id);
+        self.external_lint_crates.check_body(cx, body);
+        let expr = body.expr();
+        self.process_expr(cx, expr);
+    }
+
+    fn process_expr(&mut self, cx: &'ast AstContext<'ast>, expr: ExprKind<'ast>) {
+        self.external_lint_crates.check_expr(cx, expr);
+        match expr {
+            ExprKind::Block(block) => {
+                for stmt in block.stmts() {
+                    self.external_lint_crates.check_stmt(cx, *stmt)
+                }
+            },
+            _ => {},
+        }
     }
 }

--- a/marker_adapter/src/lib.rs
+++ b/marker_adapter/src/lib.rs
@@ -58,7 +58,7 @@ impl<'ast> Adapter<'ast> {
             ItemKind::Fn(data) => {
                 self.external_lint_crates.check_fn(cx, data);
                 if let Some(id) = data.body() {
-                    self.process_body(cx, id)
+                    self.process_body(cx, id);
                 }
             },
             ItemKind::Struct(data) => {
@@ -89,13 +89,14 @@ impl<'ast> Adapter<'ast> {
 
     fn process_expr(&mut self, cx: &'ast AstContext<'ast>, expr: ExprKind<'ast>) {
         self.external_lint_crates.check_expr(cx, expr);
+        #[expect(clippy::single_match)]
         match expr {
             ExprKind::Block(block) => {
                 for stmt in block.stmts() {
-                    self.external_lint_crates.check_stmt(cx, *stmt)
+                    self.external_lint_crates.check_stmt(cx, *stmt);
                 }
                 if let Some(expr) = block.expr() {
-                    self.process_expr(cx, expr)
+                    self.process_expr(cx, expr);
                 }
             },
             _ => {},

--- a/marker_api/src/ast/expr/block_expr.rs
+++ b/marker_api/src/ast/expr/block_expr.rs
@@ -1,4 +1,7 @@
-use crate::{ast::stmt::StmtKind, ffi::{FfiSlice, FfiOption}};
+use crate::{
+    ast::stmt::StmtKind,
+    ffi::{FfiOption, FfiSlice},
+};
 
 use super::{CommonExprData, ExprKind};
 
@@ -7,7 +10,7 @@ use super::{CommonExprData, ExprKind};
 pub struct BlockExpr<'ast> {
     data: CommonExprData<'ast>,
     stmts: FfiSlice<'ast, StmtKind<'ast>>,
-    expr: FfiOption<ExprKind<'ast>>
+    expr: FfiOption<ExprKind<'ast>>,
 }
 
 impl<'ast> BlockExpr<'ast> {
@@ -32,7 +35,7 @@ impl<'ast> BlockExpr<'ast> {
         Self {
             data,
             stmts: stmts.into(),
-            expr: expr.into()
+            expr: expr.into(),
         }
     }
 }

--- a/marker_api/src/ast/expr/block_expr.rs
+++ b/marker_api/src/ast/expr/block_expr.rs
@@ -1,17 +1,26 @@
-use crate::{ast::stmt::StmtKind, ffi::FfiSlice};
+use crate::{ast::stmt::StmtKind, ffi::{FfiSlice, FfiOption}};
 
-use super::CommonExprData;
+use super::{CommonExprData, ExprKind};
 
 #[repr(C)]
 #[derive(Debug)]
 pub struct BlockExpr<'ast> {
     data: CommonExprData<'ast>,
     stmts: FfiSlice<'ast, StmtKind<'ast>>,
+    expr: FfiOption<ExprKind<'ast>>
 }
 
 impl<'ast> BlockExpr<'ast> {
+    /// This returns all statements of this block. The optional value expression,
+    /// which is returned by the block, is stored separately. See [`BlockExpr::expr()`]
     pub fn stmts(&self) -> &[StmtKind<'ast>] {
         self.stmts.get()
+    }
+
+    /// Blocks may optionally end with an expression, indicated by an expression
+    /// without a trailing semicolon.
+    pub fn expr(&self) -> Option<ExprKind<'ast>> {
+        self.expr.copy()
     }
 }
 
@@ -19,10 +28,11 @@ super::impl_expr_data!(BlockExpr<'ast>, Block);
 
 #[cfg(feature = "driver-api")]
 impl<'ast> BlockExpr<'ast> {
-    pub fn new(data: CommonExprData<'ast>, stmts: &'ast [StmtKind<'ast>]) -> Self {
+    pub fn new(data: CommonExprData<'ast>, stmts: &'ast [StmtKind<'ast>], expr: Option<ExprKind<'ast>>) -> Self {
         Self {
             data,
             stmts: stmts.into(),
+            expr: expr.into()
         }
     }
 }

--- a/marker_api/src/ast/expr/str_lit_expr.rs
+++ b/marker_api/src/ast/expr/str_lit_expr.rs
@@ -6,16 +6,26 @@ use super::{CommonExprData, ExprPrecedence};
 #[derive(Debug)]
 pub struct StrLitExpr<'ast> {
     data: CommonExprData<'ast>,
-    str_data: StrKindWithData<'ast>,
+    is_raw: bool,
+    str_data: StrLitData<'ast>,
 }
 
 impl<'ast> StrLitExpr<'ast> {
-    pub fn str_kind(&self) -> StrKind {
-        match &self.str_data {
-            StrKindWithData::Str(_) => StrKind::Str,
-            StrKindWithData::Raw(_) => StrKind::Raw,
-            StrKindWithData::Byte(_) => StrKind::Byte,
-        }
+    /// Returns `true`, if this is a raw string literal, like `r#"Hello World!"#`
+    pub fn is_raw_lit(&self) -> bool {
+        self.is_raw
+    }
+
+    /// Returns `true`, if this is a standard string literal, like `"Hello World!"`.
+    /// This type of string is also sometimes referred to as *Cooked*.
+    pub fn is_standard_lit(&self) -> bool {
+        !self.is_raw
+    }
+
+    /// This returns `true`, if the literal is a byte string literal like `b"Hello\0"`
+    /// or `br#"World"#`
+    pub fn is_byte_str(&self) -> bool {
+        matches!(self.str_data, StrLitData::Bytes(_))
     }
 
     /// This returns the UTF-8 string value of the string, if possible. Normal
@@ -23,16 +33,16 @@ impl<'ast> StrLitExpr<'ast> {
     /// converted to UTF-8 if possible, otherwise `None` will be returned
     pub fn str_value(&self) -> Option<&str> {
         match &self.str_data {
-            StrKindWithData::Str(sym) | StrKindWithData::Raw(sym) => Some(with_cx(self, |cx| cx.symbol_str(*sym))),
-            StrKindWithData::Byte(bytes) => std::str::from_utf8(bytes.get()).ok(),
+            StrLitData::Sym(sym) => Some(with_cx(self, |cx| cx.symbol_str(*sym))),
+            StrLitData::Bytes(bytes) => std::str::from_utf8(bytes.get()).ok(),
         }
     }
 
     /// Returns the value of the string as bytes.
     pub fn byte_value(&self) -> &[u8] {
         match &self.str_data {
-            StrKindWithData::Str(sym) | StrKindWithData::Raw(sym) => with_cx(self, |cx| cx.symbol_str(*sym)).as_bytes(),
-            StrKindWithData::Byte(bytes) => bytes.get(),
+            StrLitData::Sym(sym) => with_cx(self, |cx| cx.symbol_str(*sym)).as_bytes(),
+            StrLitData::Bytes(bytes) => bytes.get(),
         }
     }
 }
@@ -45,24 +55,18 @@ super::impl_expr_data!(
     }
 );
 
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum StrKind {
-    /// A normal standard string like `"Hello world!"`
-    Str,
-    /// A raw string like `r#"Hello World!"#`
-    Raw,
-    /// A byte string like `b"Hello world!\0"`. The content of a byte string doesn't
-    /// have to be valid UTF-8
-    Byte,
+#[cfg(feature = "driver-api")]
+impl<'ast> StrLitExpr<'ast> {
+    pub fn new(data: CommonExprData<'ast>, is_raw: bool, str_data: StrLitData<'ast>) -> Self {
+        Self { data, is_raw, str_data }
+    }
 }
 
 #[derive(Debug)]
 #[allow(clippy::exhaustive_enums)]
 #[cfg_attr(feature = "driver-api", visibility::make(pub))]
-enum StrKindWithData<'ast> {
-    Str(SymbolId),
-    Raw(SymbolId),
-    /// A byte string doesn't have to be valid UTF-8
-    Byte(FfiSlice<'ast, u8>),
+enum StrLitData<'ast> {
+    Sym(SymbolId),
+    /// A byte string might not be valid UTF-8
+    Bytes(FfiSlice<'ast, u8>),
 }

--- a/marker_api/src/ast/item.rs
+++ b/marker_api/src/ast/item.rs
@@ -278,10 +278,16 @@ impl<'ast> Body<'ast> {
         self.owner
     }
 
-    /// The expression wrapped by this body. In some cases, like for functions
-    /// this expression is guaranteed to be a
+    /// The expression wrapped by this body. In most cases this will be a
     /// [block expression](`crate::ast::expr::BlockExpr`).
     pub fn expr(&self) -> ExprKind<'ast> {
         self.expr
+    }
+}
+
+#[cfg(feature = "driver-api")]
+impl<'ast> Body<'ast> {
+    pub fn new(owner: ItemId, expr: ExprKind<'ast>) -> Self {
+        Self { owner, expr }
     }
 }

--- a/marker_api/src/ast/stmt.rs
+++ b/marker_api/src/ast/stmt.rs
@@ -1,6 +1,6 @@
-use crate::ffi::FfiOption;
+use crate::{context::with_cx, ffi::FfiOption};
 
-use super::{expr::ExprKind, item::ItemKind, pat::PatKind, ty::TyKind};
+use super::{expr::ExprKind, item::ItemKind, pat::PatKind, ty::TyKind, Span, SpanId};
 
 #[repr(C)]
 #[non_exhaustive]
@@ -14,13 +14,18 @@ pub enum StmtKind<'ast> {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct LetStmt<'ast> {
+    span: SpanId,
     pat: PatKind<'ast>,
     ty: FfiOption<TyKind<'ast>>,
-    init_expr: ExprKind<'ast>,
+    init_expr: FfiOption<ExprKind<'ast>>,
     else_expr: FfiOption<ExprKind<'ast>>,
 }
 
 impl<'ast> LetStmt<'ast> {
+    pub fn span(&self) -> &Span<'ast> {
+        with_cx(self, |cx| cx.get_span(self.span))
+    }
+
     pub fn pat(&self) -> PatKind<'ast> {
         self.pat
     }
@@ -30,27 +35,29 @@ impl<'ast> LetStmt<'ast> {
         self.ty.copy()
     }
 
-    pub fn init_expr(&self) -> ExprKind<'ast> {
-        self.init_expr
+    pub fn init_expr(&self) -> Option<ExprKind<'ast>> {
+        self.init_expr.copy()
     }
 
-    pub fn else_expr(&self) -> FfiOption<ExprKind> {
-        self.else_expr
+    pub fn else_expr(&self) -> Option<ExprKind> {
+        self.else_expr.copy()
     }
 }
 
 #[cfg(feature = "driver-api")]
 impl<'ast> LetStmt<'ast> {
     pub fn new(
+        span: SpanId,
         pat: PatKind<'ast>,
         ty: Option<TyKind<'ast>>,
-        init_expr: ExprKind<'ast>,
+        init_expr: Option<ExprKind<'ast>>,
         else_expr: Option<ExprKind<'ast>>,
     ) -> Self {
         Self {
+            span,
             pat,
             ty: ty.into(),
-            init_expr,
+            init_expr: init_expr.into(),
             else_expr: else_expr.into(),
         }
     }

--- a/marker_api/src/lib.rs
+++ b/marker_api/src/lib.rs
@@ -87,6 +87,18 @@ macro_rules! lint_pass_fns {
                 &(mut) self,
                 _cx: &'ast $crate::context::AstContext<'ast>,
                 _variant: &'ast $crate::ast::item::EnumVariant<'ast>) -> ();
+            fn check_body<'ast>(
+                &(mut) self,
+                _cx: &'ast $crate::context::AstContext<'ast>,
+                _body: &'ast $crate::ast::item::Body<'ast>) -> ();
+            fn check_stmt<'ast>(
+                &(mut) self,
+                _cx: &'ast $crate::context::AstContext<'ast>,
+                _stmt: $crate::ast::stmt::StmtKind<'ast>) -> ();
+            fn check_expr<'ast>(
+                &(mut) self,
+                _cx: &'ast $crate::context::AstContext<'ast>,
+                _expr: $crate::ast::expr::ExprKind<'ast>) -> ();
         );
     };
 }

--- a/marker_driver_rustc/src/conversion/marker/item.rs
+++ b/marker_driver_rustc/src/conversion/marker/item.rs
@@ -58,14 +58,16 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
             hir::ItemKind::Const(rustc_ty, rustc_body_id) => ItemKind::Const(
                 self.alloc(|| ConstItem::new(data, self.to_ty(*rustc_ty), Some(self.to_body_id(*rustc_body_id)))),
             ),
-            hir::ItemKind::Fn(fn_sig, generics, body_id) => ItemKind::Fn(self.alloc(|| {
+            hir::ItemKind::Fn(fn_sig, generics, _body_id) => ItemKind::Fn(self.alloc(|| {
                 // Add a whole bunch of these things. The generic conversion should
                 // be done in the generics module yay
                 FnItem::new(
                     data,
                     self.to_generic_params(generics),
                     self.to_callable_data_from_fn_sig(fn_sig, false),
-                    Some(self.to_body_id(*body_id)),
+                    // FIXME: This is set to `None`, while the `body()` function is not implemented
+                    // Some(self.to_body_id(*body_id)),
+                    None,
                 )
             })),
             hir::ItemKind::Mod(rustc_mod) => {


### PR DESCRIPTION
While working on the rustc driver, I noticed some missing aspects and utils for statements, expressions, and bodies. The [grammar](https://doc.rust-lang.org/reference/expressions/literal-expr.html) was structured differently than I expected, which made me miss these at first.

I've extracted the API and adapter changes, to keep the PRs smaller overall.

---

Follow-up:  https://github.com/rust-marker/marker/pull/82

CC: https://github.com/rust-marker/marker/issues/52

r? @Niki4tap, would you like to review this? :)