### PR TITLE
Operator Expressions, precedence enum and some minor cleanup

### DIFF
--- a/marker_api/src/ast/common/ast_path.rs
+++ b/marker_api/src/ast/common/ast_path.rs
@@ -6,11 +6,7 @@
 // split it up into an `ItemPath`, `GenericPath` etc. implementation.
 
 use super::SymbolId;
-use crate::{
-    ast::generic::GenericArgs,
-    context::with_cx,
-    ffi::{FfiOption, FfiSlice},
-};
+use crate::{ast::generic::GenericArgs, context::with_cx, ffi::FfiSlice};
 
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -40,16 +36,13 @@ impl<'ast> AstPath<'ast> {
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct AstPathSegment<'ast> {
     ident: SymbolId,
-    generics: FfiOption<GenericArgs<'ast>>,
+    generics: GenericArgs<'ast>,
 }
 
 #[cfg(feature = "driver-api")]
 impl<'ast> AstPathSegment<'ast> {
-    pub fn new(ident: SymbolId, generics: Option<GenericArgs<'ast>>) -> Self {
-        Self {
-            ident,
-            generics: generics.into(),
-        }
+    pub fn new(ident: SymbolId, generics: GenericArgs<'ast>) -> Self {
+        Self { ident, generics }
     }
 }
 
@@ -58,7 +51,7 @@ impl<'ast> AstPathSegment<'ast> {
         with_cx(self, |cx| cx.symbol_str(self.ident))
     }
 
-    pub fn generics(&self) -> Option<&GenericArgs<'ast>> {
-        self.generics.get()
+    pub fn generics(&self) -> &GenericArgs<'ast> {
+        &self.generics
     }
 }

