### PR TITLE
Clean up id transmutes in rustc driver

### DIFF
--- a/marker_driver_rustc/src/conversion/common.rs
+++ b/marker_driver_rustc/src/conversion/common.rs
@@ -49,3 +49,15 @@ pub struct VarIdLayout {
     pub owner: u32,
     pub index: u32,
 }
+
+#[macro_export]
+macro_rules! transmute_id {
+    ($t1:ty as $t2:ty = $e:expr) => {
+        {
+            assert_eq!(size_of::<$t1>(), size_of::<$t2>(), "the layout is invalid");
+            // # Safety
+            // The layout is validated with the `assert` above
+            unsafe { transmute::<$t1, $t2>($e) }
+        }
+    };
+}

--- a/marker_driver_rustc/src/conversion/marker/common.rs
+++ b/marker_driver_rustc/src/conversion/marker/common.rs
@@ -9,6 +9,7 @@ use rustc_hir as hir;
 use crate::conversion::common::{
     BodyIdLayout, ExprIdLayout, GenericIdLayout, ItemIdLayout, SpanSourceInfo, TyDefIdLayout, VarIdLayout,
 };
+use crate::transmute_id;
 
 use super::MarkerConversionContext;
 
@@ -88,75 +89,51 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
 
     #[must_use]
     pub fn to_generic_id(&self, id: impl Into<GenericIdLayout>) -> GenericId {
-        assert_eq!(
-            size_of::<GenericId>(),
-            size_of::<GenericIdLayout>(),
-            "the layout is invalid"
-        );
-        let layout: GenericIdLayout = id.into();
-        // # Safety
-        // The layout is validated with the `assert` above
-        unsafe { transmute(layout) }
+        transmute_id!(GenericIdLayout as GenericId = id.into())
     }
 
     #[must_use]
     pub fn to_ty_def_id(&self, rustc_id: hir::def_id::DefId) -> TyDefId {
-        assert_eq!(
-            size_of::<TyDefId>(),
-            size_of::<TyDefIdLayout>(),
-            "the layout is invalid"
-        );
-        let layout = TyDefIdLayout {
-            krate: rustc_id.krate.as_u32(),
-            index: rustc_id.index.as_u32(),
-        };
-        // # Safety
-        // The layout is validated with the `assert` above
-        unsafe { transmute(layout) }
+        transmute_id!(
+            TyDefIdLayout as TyDefId = TyDefIdLayout {
+                krate: rustc_id.krate.as_u32(),
+                index: rustc_id.index.as_u32(),
+            }
+        )
     }
 
     pub fn to_item_id(&self, id: impl Into<ItemIdLayout>) -> ItemId {
-        let layout: ItemIdLayout = id.into();
-        assert_eq!(size_of::<ItemId>(), size_of::<ItemIdLayout>(), "the layout is invalid");
-        // # Safety
-        // The layout is validated with the `assert` above
-        unsafe { transmute(layout) }
+        transmute_id!(ItemIdLayout as ItemId = id.into())
     }
 
     #[must_use]
     pub fn to_body_id(&self, rustc_id: hir::BodyId) -> BodyId {
-        assert_eq!(size_of::<BodyId>(), size_of::<BodyIdLayout>(), "the layout is invalid");
-        let layout = BodyIdLayout {
-            owner: rustc_id.hir_id.owner.def_id.local_def_index.as_u32(),
-            index: rustc_id.hir_id.local_id.as_u32(),
-        };
-        // # Safety
-        // The layout is validated with the `assert` above
-        unsafe { transmute(layout) }
+        transmute_id!(
+            BodyIdLayout as BodyId = BodyIdLayout {
+                owner: rustc_id.hir_id.owner.def_id.local_def_index.as_u32(),
+                index: rustc_id.hir_id.local_id.as_u32(),
+            }
+        )
     }
 
     #[must_use]
     pub fn to_var_id(&self, rustc_id: hir::HirId) -> VarId {
-        assert_eq!(size_of::<VarId>(), size_of::<VarIdLayout>(), "the layout is invalid");
-        let layout = VarIdLayout {
-            owner: rustc_id.owner.def_id.local_def_index.as_u32(),
-            index: rustc_id.local_id.as_u32(),
-        };
-        // # Safety
-        // The layout is validated with the `assert` above
-        unsafe { transmute(layout) }
+        transmute_id!(
+            VarIdLayout as VarId = VarIdLayout {
+                owner: rustc_id.owner.def_id.local_def_index.as_u32(),
+                index: rustc_id.local_id.as_u32(),
+            }
+        )
     }
 
     #[must_use]
     pub fn to_expr_id(&self, rustc_id: hir::HirId) -> ExprId {
-        assert_eq!(size_of::<ExprId>(), size_of::<ExprIdLayout>(), "the layout is invalid");
-        let layout = ExprIdLayout {
-            owner: rustc_id.owner.def_id.local_def_index.as_u32(),
-            index: rustc_id.local_id.as_u32(),
-        };
-        // # Safety
-        // The layout is validated with the `assert` above
-        unsafe { transmute(layout) }
+        transmute_id!(
+            ExprIdLayout as ExprId = ExprIdLayout {
+                owner: rustc_id.owner.def_id.local_def_index.as_u32(),
+                index: rustc_id.local_id.as_u32(),
+            }
+        )
     }
 }
 

