### PR TITLE
Start on rustc body, expr and stmt conversion

### DIFF
--- a/marker_api/src/ast/stmt.rs
+++ b/marker_api/src/ast/stmt.rs
@@ -6,9 +6,9 @@ use super::{expr::ExprKind, item::ItemKind, pat::PatKind, ty::TyKind, Span, Span
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone)]
 pub enum StmtKind<'ast> {
-    Item(&'ast ItemKind<'ast>),
+    Item(ItemKind<'ast>),
     Let(&'ast LetStmt<'ast>),
-    Expr(&'ast ExprKind<'ast>),
+    Expr(ExprKind<'ast>),
 }
 
 #[repr(C)]

--- a/marker_driver_rustc/src/context.rs
+++ b/marker_driver_rustc/src/context.rs
@@ -86,8 +86,8 @@ impl<'ast, 'tcx: 'ast> DriverContext<'ast> for RustcContext<'ast, 'tcx> {
     }
 
     fn body(&'ast self, id: BodyId) -> &'ast Body<'ast> {
-        // This message sounds kind of ominous xD
-        todo!("a body was requested {id:#?}");
+        let rustc_body = self.rustc_cx.hir().body(self.rustc_converter.to_body_id(id));
+        self.marker_converter.to_body(rustc_body)
     }
 
     fn get_span(&'ast self, owner: &SpanOwner) -> &'ast Span<'ast> {

--- a/marker_driver_rustc/src/conversion/common.rs
+++ b/marker_driver_rustc/src/conversion/common.rs
@@ -33,6 +33,11 @@ pub struct DefIdInfo {
     pub krate: u32,
 }
 
+pub struct ExprIdLayout {
+    pub owner: u32,
+    pub index: u32,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct SpanSourceInfo {
     pub rustc_span_cx: rustc_span::hygiene::SyntaxContext,

--- a/marker_driver_rustc/src/conversion/marker.rs
+++ b/marker_driver_rustc/src/conversion/marker.rs
@@ -4,15 +4,21 @@
 //! together and share access to common objects easily.
 
 mod common;
+mod expr;
 mod generics;
 mod item;
 mod pat;
+mod stmts;
 mod ty;
 
 use std::cell::RefCell;
 
 use crate::context::storage::Storage;
-use marker_api::ast::{item::ItemKind, Crate, ItemId, SymbolId};
+use marker_api::ast::{
+    expr::ExprKind,
+    item::{Body, ItemKind},
+    BodyId, Crate, ExprId, ItemId, SymbolId,
+};
 use rustc_hash::FxHashMap;
 use rustc_hir as hir;
 
@@ -20,6 +26,8 @@ pub struct MarkerConversionContext<'ast, 'tcx> {
     rustc_cx: rustc_middle::ty::TyCtxt<'tcx>,
     storage: &'ast Storage<'ast>,
     items: RefCell<FxHashMap<ItemId, ItemKind<'ast>>>,
+    bodies: RefCell<FxHashMap<BodyId, &'ast Body<'ast>>>,
+    exprs: RefCell<FxHashMap<ExprId, ExprKind<'ast>>>,
     num_symbols: RefCell<FxHashMap<u32, SymbolId>>,
 }
 
@@ -30,6 +38,8 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
             rustc_cx,
             storage,
             items: RefCell::default(),
+            bodies: RefCell::default(),
+            exprs: RefCell::default(),
             num_symbols: RefCell::default(),
         }
     }

--- a/marker_driver_rustc/src/conversion/marker/common.rs
+++ b/marker_driver_rustc/src/conversion/marker/common.rs
@@ -1,13 +1,13 @@
 use std::mem::{size_of, transmute};
 
 use marker_api::ast::{
-    Abi, AstPath, AstPathSegment, BodyId, CrateId, GenericId, Ident, ItemId, Span, SpanId, SpanSource, SymbolId,
-    TraitRef, TyDefId, VarId,
+    Abi, AstPath, AstPathSegment, BodyId, CrateId, ExprId, GenericId, Ident, ItemId, Span, SpanId, SpanSource,
+    SymbolId, TraitRef, TyDefId, VarId,
 };
 use rustc_hir as hir;
 
 use crate::conversion::common::{
-    BodyIdLayout, GenericIdLayout, ItemIdLayout, SpanSourceInfo, TyDefIdLayout, VarIdLayout,
+    BodyIdLayout, ExprIdLayout, GenericIdLayout, ItemIdLayout, SpanSourceInfo, TyDefIdLayout, VarIdLayout,
 };
 
 use super::MarkerConversionContext;
@@ -139,6 +139,18 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
     pub fn to_var_id(&self, rustc_id: hir::HirId) -> VarId {
         assert_eq!(size_of::<VarId>(), size_of::<VarIdLayout>(), "the layout is invalid");
         let layout = VarIdLayout {
+            owner: rustc_id.owner.def_id.local_def_index.as_u32(),
+            index: rustc_id.local_id.as_u32(),
+        };
+        // # Safety
+        // The layout is validated with the `assert` above
+        unsafe { transmute(layout) }
+    }
+
+    #[must_use]
+    pub fn to_expr_id(&self, rustc_id: hir::HirId) -> ExprId {
+        assert_eq!(size_of::<ExprId>(), size_of::<ExprIdLayout>(), "the layout is invalid");
+        let layout = ExprIdLayout {
             owner: rustc_id.owner.def_id.local_def_index.as_u32(),
             index: rustc_id.local_id.as_u32(),
         };

--- a/marker_driver_rustc/src/conversion/marker/expr.rs
+++ b/marker_driver_rustc/src/conversion/marker/expr.rs
@@ -43,8 +43,10 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
 
     #[must_use]
     fn to_block_expr(&self, data: CommonExprData<'ast>, block: &hir::Block<'tcx>) -> BlockExpr<'ast> {
-        let stmts = self.alloc_slice_iter(block.stmts.iter().map(|stmt| self.to_stmt(stmt)));
-        BlockExpr::new(data, stmts, None)
+        let stmts: Vec<_> = block.stmts.iter().filter_map(|stmt| self.to_stmt(stmt)).collect();
+        let stmts = self.alloc_slice_iter(stmts.into_iter());
+        let expr = block.expr.map(|expr| self.to_expr(expr));
+        BlockExpr::new(data, stmts, expr)
     }
 
     fn to_expr_from_lit_kind(&self, data: CommonExprData<'ast>, lit_kind: &rustc_ast::LitKind) -> ExprKind<'ast> {

--- a/marker_driver_rustc/src/conversion/marker/expr.rs
+++ b/marker_driver_rustc/src/conversion/marker/expr.rs
@@ -1,0 +1,101 @@
+use marker_api::ast::expr::{
+    BlockExpr, BoolLitExpr, CharLitExpr, CommonExprData, ExprKind, FloatLitExpr, FloatSuffix, IntLitExpr, IntSuffix,
+    StrLitData, StrLitExpr,
+};
+use rustc_hir as hir;
+use std::str::FromStr;
+
+use super::MarkerConversionContext;
+
+impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
+    #[must_use]
+    pub fn to_expr_from_block(&self, block: &hir::Block<'tcx>) -> ExprKind<'ast> {
+        let id = self.to_expr_id(block.hir_id);
+        if let Some(expr) = self.exprs.borrow().get(&id) {
+            return *expr;
+        }
+
+        let data = CommonExprData::new(id, self.to_span_id(block.span));
+        let expr = ExprKind::Block(self.alloc(|| self.to_block_expr(data, block)));
+
+        self.exprs.borrow_mut().insert(id, expr);
+        expr
+    }
+
+    #[must_use]
+    pub fn to_expr(&self, expr: &hir::Expr<'tcx>) -> ExprKind<'ast> {
+        let id = self.to_expr_id(expr.hir_id);
+        if let Some(expr) = self.exprs.borrow().get(&id) {
+            return *expr;
+        }
+
+        let data = CommonExprData::new(id, self.to_span_id(expr.span));
+        let expr = match &expr.kind {
+            hir::ExprKind::Lit(spanned_lit) => self.to_expr_from_lit_kind(data, &spanned_lit.node),
+            hir::ExprKind::Block(block, None) => ExprKind::Block(self.alloc(|| self.to_block_expr(data, block))),
+            hir::ExprKind::Err => unreachable!("would have triggered a rustc error"),
+            _ => todo!("{expr:#?}"),
+        };
+
+        self.exprs.borrow_mut().insert(id, expr);
+        expr
+    }
+
+    #[must_use]
+    fn to_block_expr(&self, data: CommonExprData<'ast>, block: &hir::Block<'tcx>) -> BlockExpr<'ast> {
+        let stmts = self.alloc_slice_iter(block.stmts.iter().map(|stmt| self.to_stmt(stmt)));
+        BlockExpr::new(data, stmts, None)
+    }
+
+    fn to_expr_from_lit_kind(&self, data: CommonExprData<'ast>, lit_kind: &rustc_ast::LitKind) -> ExprKind<'ast> {
+        match &lit_kind {
+            rustc_ast::LitKind::Str(sym, kind) => ExprKind::StrLit(self.alloc(|| {
+                StrLitExpr::new(
+                    data,
+                    matches!(kind, rustc_ast::StrStyle::Raw(_)),
+                    StrLitData::Sym(self.to_symbol_id(*sym)),
+                )
+            })),
+            rustc_ast::LitKind::ByteStr(bytes, kind) => ExprKind::StrLit(self.alloc(|| {
+                StrLitExpr::new(
+                    data,
+                    matches!(kind, rustc_ast::StrStyle::Raw(_)),
+                    StrLitData::Bytes(self.alloc_slice_iter(bytes.iter().copied()).into()),
+                )
+            })),
+            rustc_ast::LitKind::Byte(value) => {
+                ExprKind::IntLit(self.alloc(|| IntLitExpr::new(data, u128::from(*value), None)))
+            },
+            rustc_ast::LitKind::Char(value) => ExprKind::CharLit(self.alloc(|| CharLitExpr::new(data, *value))),
+            rustc_ast::LitKind::Int(value, kind) => {
+                let suffix = match kind {
+                    rustc_ast::LitIntType::Signed(rustc_ast::IntTy::Isize) => Some(IntSuffix::Isize),
+                    rustc_ast::LitIntType::Signed(rustc_ast::IntTy::I8) => Some(IntSuffix::I8),
+                    rustc_ast::LitIntType::Signed(rustc_ast::IntTy::I16) => Some(IntSuffix::I16),
+                    rustc_ast::LitIntType::Signed(rustc_ast::IntTy::I32) => Some(IntSuffix::I32),
+                    rustc_ast::LitIntType::Signed(rustc_ast::IntTy::I64) => Some(IntSuffix::I64),
+                    rustc_ast::LitIntType::Signed(rustc_ast::IntTy::I128) => Some(IntSuffix::I128),
+                    rustc_ast::LitIntType::Unsigned(rustc_ast::UintTy::Usize) => Some(IntSuffix::Usize),
+                    rustc_ast::LitIntType::Unsigned(rustc_ast::UintTy::U8) => Some(IntSuffix::U8),
+                    rustc_ast::LitIntType::Unsigned(rustc_ast::UintTy::U16) => Some(IntSuffix::U16),
+                    rustc_ast::LitIntType::Unsigned(rustc_ast::UintTy::U32) => Some(IntSuffix::U32),
+                    rustc_ast::LitIntType::Unsigned(rustc_ast::UintTy::U64) => Some(IntSuffix::U64),
+                    rustc_ast::LitIntType::Unsigned(rustc_ast::UintTy::U128) => Some(IntSuffix::U128),
+                    rustc_ast::LitIntType::Unsuffixed => None,
+                };
+                ExprKind::IntLit(self.alloc(|| IntLitExpr::new(data, *value, suffix)))
+            },
+            rustc_ast::LitKind::Float(lit_sym, kind) => {
+                let suffix = match kind {
+                    rustc_ast::LitFloatType::Suffixed(rustc_ast::ast::FloatTy::F32) => Some(FloatSuffix::F32),
+                    rustc_ast::LitFloatType::Suffixed(rustc_ast::ast::FloatTy::F64) => Some(FloatSuffix::F64),
+                    rustc_ast::LitFloatType::Unsuffixed => None,
+                };
+                let value = f64::from_str(lit_sym.as_str()).expect("rustc should have validated the literal");
+                ExprKind::FloatLit(self.alloc(|| FloatLitExpr::new(data, value, suffix)))
+            },
+            rustc_ast::LitKind::Bool(value) => ExprKind::BoolLit(self.alloc(|| BoolLitExpr::new(data, *value))),
+            rustc_ast::LitKind::Err => unreachable!("would have triggered a rustc error"),
+        }
+    }
+}

--- a/marker_driver_rustc/src/conversion/marker/item.rs
+++ b/marker_driver_rustc/src/conversion/marker/item.rs
@@ -12,8 +12,8 @@ use super::MarkerConversionContext;
 
 impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
     #[must_use]
-    pub fn to_items(&self, item: &[hir::ItemId]) -> &'ast [ItemKind<'ast>] {
-        let items: Vec<_> = item
+    pub fn to_items(&self, items: &[hir::ItemId]) -> &'ast [ItemKind<'ast>] {
+        let items: Vec<_> = items
             .iter()
             .map(|rid| self.rustc_cx.hir().item(*rid))
             .filter_map(|rustc_item| self.to_item(rustc_item))
@@ -21,6 +21,12 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
         self.alloc_slice_iter(items.into_iter())
     }
 
+    pub fn to_item_from_id(&self, item: hir::ItemId) -> Option<ItemKind<'ast>> {
+        let item = self.rustc_cx.hir().item(item);
+        self.to_item(item)
+    }
+
+    #[must_use]
     pub fn to_item(&self, rustc_item: &'tcx hir::Item<'tcx>) -> Option<ItemKind<'ast>> {
         let id = self.to_item_id(rustc_item.owner_id);
         // During normal conversion, this'll never be hit. However, if the user

--- a/marker_driver_rustc/src/conversion/marker/item.rs
+++ b/marker_driver_rustc/src/conversion/marker/item.rs
@@ -1,8 +1,8 @@
 use marker_api::ast::{
     item::{
-        AdtKind, AssocItemKind, CommonItemData, ConstItem, EnumItem, EnumVariant, ExternBlockItem, ExternCrateItem,
-        ExternItemKind, Field, FnItem, ImplItem, ItemKind, ModItem, StaticItem, StructItem, TraitItem, TyAliasItem,
-        UnionItem, UnstableItem, UseItem, UseKind, Visibility,
+        AdtKind, AssocItemKind, Body, CommonItemData, ConstItem, EnumItem, EnumVariant, ExternBlockItem,
+        ExternCrateItem, ExternItemKind, Field, FnItem, ImplItem, ItemKind, ModItem, StaticItem, StructItem, TraitItem,
+        TyAliasItem, UnionItem, UnstableItem, UseItem, UseKind, Visibility,
     },
     Abi, CommonCallableData, Parameter,
 };
@@ -58,16 +58,12 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
             hir::ItemKind::Const(rustc_ty, rustc_body_id) => ItemKind::Const(
                 self.alloc(|| ConstItem::new(data, self.to_ty(*rustc_ty), Some(self.to_body_id(*rustc_body_id)))),
             ),
-            hir::ItemKind::Fn(fn_sig, generics, _body_id) => ItemKind::Fn(self.alloc(|| {
-                // Add a whole bunch of these things. The generic conversion should
-                // be done in the generics module yay
+            hir::ItemKind::Fn(fn_sig, generics, body_id) => ItemKind::Fn(self.alloc(|| {
                 FnItem::new(
                     data,
                     self.to_generic_params(generics),
                     self.to_callable_data_from_fn_sig(fn_sig, false),
-                    // FIXME: This is set to `None`, while the `body()` function is not implemented
-                    // Some(self.to_body_id(*body_id)),
-                    None,
+                    Some(self.to_body_id(*body_id)),
                 )
             })),
             hir::ItemKind::Mod(rustc_mod) => {
@@ -337,5 +333,16 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
 
         self.items.borrow_mut().insert(id, item.as_item());
         item
+    }
+
+    pub fn to_body(&self, body: &hir::Body<'tcx>) -> &'ast Body<'ast> {
+        let id = self.to_body_id(body.id());
+        if let Some(&body) = self.bodies.borrow().get(&id) {
+            return body;
+        }
+        let owner = self.to_item_id(self.rustc_cx.hir().body_owner_def_id(body.id()));
+        let api_body = self.alloc(|| Body::new(owner, self.to_expr(body.value)));
+        self.bodies.borrow_mut().insert(id, api_body);
+        api_body
     }
 }

--- a/marker_driver_rustc/src/conversion/marker/stmts.rs
+++ b/marker_driver_rustc/src/conversion/marker/stmts.rs
@@ -1,0 +1,25 @@
+use marker_api::ast::stmt::{LetStmt, StmtKind};
+use rustc_hir as hir;
+
+use super::MarkerConversionContext;
+
+impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
+    pub fn to_stmt(&self, stmt: &hir::Stmt<'tcx>) -> StmtKind<'ast> {
+        match &stmt.kind {
+            hir::StmtKind::Local(local) => StmtKind::Let(self.alloc(|| self.to_let_stmt(local))),
+            hir::StmtKind::Item(_) => todo!(),
+            hir::StmtKind::Expr(_) => todo!(),
+            hir::StmtKind::Semi(_) => todo!(),
+        }
+    }
+
+    fn to_let_stmt(&self, local: &hir::Local<'tcx>) -> LetStmt<'ast> {
+        LetStmt::new(
+            self.to_span_id(local.span),
+            self.to_pat(local.pat),
+            local.ty.map(|ty| self.to_ty(ty)),
+            local.init.map(|init| self.to_expr(init)),
+            local.els.map(|els| self.to_expr_from_block(els)),
+        )
+    }
+}

--- a/marker_driver_rustc/src/conversion/marker/stmts.rs
+++ b/marker_driver_rustc/src/conversion/marker/stmts.rs
@@ -4,12 +4,11 @@ use rustc_hir as hir;
 use super::MarkerConversionContext;
 
 impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
-    pub fn to_stmt(&self, stmt: &hir::Stmt<'tcx>) -> StmtKind<'ast> {
+    pub fn to_stmt(&self, stmt: &hir::Stmt<'tcx>) -> Option<StmtKind<'ast>> {
         match &stmt.kind {
-            hir::StmtKind::Local(local) => StmtKind::Let(self.alloc(|| self.to_let_stmt(local))),
-            hir::StmtKind::Item(_) => todo!(),
-            hir::StmtKind::Expr(_) => todo!(),
-            hir::StmtKind::Semi(_) => todo!(),
+            hir::StmtKind::Local(local) => Some(StmtKind::Let(self.alloc(|| self.to_let_stmt(local)))),
+            hir::StmtKind::Item(item) => self.to_item_from_id(*item).map(StmtKind::Item),
+            hir::StmtKind::Expr(expr) | hir::StmtKind::Semi(expr) => Some(StmtKind::Expr(self.to_expr(expr))),
         }
     }
 

--- a/marker_lints/src/lib.rs
+++ b/marker_lints/src/lib.rs
@@ -110,7 +110,7 @@ impl LintPass for TestLintPass {
 
     fn check_stmt<'ast>(&mut self, _cx: &'ast AstContext<'ast>, stmt: StmtKind<'ast>) {
         // I didn't realize that `let_chains` are still unstable. This makes the
-        // code a significantly less readable -.-
+        // code significantly less readable -.-
         if let StmtKind::Let(lets) = stmt {
             let PatKind::Ident(ident) = lets.pat() else { return };
             if ident.name().starts_with("_print") {

--- a/marker_lints/src/lib.rs
+++ b/marker_lints/src/lib.rs
@@ -7,6 +7,7 @@ use marker_api::{
             ConstItem, EnumItem, EnumVariant, ExternCrateItem, Field, FnItem, ItemData, ModItem, StaticItem,
             StructItem, UseItem,
         },
+        stmt::StmtKind,
         Span,
     },
     context::AstContext,
@@ -103,6 +104,14 @@ impl LintPass for TestLintPass {
     fn check_fn<'ast>(&mut self, cx: &'ast AstContext<'ast>, item: &'ast FnItem<'ast>) {
         if matches!(item.ident(), Some(name) if name == "foo") {
             emit_foo_lint(cx, "a function", item.span());
+        }
+    }
+
+    fn check_stmt<'ast>(&mut self, _cx: &'ast AstContext<'ast>, stmt: StmtKind<'ast>) {
+        if let StmtKind::Let(stmt) = stmt {
+            if let Some(expr) = stmt.init_expr() {
+                println!("{expr:#?}\n");
+            }
         }
     }
 }

--- a/marker_lints/src/lib.rs
+++ b/marker_lints/src/lib.rs
@@ -7,6 +7,7 @@ use marker_api::{
             ConstItem, EnumItem, EnumVariant, ExternCrateItem, Field, FnItem, ItemData, ModItem, StaticItem,
             StructItem, UseItem,
         },
+        pat::PatKind,
         stmt::StmtKind,
         Span,
     },
@@ -108,8 +109,13 @@ impl LintPass for TestLintPass {
     }
 
     fn check_stmt<'ast>(&mut self, _cx: &'ast AstContext<'ast>, stmt: StmtKind<'ast>) {
-        if let StmtKind::Let(stmt) = stmt {
-            if let Some(expr) = stmt.init_expr() {
+        // I didn't realize that `let_chains` are still unstable. This makes the
+        // code a significantly less readable -.-
+        if let StmtKind::Let(lets) = stmt {
+            let PatKind::Ident(ident) = lets.pat() else { return };
+            if ident.name().starts_with("_print") {
+                let Some(expr) = lets.init_expr() else { return };
+
                 println!("{expr:#?}\n");
             }
         }

--- a/marker_lints/tests/ui/foo_items.rs
+++ b/marker_lints/tests/ui/foo_items.rs
@@ -4,7 +4,7 @@ mod good {
     static FOO: i32 = 0;
 
     struct Foo {
-        foo: i32
+        foo: i32,
     }
 }
 
@@ -14,7 +14,7 @@ mod foo {
     const FOO: i32 = 0;
 
     enum Foo {
-        Foo
+        Foo,
     }
 }
 

--- a/marker_lints/tests/ui/foo_items.stderr
+++ b/marker_lints/tests/ui/foo_items.stderr
@@ -16,14 +16,14 @@ warning: a struct named `foo`, consider using a more meaningful name
  --> $DIR/foo_items.rs:6:5
   |
 6 | /     struct Foo {
-7 | |         foo: i32
+7 | |         foo: i32,
 8 | |     }
   | |_____^
 
 warning: a field named `foo`, consider using a more meaningful name
  --> $DIR/foo_items.rs:7:9
   |
-7 |         foo: i32
+7 |         foo: i32,
   |         ^^^^^^^^
 
 warning: a module named `foo`, consider using a more meaningful name
@@ -54,14 +54,14 @@ warning: an enum named `foo`, consider using a more meaningful name
   --> $DIR/foo_items.rs:16:5
    |
 16 | /     enum Foo {
-17 | |         Foo
+17 | |         Foo,
 18 | |     }
    | |_____^
 
 warning: an enum variant named `foo`, consider using a more meaningful name
   --> $DIR/foo_items.rs:17:9
    |
-17 |         Foo
+17 |         Foo,
    |         ^^^
 
 warning: 9 warnings emitted

--- a/marker_lints/tests/ui/print_let_expr.rs
+++ b/marker_lints/tests/ui/print_let_expr.rs
@@ -1,10 +1,10 @@
 fn main() {
-    let _str = r#"Hello"#;
-    let _byte_str = b"Hello\n";
-    let _int = 17_i32;
-    let _float = 0.000015;
-    let _char = 'h';
-    let _hex_int = 0xcafe;
-    let _byte = b'D';
-    let _block_int = { -3 };
+    let _print_str = r#"Hello"#;
+    let _print_byte_str = b"Hello\n";
+    let _print_int = 17_i32;
+    let _print_float = 0.000015;
+    let _print_char = 'h';
+    let _print_hex_int = 0xcafe;
+    let _print_byte = b'D';
+    let _print_block_int = { 3 };
 }

--- a/marker_lints/tests/ui/print_let_expr.rs
+++ b/marker_lints/tests/ui/print_let_expr.rs
@@ -1,0 +1,10 @@
+fn main() {
+    let _str = r#"Hello"#;
+    let _byte_str = b"Hello\n";
+    let _int = 17_i32;
+    let _float = 0.000015;
+    let _char = 'h';
+    let _hex_int = 0xcafe;
+    let _byte = b'D';
+    let _block_int = { -3 };
+}

--- a/marker_lints/tests/ui/print_let_expr.stdout
+++ b/marker_lints/tests/ui/print_let_expr.stdout
@@ -1,0 +1,108 @@
+StrLit(
+    StrLitExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        is_raw: true,
+        str_data: Sym(
+            SymbolId(..),
+        ),
+    },
+)
+
+StrLit(
+    StrLitExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        is_raw: false,
+        str_data: Bytes(
+            [
+                72,
+                101,
+                108,
+                108,
+                111,
+                10,
+            ],
+        ),
+    },
+)
+
+IntLit(
+    IntLitExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        value: 17,
+        suffix: Some(
+            I32,
+        ),
+    },
+)
+
+FloatLit(
+    FloatLitExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        value: 1.5e-5,
+        suffix: None,
+    },
+)
+
+CharLit(
+    CharLitExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        value: 'h',
+    },
+)
+
+IntLit(
+    IntLitExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        value: 51966,
+        suffix: None,
+    },
+)
+
+IntLit(
+    IntLitExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        value: 68,
+        suffix: None,
+    },
+)
+
+Block(
+    BlockExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        stmts: [],
+        expr: None,
+    },
+)
+

--- a/marker_lints/tests/ui/print_let_expr.stdout
+++ b/marker_lints/tests/ui/print_let_expr.stdout
@@ -102,7 +102,19 @@ Block(
             span: SpanId(..),
         },
         stmts: [],
-        expr: None,
+        expr: Some(
+            IntLit(
+                IntLitExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    value: 3,
+                    suffix: None,
+                },
+            ),
+        ),
     },
 )
 

--- a/marker_lints/tests/ui/print_ty.rs
+++ b/marker_lints/tests/ui/print_ty.rs
@@ -18,7 +18,7 @@ static PRINT_TYPE_COMPLEX: Option<
 
 pub union UnionItem {
     _f: f32,
-    _i: i32
+    _i: i32,
 }
 
 pub struct AllowSync<T> {


### PR DESCRIPTION
This is the last PR I have queued up right now. It adds the rustc backend and allows us to check the first expressions and statements in lint crates :tada:.

---

This PR feels like the biggest milestone yet, as it adds one of the last conversion modules. Semantic types are the last major `rustc -> marker` module, I can think of. And we could tackle that one after this. For `marker -> rustc` direction, we have diagnostic objects and type checks, like and `implements_trait` method. These should also be unblocked soon. It's cool to see, and maybe a bit frightening, due to all the options.

I'm not sure what I'll work on next, it'll depend on my mood and how much time I have. Though, it'll likely be adding more expressions to the API. And that's enough of story telling ^^

---

r? @Niki4tap If you don't mind. Don't worry ~130 lines is just uitest output :)