--- a/marker_api/src/ast/expr/op_exprs.rs
+++ b/marker_api/src/ast/expr/op_exprs.rs
@@ -1,0 +1,242 @@
+use crate::ast::ty::TyKind;
+
+use super::{CommonExprData, ExprKind, ExprPrecedence};
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct BinaryOpExpr<'ast> {
+    data: CommonExprData<'ast>,
+    left: ExprKind<'ast>,
+    right: ExprKind<'ast>,
+    kind: BinaryOpKind,
+}
+
+impl<'ast> BinaryOpExpr<'ast> {
+    pub fn left(&self) -> ExprKind<'ast> {
+        self.left
+    }
+
+    pub fn right(&self) -> ExprKind<'ast> {
+        self.right
+    }
+
+    pub fn kind(&self) -> BinaryOpKind {
+        self.kind
+    }
+}
+
+super::impl_expr_data!(
+    BinaryOpExpr<'ast>,
+    BinaryOp,
+    fn precedence(&self) -> ExprPrecedence {
+        match self.kind {
+            BinaryOpKind::Mul => ExprPrecedence::Mul,
+            BinaryOpKind::Div => ExprPrecedence::Div,
+            BinaryOpKind::Rem => ExprPrecedence::Rem,
+            BinaryOpKind::Add => ExprPrecedence::Add,
+            BinaryOpKind::Sub => ExprPrecedence::Sub,
+            BinaryOpKind::Shr => ExprPrecedence::Shr,
+            BinaryOpKind::Shl => ExprPrecedence::Shl,
+            BinaryOpKind::BitAnd => ExprPrecedence::BitAnd,
+            BinaryOpKind::BitXor => ExprPrecedence::BitXor,
+            BinaryOpKind::BitOr => ExprPrecedence::BitOr,
+            BinaryOpKind::Eq
+            | BinaryOpKind::Greater
+            | BinaryOpKind::GreaterEq
+            | BinaryOpKind::Lesser
+            | BinaryOpKind::LesserEq
+            | BinaryOpKind::NotEq => ExprPrecedence::Comparison,
+            BinaryOpKind::And => ExprPrecedence::And,
+            BinaryOpKind::Or => ExprPrecedence::Or,
+        }
+    }
+);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> BinaryOpExpr<'ast> {
+    pub fn new(data: CommonExprData<'ast>, left: ExprKind<'ast>, right: ExprKind<'ast>, kind: BinaryOpKind) -> Self {
+        Self {
+            data,
+            left,
+            right,
+            kind,
+        }
+    }
+}
+
+#[repr(C)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone)]
+pub enum BinaryOpKind {
+    /// The `*` operator
+    Mul,
+    /// The `/` operator
+    Div,
+    /// The `%` operator
+    Rem,
+    /// The `+` operator
+    Add,
+    /// The `-` operator
+    Sub,
+    /// The `>>` operator
+    Shr,
+    /// The `<<` operator
+    Shl,
+    /// The `&` operator
+    BitAnd,
+    /// The `^` operator
+    BitXor,
+    /// The `|` operator
+    BitOr,
+    /// The `==` operator
+    Eq,
+    /// The `!=` operator
+    NotEq,
+    /// The `>` operator
+    Greater,
+    /// The `>=` operator
+    GreaterEq,
+    /// The `<` operator
+    Lesser,
+    /// The `<=` operator
+    LesserEq,
+    /// The `&&` operator
+    And,
+    /// The `||` operator
+    Or,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+// FIXME, `ReferenceExpr` might be a better name for this. Thoughts?
+pub struct BorrowExpr<'ast> {
+    data: CommonExprData<'ast>,
+    expr: ExprKind<'ast>,
+    is_mut: bool,
+}
+
+impl<'ast> BorrowExpr<'ast> {
+    pub fn expr(&self) -> ExprKind<'ast> {
+        self.expr
+    }
+
+    pub fn is_mut(&self) -> bool {
+        self.is_mut
+    }
+}
+
+super::impl_expr_data!(
+    BorrowExpr<'ast>,
+    Borrow,
+    fn precedence(&self) -> ExprPrecedence {
+        ExprPrecedence::Reference
+    }
+);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> BorrowExpr<'ast> {
+    pub fn new(data: CommonExprData<'ast>, expr: ExprKind<'ast>, is_mut: bool) -> Self {
+        Self { data, expr, is_mut }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct QuestionMarkExpr<'ast> {
+    data: CommonExprData<'ast>,
+    expr: ExprKind<'ast>,
+}
+
+impl<'ast> QuestionMarkExpr<'ast> {
+    pub fn expr(&self) -> ExprKind<'ast> {
+        self.expr
+    }
+}
+
+super::impl_expr_data!(QuestionMarkExpr<'ast>, QuestionMark);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> QuestionMarkExpr<'ast> {
+    pub fn new(data: CommonExprData<'ast>, expr: ExprKind<'ast>) -> Self {
+        Self { data, expr }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct UnaryOpExpr<'ast> {
+    data: CommonExprData<'ast>,
+    expr: ExprKind<'ast>,
+    kind: UnaryOpKind,
+}
+
+impl<'ast> UnaryOpExpr<'ast> {
+    pub fn expr(&self) -> ExprKind<'ast> {
+        self.expr
+    }
+
+    pub fn kind(&self) -> UnaryOpKind {
+        self.kind
+    }
+}
+
+super::impl_expr_data!(
+    UnaryOpExpr<'ast>,
+    UnaryOp,
+    fn precedence(&self) -> ExprPrecedence {
+        match self.kind {
+            UnaryOpKind::Neg => ExprPrecedence::Neg,
+            UnaryOpKind::Not => ExprPrecedence::Not,
+            UnaryOpKind::Deref => ExprPrecedence::Deref,
+        }
+    }
+);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> UnaryOpExpr<'ast> {
+    pub fn new(data: CommonExprData<'ast>, expr: ExprKind<'ast>, kind: UnaryOpKind) -> Self {
+        Self { data, expr, kind }
+    }
+}
+
+#[repr(C)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone)]
+pub enum UnaryOpKind {
+    /// The arithmetic negation `-` operator, like `-2`
+    Neg,
+    /// The logical negation `!` operator, like `!true`
+    Not,
+    /// The dereference `*` operator, like `*value`
+    Deref,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct AsExpr<'ast> {
+    data: CommonExprData<'ast>,
+    expr: ExprKind<'ast>,
+    ty: TyKind<'ast>,
+}
+
+impl<'ast> AsExpr<'ast> {
+    pub fn expr(&self) -> ExprKind<'ast> {
+        self.expr
+    }
+
+    pub fn ty(&self) -> TyKind<'ast> {
+        self.ty
+    }
+}
+
+super::impl_expr_data!(AsExpr<'ast>, As);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> AsExpr<'ast> {
+    pub fn new(data: CommonExprData<'ast>, expr: ExprKind<'ast>, ty: TyKind<'ast>) -> Self {
+        Self { data, expr, ty }
+    }
+}
+
+// FIXME: Add Assign expressions, these will require place expressions and a decision
+// if some cases should be represented as patterns or always as expressions.

--- a/marker_api/src/ast/generic.rs
+++ b/marker_api/src/ast/generic.rs
@@ -41,6 +41,10 @@ impl<'ast> GenericArgs<'ast> {
     pub fn args(&self) -> &'ast [GenericArgKind<'ast>] {
         self.args.get()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.args.is_empty()
+    }
 }
 
 #[cfg(feature = "driver-api")]

--- a/marker_api/src/ffi.rs
+++ b/marker_api/src/ffi.rs
@@ -115,6 +115,10 @@ impl<'a, T> FfiSlice<'a, T> {
     pub fn as_slice(&self) -> &'a [T] {
         self.into()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
 }
 
 impl<'a, T> From<&'a [T]> for FfiSlice<'a, T> {

--- a/marker_driver_rustc/src/conversion/marker/common.rs
+++ b/marker_driver_rustc/src/conversion/marker/common.rs
@@ -171,7 +171,7 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
     fn to_path_segment(&self, segment: &hir::PathSegment<'tcx>) -> AstPathSegment<'ast> {
         AstPathSegment::new(
             self.to_symbol_id(segment.ident.name),
-            Some(self.to_generic_args(segment.args)),
+            self.to_generic_args(segment.args),
         )
     }
 


### PR DESCRIPTION
This PR adds a stable representation for most op expressions. The backend will be done in a different PR.

For the operation and precedence names, I was considering if full names like `Addition` would be better than `Add`. However, I think it's better to use the short hand, as most parts of the API do so, as well as rust's [traits](https://doc.rust-lang.org/std/ops/index.html#traits).

Also closes https://github.com/rust-marker/marker/issues/85

---

I took a few days off, and this is me slowly getting back into Marker. Expressions are a bit harder to *express* in a stable way. The next PR might again take a few days, though I hope to get a good rhythm going again.

r? @Niki4tap Would you mind reviewing this if you have time? :)