### PR TITLE
Add API representation for constructors

### DIFF
--- a/marker_api/src/ast/expr.rs
+++ b/marker_api/src/ast/expr.rs
@@ -4,17 +4,17 @@ use std::{fmt::Debug, marker::PhantomData};
 
 mod block_expr;
 mod call_exprs;
+mod ctor_expr;
 mod lit_expr;
 mod op_exprs;
 mod path_expr;
-mod pattern_expr;
 mod unstable_expr;
 pub use block_expr::*;
 pub use call_exprs::*;
+pub use ctor_expr::*;
 pub use lit_expr::*;
 pub use op_exprs::*;
 pub use path_expr::*;
-pub use pattern_expr::*;
 pub use unstable_expr::*;
 
 pub trait ExprData<'ast>: Debug {

--- a/marker_api/src/ast/expr.rs
+++ b/marker_api/src/ast/expr.rs
@@ -50,6 +50,7 @@ pub enum ExprKind<'ast> {
     Call(&'ast CallExpr<'ast>),
     Array(&'ast ArrayExpr<'ast>),
     Tuple(&'ast TupleExpr<'ast>),
+    Ctor(&'ast CtorExpr<'ast>),
     Unstable(&'ast UnstableExpr<'ast>),
 }
 
@@ -66,7 +67,7 @@ impl<'ast> ExprKind<'ast> {
 pub enum ExprPrecedence {
     Lit = 0x1400_0000,
     Block = 0x1400_0001,
-    Pattern = 0x1400_0002,
+    Ctor = 0x1400_0002,
 
     Path = 0x1300_0000,
 
@@ -145,7 +146,7 @@ macro_rules! impl_expr_kind_fn {
     ($method:ident () -> $return_ty:ty) => {
         impl_expr_kind_fn!($method() -> $return_ty,
             IntLit, FloatLit, StrLit, CharLit, BoolLit, Block, UnaryOp, Borrow,
-            BinaryOp, QuestionMark, As, Path, Call, Array, Tuple, Unstable
+            BinaryOp, QuestionMark, As, Path, Call, Array, Tuple, Ctor, Unstable
         );
     };
     ($method:ident () -> $return_ty:ty $(, $kind:ident)+) => {

--- a/marker_api/src/ast/expr.rs
+++ b/marker_api/src/ast/expr.rs
@@ -7,12 +7,14 @@ mod call_exprs;
 mod lit_expr;
 mod op_exprs;
 mod path_expr;
+mod pattern_expr;
 mod unstable_expr;
 pub use block_expr::*;
 pub use call_exprs::*;
 pub use lit_expr::*;
 pub use op_exprs::*;
 pub use path_expr::*;
+pub use pattern_expr::*;
 pub use unstable_expr::*;
 
 pub trait ExprData<'ast>: Debug {
@@ -46,6 +48,8 @@ pub enum ExprKind<'ast> {
     As(&'ast AsExpr<'ast>),
     Path(&'ast PathExpr<'ast>),
     Call(&'ast CallExpr<'ast>),
+    Array(&'ast ArrayExpr<'ast>),
+    Tuple(&'ast TupleExpr<'ast>),
     Unstable(&'ast UnstableExpr<'ast>),
 }
 
@@ -62,6 +66,7 @@ impl<'ast> ExprKind<'ast> {
 pub enum ExprPrecedence {
     Lit = 0x1400_0000,
     Block = 0x1400_0001,
+    Pattern = 0x1400_0002,
 
     Path = 0x1300_0000,
 
@@ -140,7 +145,7 @@ macro_rules! impl_expr_kind_fn {
     ($method:ident () -> $return_ty:ty) => {
         impl_expr_kind_fn!($method() -> $return_ty,
             IntLit, FloatLit, StrLit, CharLit, BoolLit, Block, UnaryOp, Borrow,
-            BinaryOp, QuestionMark, As, Path, Call, Unstable
+            BinaryOp, QuestionMark, As, Path, Call, Array, Tuple, Unstable
         );
     };
     ($method:ident () -> $return_ty:ty $(, $kind:ident)+) => {

--- a/marker_api/src/ast/expr.rs
+++ b/marker_api/src/ast/expr.rs
@@ -51,6 +51,7 @@ pub enum ExprKind<'ast> {
     Array(&'ast ArrayExpr<'ast>),
     Tuple(&'ast TupleExpr<'ast>),
     Ctor(&'ast CtorExpr<'ast>),
+    Range(&'ast RangeExpr<'ast>),
     Unstable(&'ast UnstableExpr<'ast>),
 }
 
@@ -146,7 +147,8 @@ macro_rules! impl_expr_kind_fn {
     ($method:ident () -> $return_ty:ty) => {
         impl_expr_kind_fn!($method() -> $return_ty,
             IntLit, FloatLit, StrLit, CharLit, BoolLit, Block, UnaryOp, Borrow,
-            BinaryOp, QuestionMark, As, Path, Call, Array, Tuple, Ctor, Unstable
+            BinaryOp, QuestionMark, As, Path, Call, Array, Tuple, Ctor, Range,
+            Unstable
         );
     };
     ($method:ident () -> $return_ty:ty $(, $kind:ident)+) => {

--- a/marker_api/src/ast/expr/ctor_expr.rs
+++ b/marker_api/src/ast/expr/ctor_expr.rs
@@ -1,6 +1,4 @@
-//! This module contains all expressions, which are typically used to construct
-//! or deconstruct data. A simple example is the [`ArrayExpr`] which can be
-//! used to create or destruct an array.
+//! This module contains all expressions, which are typically used to construct data.
 
 use crate::{
     ast::{AstQPath, Ident, Span, SpanId},
@@ -10,16 +8,13 @@ use crate::{
 
 use super::{CommonExprData, ExprKind, ExprPrecedence};
 
-/// An array expressions can be used to construct an array or destruct an array.
+/// An expression constructing an array.
 ///
 /// ```
 /// //            vvvvvvvvvvvv An array expression with four element expressions
 /// let array_1 = [1, 2, 3, 4];
-/// //            vvvvvv An array expression with one element and one len expression
+/// //            vvvvvv A repeat array expression with repeat and length operands
 /// let array_2 = [6; 3];
-///
-/// //  vvvvvvvvv An array expression destructing `array_2`
-/// let [a, b, c] = array_2;
 /// ```
 #[repr(C)]
 #[derive(Debug)]
@@ -62,14 +57,11 @@ impl<'ast> ArrayExpr<'ast> {
     }
 }
 
-/// A tuple expression used to construct or deconstruct a tuple.
+/// An expression used to construct a tuple.
 ///
 /// ```
 /// //          vvvvvvvvvvvv A tuple expression with four elements
 /// let slice = (1, 2, 3, 4);
-///
-/// //  vvvvvvvvvvvv A tuple expression destructing `slice`
-/// let (a, b, c, _) = slice;
 /// ```
 #[repr(C)]
 #[derive(Debug)]
@@ -94,13 +86,16 @@ super::impl_expr_data!(
 
 #[cfg(feature = "driver-api")]
 impl<'ast> TupleExpr<'ast> {
-    pub fn new(data: CommonExprData<'ast>, elements: &'ast[ExprKind<'ast>]) -> Self {
-        Self { data, elements: elements.into() }
+    pub fn new(data: CommonExprData<'ast>, elements: &'ast [ExprKind<'ast>]) -> Self {
+        Self {
+            data,
+            elements: elements.into(),
+        }
     }
 }
 
-/// An expression constructing structs, unions and enum variants. For tuple
-/// constructors, the field names will correspond to the field index.
+/// An expression used to construct structs, unions and enum variants. For tuple
+/// constructors, the field names will correspond to the field indices.
 ///
 /// ```
 /// # #[derive(Debug, Default)]
@@ -154,7 +149,7 @@ pub struct CtorExpr<'ast> {
 }
 
 impl<'ast> CtorExpr<'ast> {
-    /// The path will point to the
+    /// The path identifies the item or enum variant that will be constructed.
     pub fn path(&self) -> &AstQPath<'ast> {
         &self.path
     }
@@ -249,7 +244,7 @@ impl<'ast> RangeExpr<'ast> {
     }
 
     pub fn end(&self) -> Option<ExprKind<'ast>> {
-        self.start.copy()
+        self.end.copy()
     }
 
     pub fn is_inclusive(&self) -> bool {

--- a/marker_api/src/ast/expr/ctor_expr.rs
+++ b/marker_api/src/ast/expr/ctor_expr.rs
@@ -43,7 +43,7 @@ super::impl_expr_data!(
     ArrayExpr<'ast>,
     Array,
     fn precedence(&self) -> ExprPrecedence {
-        ExprPrecedence::Pattern
+        ExprPrecedence::Ctor
     }
 );
 
@@ -88,14 +88,14 @@ super::impl_expr_data!(
     TupleExpr<'ast>,
     Tuple,
     fn precedence(&self) -> ExprPrecedence {
-        ExprPrecedence::Pattern
+        ExprPrecedence::Ctor
     }
 );
 
 #[cfg(feature = "driver-api")]
 impl<'ast> TupleExpr<'ast> {
-    pub fn new(data: CommonExprData<'ast>, elements: FfiSlice<'ast, ExprKind<'ast>>) -> Self {
-        Self { data, elements }
+    pub fn new(data: CommonExprData<'ast>, elements: &'ast[ExprKind<'ast>]) -> Self {
+        Self { data, elements: elements.into() }
     }
 }
 

--- a/marker_api/src/ast/expr/pattern_expr.rs
+++ b/marker_api/src/ast/expr/pattern_expr.rs
@@ -1,0 +1,96 @@
+//! This module contains all expressions, which are typically used to construct
+//! or deconstruct data. A simple example is the [`ArrayExpr`] which can be
+//! used to create or destruct an array.
+
+use crate::ffi::{FfiOption, FfiSlice};
+
+use super::{CommonExprData, ExprKind, ExprPrecedence};
+
+/// An array expressions can be used to construct an array or destruct an array.
+///
+/// ```
+/// //            vvvvvvvvvvvv An array expression with four element expressions
+/// let array_1 = [1, 2, 3, 4];
+/// //            vvvvvv An array expression with one element and one len expression
+/// let array_2 = [6; 3];
+///
+/// //  vvvvvvvvv An array expression destructing `array_2`
+/// let [a, b, c] = array_2;
+/// ```
+#[repr(C)]
+#[derive(Debug)]
+pub struct ArrayExpr<'ast> {
+    data: CommonExprData<'ast>,
+    elements: FfiSlice<'ast, ExprKind<'ast>>,
+    len_expr: FfiOption<ExprKind<'ast>>,
+}
+
+impl<'ast> ArrayExpr<'ast> {
+    pub fn elements(&self) -> &[ExprKind<'ast>] {
+        self.elements.get()
+    }
+
+    pub fn len_expr(&self) -> Option<ExprKind<'ast>> {
+        self.len_expr.copy()
+    }
+}
+
+super::impl_expr_data!(
+    ArrayExpr<'ast>,
+    Array,
+    fn precedence(&self) -> ExprPrecedence {
+        ExprPrecedence::Pattern
+    }
+);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> ArrayExpr<'ast> {
+    pub fn new(
+        data: CommonExprData<'ast>,
+        elem_exprs: &'ast [ExprKind<'ast>],
+        len_expr: Option<ExprKind<'ast>>,
+    ) -> Self {
+        Self {
+            data,
+            elements: elem_exprs.into(),
+            len_expr: len_expr.into(),
+        }
+    }
+}
+
+/// A tuple expression used to construct or deconstruct a tuple.
+///
+/// ```
+/// //          vvvvvvvvvvvv A tuple expression with four elements
+/// let slice = (1, 2, 3, 4);
+///
+/// //  vvvvvvvvvvvv A tuple expression destructing `slice`
+/// let (a, b, c, _) = slice;
+/// ```
+#[repr(C)]
+#[derive(Debug)]
+pub struct TupleExpr<'ast> {
+    data: CommonExprData<'ast>,
+    elements: FfiSlice<'ast, ExprKind<'ast>>,
+}
+
+impl<'ast> TupleExpr<'ast> {
+    pub fn elements(&self) -> &[ExprKind<'ast>] {
+        self.elements.get()
+    }
+}
+
+super::impl_expr_data!(
+    TupleExpr<'ast>,
+    Tuple,
+    fn precedence(&self) -> ExprPrecedence {
+        ExprPrecedence::Pattern
+    }
+);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> TupleExpr<'ast> {
+    pub fn new(data: CommonExprData<'ast>, elements: FfiSlice<'ast, ExprKind<'ast>>) -> Self {
+        Self { data, elements }
+    }
+}

--- a/marker_api/src/ast/expr/pattern_expr.rs
+++ b/marker_api/src/ast/expr/pattern_expr.rs
@@ -2,7 +2,11 @@
 //! or deconstruct data. A simple example is the [`ArrayExpr`] which can be
 //! used to create or destruct an array.
 
-use crate::ffi::{FfiOption, FfiSlice};
+use crate::{
+    ast::{AstQPath, Ident, Span, SpanId},
+    context::with_cx,
+    ffi::{FfiOption, FfiSlice},
+};
 
 use super::{CommonExprData, ExprKind, ExprPrecedence};
 
@@ -92,5 +96,131 @@ super::impl_expr_data!(
 impl<'ast> TupleExpr<'ast> {
     pub fn new(data: CommonExprData<'ast>, elements: FfiSlice<'ast, ExprKind<'ast>>) -> Self {
         Self { data, elements }
+    }
+}
+
+/// An expression constructing structs, unions and enum variants. For tuple
+/// constructors, the field names will correspond to the field index.
+///
+/// ```
+/// # #[derive(Debug, Default)]
+/// # struct FieldStruct {
+/// #     a: u32,
+/// #     b: u32,
+/// # }
+/// # #[derive(Default)]
+/// # struct TupleStruct(u32, u32);
+/// # union Union {
+/// #     a: u32,
+/// # }
+/// # enum Enum {
+/// #     A,
+/// #     B(u32),
+/// #     C { f1: u32, f2: u32 },
+/// # }
+///
+/// let _ = FieldStruct { a: 1, b: 2 };
+/// //      ^^^^^^^^^^^^^^^^^^^^^^^^^^ A field struct constructor with two fields
+/// let _ = FieldStruct { a: 10, ..FieldStruct::default() };
+/// //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/// //      A field struct constructor with an optional base expression
+///
+/// let _ = Union { a: 8 };
+/// //      ^^^^^^^^^^^^^ A union constructor with one field
+///
+/// let _ = TupleStruct { 0: 3, 1: 9 };
+/// //      ^^^^^^^^^^^^^^^^^^^^^^^^^^ A tuple struct constructor with two fields
+/// let _ = TupleStruct(1, 2);
+/// //      ^^^^^^^^^^^^^^^^^ A tuple constructor with two elements, represented
+/// //                        with field names, as above.
+/// let _ = TupleStruct { 0: 3, ..TupleStruct::default() };
+/// //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/// //      A tuple struct constructor with an optional base expression
+///
+/// let _ = Enum::A;
+/// //      ^^^^^^^ An enum variant constructor without any elements
+/// let _ = Enum::B(1);
+/// //      ^^^^^^^^^^ An enum variant constructor with two elements
+/// let _ = Enum::C { f1: 44, f2: 55 };
+/// //      ^^^^^^^^^^^^^^^^^^^^^^^^^^ An enum variant constructor with named fields
+/// ```
+#[repr(C)]
+#[derive(Debug)]
+pub struct CtorExpr<'ast> {
+    data: CommonExprData<'ast>,
+    path: AstQPath<'ast>,
+    fields: FfiSlice<'ast, CtorField<'ast>>,
+    base: FfiOption<ExprKind<'ast>>,
+}
+
+impl<'ast> CtorExpr<'ast> {
+    /// The path will point to the
+    pub fn path(&self) -> &AstQPath<'ast> {
+        &self.path
+    }
+
+    pub fn fields(&self) -> &'ast [CtorField<'ast>] {
+        self.fields.get()
+    }
+
+    pub fn base(&self) -> Option<ExprKind<'ast>> {
+        self.base.copy()
+    }
+}
+
+super::impl_expr_data!(
+    CtorExpr<'ast>,
+    Ctor,
+    fn precedence(&self) -> ExprPrecedence {
+        ExprPrecedence::Ctor
+    }
+);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> CtorExpr<'ast> {
+    pub fn new(
+        data: CommonExprData<'ast>,
+        path: AstQPath<'ast>,
+        fields: &'ast [CtorField<'ast>],
+        base: Option<ExprKind<'ast>>,
+    ) -> Self {
+        Self {
+            data,
+            path,
+            fields: fields.into(),
+            base: base.into(),
+        }
+    }
+}
+
+/// A single field inside a [`CtorExpr`].
+#[repr(C)]
+#[derive(Debug)]
+pub struct CtorField<'ast> {
+    span: SpanId,
+    ident: Ident<'ast>,
+    expr: ExprKind<'ast>,
+}
+
+impl<'ast> CtorField<'ast> {
+    /// This returns the span of the entire field expression
+    pub fn span(&self) -> &Span<'ast> {
+        with_cx(self, |cx| cx.get_span(self.span))
+    }
+
+    /// The identifier of the field.
+    pub fn ident(&self) -> &Ident<'ast> {
+        &self.ident
+    }
+
+    pub fn expr(&self) -> ExprKind<'ast> {
+        self.expr
+    }
+}
+
+#[cfg(feature = "driver-api")]
+impl<'ast> CtorField<'ast> {
+    pub fn new(span: SpanId, ident: Ident<'ast>, expr: ExprKind<'ast>) -> Self {
+        Self { span, ident, expr }
     }
 }

