### PR TITLE
Update license info

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -174,28 +174,3 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
    of your accepting any such warranty or additional liability.
 
 END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-   To apply the Apache License to your work, attach the following
-   boilerplate notice, with the fields enclosed by brackets "[]"
-   replaced with your own identifying information. (Don't include
-   the brackets!)  The text should be enclosed in the appropriate
-   comment syntax for the file format. We also recommend that a
-   file or class name and description of purpose be included on the
-   same "printed page" as the copyright notice for easier
-   identification within third-party archives.
-
-Copyright 2014-2022 The Rust Project Developers
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,7 +1,3 @@
-MIT License
-
-Copyright (c) 2022-2022 Rust-marker
-
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
 documentation files (the "Software"), to deal in the

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![Bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/46214)
 ![CI Status](https://github.com/rust-marker/marker/actions/workflows/rust_bors.yml/badge.svg)
+[![License: MIT OR Apache-2.0](https://img.shields.io/crates/l/cargo_marker.svg)](#license)
 
 **An experimental linting interface for Rust. Let's make custom lints a reality!**
 
@@ -45,10 +46,7 @@ Internal structure of marker and its components is documented in [`docs/internal
 
 ## License
 
-Copyright (c) 2022-2022 Rust-marker
-
 Rust-marker is distributed under the terms of both the MIT license
 and the Apache License (Version 2.0).
 
 See [LICENSE-APACHE](./LICENSE-APACHE), [LICENSE-MIT](./LICENSE-MIT).
-


### PR DESCRIPTION
Keeping license texts in sync with other rust repos (design repo probably needs this too).

License badge isn't quite correct, since placeholder on crates.io is purely MIT licensed, if [marker-crate-reservations](https://github.com/rust-marker/marker-crate-reservations) can be dual-licensed, like all other repos, and updated on crates.io, that would be great!

Context:
- https://github.com/rust-lang/rust/commit/2a8807e889a43c6b89eb6f2736907afa87ae592f
- https://github.com/serde-rs/serde/pull/2355
- https://github.com/rust-lang/rust/pull/67734
- https://github.com/rust-lang/miri/pull/1846