--- a/marker_driver_rustc/src/conversion/rustc/common.rs
+++ b/marker_driver_rustc/src/conversion/rustc/common.rs
@@ -7,6 +7,7 @@ use marker_api::{
 use rustc_hir as hir;
 
 use crate::conversion::common::{BodyIdLayout, DefIdInfo, GenericIdLayout, ItemIdLayout, TyDefIdLayout};
+use crate::transmute_id;
 
 use super::RustcConversionContext;
 
@@ -14,10 +15,7 @@ macro_rules! impl_into_def_id_for {
     ($id:ty, $layout:ty) => {
         impl From<$id> for DefIdInfo {
             fn from(value: $id) -> Self {
-                assert_eq!(size_of::<$id>(), size_of::<$layout>(), "the layout is invalid");
-                // # Safety
-                // The layout is validated with the `assert` above
-                let layout: $layout = unsafe { transmute(value) };
+                let layout = transmute_id!($id as $layout = value);
                 DefIdInfo {
                     index: layout.index,
                     krate: layout.krate,
@@ -48,10 +46,7 @@ impl<'ast, 'tcx> RustcConversionContext<'ast, 'tcx> {
 
     #[must_use]
     pub fn to_item_id(&self, api_id: ItemId) -> hir::ItemId {
-        assert_eq!(size_of::<ItemId>(), size_of::<ItemIdLayout>(), "the layout is invalid");
-        // # Safety
-        // The layout is validated with the `assert` above
-        let layout: ItemIdLayout = unsafe { transmute(api_id) };
+        let layout = transmute_id!(ItemId as ItemIdLayout = api_id);
         hir::ItemId {
             owner_id: hir::OwnerId {
                 def_id: hir::def_id::LocalDefId {
@@ -63,10 +58,7 @@ impl<'ast, 'tcx> RustcConversionContext<'ast, 'tcx> {
 
     #[must_use]
     pub fn to_body_id(&self, api_id: BodyId) -> hir::BodyId {
-        assert_eq!(size_of::<BodyId>(), size_of::<BodyIdLayout>(), "the layout is invalid");
-        // # Safety
-        // The layout is validated with the `assert` above
-        let layout: BodyIdLayout = unsafe { transmute(api_id) };
+        let layout = transmute_id!(BodyId as BodyIdLayout = api_id);
         hir::BodyId {
             hir_id: hir::HirId {
                 owner: hir::OwnerId {


### PR DESCRIPTION
Pretty much it, just a simple macro to stop repeating the same layout checks for ids again and again.

@xFrednet :)