--- a/marker_api/src/ast/expr/pattern_expr.rs
+++ b/marker_api/src/ast/expr/pattern_expr.rs
@@ -224,3 +224,54 @@ impl<'ast> CtorField<'ast> {
         Self { span, ident, expr }
     }
 }
+
+/// A range expression, like these:
+///
+/// ```
+/// 1..9;
+/// 3..;
+/// ..5;
+/// ..;
+/// 0..=1;
+/// ```
+#[repr(C)]
+#[derive(Debug)]
+pub struct RangeExpr<'ast> {
+    data: CommonExprData<'ast>,
+    start: FfiOption<ExprKind<'ast>>,
+    end: FfiOption<ExprKind<'ast>>,
+    is_inclusive: bool,
+}
+
+impl<'ast> RangeExpr<'ast> {
+    pub fn start(&self) -> Option<ExprKind<'ast>> {
+        self.start.copy()
+    }
+
+    pub fn end(&self) -> Option<ExprKind<'ast>> {
+        self.start.copy()
+    }
+
+    pub fn is_inclusive(&self) -> bool {
+        self.is_inclusive
+    }
+}
+
+super::impl_expr_data!(RangeExpr<'ast>, Range);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> RangeExpr<'ast> {
+    pub fn new(
+        data: CommonExprData<'ast>,
+        start: Option<ExprKind<'ast>>,
+        end: Option<ExprKind<'ast>>,
+        is_inclusive: bool,
+    ) -> Self {
+        Self {
+            data,
+            start: start.into(),
+            end: end.into(),
+            is_inclusive,
+        }
+    }
+}

--- a/marker_api/src/ast/item/adt_item.rs
+++ b/marker_api/src/ast/item/adt_item.rs
@@ -97,6 +97,7 @@ pub struct EnumVariant<'ast> {
     span: SpanId,
     kind: AdtKind<'ast>,
     // FIXME: Add <discriminant: FfiOption<ExprKind<'ast>>>
+    // FIXME: Add some kind of ID to reference individual variants
 }
 
 impl<'ast> EnumVariant<'ast> {


### PR DESCRIPTION
This PR adds an API representation for constructors. The rustc backend will be added in a follow-up PR to keep the changes reviewable.

---

cc: #52

r? @Niki4tap if you don't mind reviewing some more API changes :)