### PR TITLE
Add rustc backend for Ctors

### DIFF
--- a/marker_api/src/ast/common/ast_path.rs
+++ b/marker_api/src/ast/common/ast_path.rs
@@ -5,7 +5,7 @@
 // FIXME: It might be useful to not use a single path for everything, but instead
 // split it up into an `ItemPath`, `GenericPath` etc. implementation.
 
-use super::{GenericId, Ident, ItemId, VarId};
+use super::{GenericId, Ident, ItemId, VarId, VariantId};
 use crate::{
     ast::{generic::GenericArgs, ty::TyKind},
     ffi::{FfiOption, FfiSlice},
@@ -214,6 +214,8 @@ pub enum AstPathTarget {
     /// [`StaticItem`](crate::ast::item::ImplItem),
     /// [`FnItem`](crate::ast::item::FnItem).
     Item(ItemId),
+    /// The path target is a variant from an enum, identified by the [`VariantId`]
+    Variant(VariantId),
     /// The path target is a local variable, identified by the [`VarId`].
     Var(VarId),
     /// The path target is a generic type, identified by the [`GenericId`].

--- a/marker_api/src/ast/common/id.rs
+++ b/marker_api/src/ast/common/id.rs
@@ -50,6 +50,11 @@ new_id! {
 }
 
 new_id! {
+    ///  This ID uniquely identifies an enum variant during linting.
+    pub VariantId: u64
+}
+
+new_id! {
     /// This ID uniquely identifies a user defined type during linting.
     pub TyDefId: u64
 }

--- a/marker_api/src/ast/item/adt_item.rs
+++ b/marker_api/src/ast/item/adt_item.rs
@@ -1,6 +1,6 @@
 use crate::ast::generic::GenericParams;
 use crate::ast::ty::TyKind;
-use crate::ast::{Span, SpanId, SymbolId};
+use crate::ast::{Span, SpanId, SymbolId, VariantId};
 use crate::context::with_cx;
 use crate::ffi::FfiSlice;
 
@@ -93,14 +93,18 @@ impl<'ast> EnumItem<'ast> {
 #[repr(C)]
 #[derive(Debug)]
 pub struct EnumVariant<'ast> {
+    id: VariantId,
     ident: SymbolId,
     span: SpanId,
     kind: AdtKind<'ast>,
     // FIXME: Add <discriminant: FfiOption<ExprKind<'ast>>>
-    // FIXME: Add some kind of ID to reference individual variants
 }
 
 impl<'ast> EnumVariant<'ast> {
+    pub fn id(&self) -> VariantId {
+        self.id
+    }
+
     pub fn ident(&self) -> &str {
         with_cx(self, |cx| cx.symbol_str(self.ident))
     }
@@ -159,8 +163,8 @@ impl<'ast> EnumVariant<'ast> {
 
 #[cfg(feature = "driver-api")]
 impl<'ast> EnumVariant<'ast> {
-    pub fn new(ident: SymbolId, span: SpanId, kind: AdtKind<'ast>) -> Self {
-        Self { ident, span, kind }
+    pub fn new(id: VariantId, ident: SymbolId, span: SpanId, kind: AdtKind<'ast>) -> Self {
+        Self { id, ident, span, kind }
     }
 }
 

--- a/marker_driver_rustc/src/conversion/marker/common.rs
+++ b/marker_driver_rustc/src/conversion/marker/common.rs
@@ -7,6 +7,7 @@ use marker_api::ast::{
 };
 use rustc_hir as hir;
 use rustc_middle as mid;
+use rustc_middle::ty::DefIdTree;
 
 use crate::conversion::common::{
     BodyIdLayout, ExprIdLayout, GenericIdLayout, ItemIdLayout, SpanSourceInfo, TyDefIdLayout, VarIdLayout,
@@ -282,10 +283,13 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
                 | hir::def::DefKind::AssocTy
                 | hir::def::DefKind::TraitAlias
                 | hir::def::DefKind::AssocFn
-                | hir::def::DefKind::Static(_)
-                | hir::def::DefKind::Ctor(_, _),
+                | hir::def::DefKind::Static(_),
                 id,
             ) => AstPathTarget::Item(self.to_item_id(*id)),
+            hir::def::Res::Def(hir::def::DefKind::Ctor(_, _), ctor_id) => {
+                let target = self.rustc_cx.parent(*ctor_id);
+                AstPathTarget::Item(self.to_item_id(target))
+            },
             hir::def::Res::Def(_, _) => todo!("{res:#?}"),
             hir::def::Res::PrimTy(_) => todo!("{res:#?}"),
             hir::def::Res::SelfTyParam { trait_: def_id, .. } | hir::def::Res::SelfTyAlias { alias_to: def_id, .. } => {

--- a/marker_driver_rustc/src/conversion/marker/expr.rs
+++ b/marker_driver_rustc/src/conversion/marker/expr.rs
@@ -64,7 +64,7 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
                                 self.to_span_id(expr.span),
                                 Ident::new(
                                     self.to_symbol_id_for_num(
-                                        u32::try_from(index).expect("a index over 2^32 us unexpected"),
+                                        u32::try_from(index).expect("a index over 2^32 is unexpected"),
                                     ),
                                     self.to_span_id(rustc_span::DUMMY_SP),
                                 ),
@@ -78,6 +78,15 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
 
                     _ => ExprKind::Call(self.alloc(|| CallExpr::new(data, self.to_expr(operand), self.to_exprs(args)))),
                 },
+                hir::ExprKind::Path(
+                    path @ hir::QPath::Resolved(
+                        None,
+                        hir::Path {
+                            res: hir::def::Res::Def(hir::def::DefKind::Ctor(_, _), ..),
+                            ..
+                        },
+                    ),
+                ) => ExprKind::Ctor(self.alloc(|| CtorExpr::new(data, self.to_qpath_from_expr(path, expr), &[], None))),
                 hir::ExprKind::Path(qpath) => {
                     ExprKind::Path(self.alloc(|| PathExpr::new(data, self.to_qpath_from_expr(qpath, expr))))
                 },

--- a/marker_driver_rustc/src/conversion/marker/item.rs
+++ b/marker_driver_rustc/src/conversion/marker/item.rs
@@ -94,6 +94,7 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
             hir::ItemKind::Enum(enum_def, generics) => {
                 let variants = self.alloc_slice_iter(enum_def.variants.iter().map(|variant| {
                     EnumVariant::new(
+                        self.to_variant_id(variant.def_id),
                         self.to_symbol_id(variant.ident.name),
                         self.to_span_id(variant.span),
                         self.to_adt_kind(&variant.data),

--- a/marker_driver_rustc/src/conversion/marker/pat.rs
+++ b/marker_driver_rustc/src/conversion/marker/pat.rs
@@ -50,7 +50,7 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
                     }
                     StructFieldPat::new(
                         self.to_span_id(pat.span),
-                        self.to_symbol_id_for_num(u32::try_from(index).expect("a index over 2^32 us unexpected")),
+                        self.to_symbol_id_for_num(u32::try_from(index).expect("a index over 2^32 is unexpected")),
                         self.to_pat(pat),
                     )
                 }));

--- a/marker_lints/tests/ui/print_ctor.rs
+++ b/marker_lints/tests/ui/print_ctor.rs
@@ -38,5 +38,5 @@ fn main() {
 
     let _print_ctor = Enum::A;
     let _print_ctor = Enum::B(1);
-    // let _print_ctor = Enum::C { f1: 44, f2: 55 };
+    let _print_ctor = Enum::C { f1: 44, f2: 55 };
 }

--- a/marker_lints/tests/ui/print_ctor.rs
+++ b/marker_lints/tests/ui/print_ctor.rs
@@ -1,0 +1,5 @@
+pub fn main() {
+    let _print_tuple = (1, 2, 3);
+    let _print_array = [1, 2, 3];
+    let _print_array = [1; 3];
+}

--- a/marker_lints/tests/ui/print_ctor.rs
+++ b/marker_lints/tests/ui/print_ctor.rs
@@ -33,10 +33,10 @@ fn main() {
 
     let _print_ctor = Union { a: 8 };
 
-    // let _ = TupleStruct(1, 2);
+    let _print_ctor = TupleStruct(1, 2);
     let _print_ctor = TupleStruct { 0: 3, ..TupleStruct::default() };
 
-    let _ = Enum::A;
-    // let _ = Enum::B(1);
-    // let _ = Enum::C { f1: 44, f2: 55 };
+    let _print_ctor = Enum::A;
+    let _print_ctor = Enum::B(1);
+    // let _print_ctor = Enum::C { f1: 44, f2: 55 };
 }

--- a/marker_lints/tests/ui/print_ctor.rs
+++ b/marker_lints/tests/ui/print_ctor.rs
@@ -1,3 +1,21 @@
+// normalize-stdout-windows: "tests/ui/" -> "$$DIR/"
+
+#[derive(Debug, Default)]
+struct FieldStruct {
+    a: u32,
+    b: u32,
+}
+#[derive(Default)]
+struct TupleStruct(u32, u32);
+union Union {
+    a: u32,
+}
+enum Enum {
+    A,
+    B(u32),
+    C { f1: u32, f2: u32 },
+}
+
 fn main() {
     let _print_tuple = (1, 2, 3);
     let _print_array = [1, 2, 3];
@@ -9,4 +27,16 @@ fn main() {
     let _print_range = ..=3;
     let _print_range = 1..=3;
     let _print_range = ..;
+
+    let _print_ctor = FieldStruct { a: 1, b: 2 };
+    let _print_ctor = FieldStruct { a: 10, ..FieldStruct::default() };
+
+    let _print_ctor = Union { a: 8 };
+
+    // let _ = TupleStruct(1, 2);
+    let _print_ctor = TupleStruct { 0: 3, ..TupleStruct::default() };
+
+    let _ = Enum::A;
+    // let _ = Enum::B(1);
+    // let _ = Enum::C { f1: 44, f2: 55 };
 }

--- a/marker_lints/tests/ui/print_ctor.rs
+++ b/marker_lints/tests/ui/print_ctor.rs
@@ -1,5 +1,12 @@
-pub fn main() {
+fn main() {
     let _print_tuple = (1, 2, 3);
     let _print_array = [1, 2, 3];
     let _print_array = [1; 3];
+
+    let _print_range = 11..;
+    let _print_range = 1..3;
+    let _print_range = ..3;
+    let _print_range = ..=3;
+    let _print_range = 1..=3;
+    let _print_range = ..;
 }

--- a/marker_lints/tests/ui/print_ctor.stdout
+++ b/marker_lints/tests/ui/print_ctor.stdout
@@ -848,8 +848,8 @@ Ctor(
     },
 )
 
-Path(
-    PathExpr {
+Ctor(
+    CtorExpr {
         data: CommonExprData {
             _lifetime: PhantomData<&()>,
             id: ExprId(..),
@@ -892,10 +892,12 @@ Path(
                     },
                 ],
             },
-            target: Item(
-                ItemId(..),
+            target: Variant(
+                VariantId(..),
             ),
         },
+        fields: [],
+        base: None,
     },
 )
 
@@ -943,8 +945,8 @@ Ctor(
                     },
                 ],
             },
-            target: Item(
-                ItemId(..),
+            target: Variant(
+                VariantId(..),
             ),
         },
         fields: [
@@ -968,6 +970,108 @@ Ctor(
                             span: SpanId(..),
                         },
                         value: 1,
+                        suffix: None,
+                    },
+                ),
+            },
+        ],
+        base: None,
+    },
+)
+
+Ctor(
+    CtorExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        path: AstQPath {
+            self_ty: None,
+            path_ty: None,
+            path: AstPath {
+                segments: [
+                    AstPathSegment {
+                        ident: Ident {
+                            name: "Enum",
+                            span: Span {
+                                source: File(
+                                    "$DIR/print_ctor.rs",
+                                ),
+                                start: 911,
+                                end: 915,
+                            },
+                        },
+                        generics: GenericArgs {
+                            args: [],
+                        },
+                    },
+                    AstPathSegment {
+                        ident: Ident {
+                            name: "C",
+                            span: Span {
+                                source: File(
+                                    "$DIR/print_ctor.rs",
+                                ),
+                                start: 917,
+                                end: 918,
+                            },
+                        },
+                        generics: GenericArgs {
+                            args: [],
+                        },
+                    },
+                ],
+            },
+            target: Variant(
+                VariantId(..),
+            ),
+        },
+        fields: [
+            CtorField {
+                span: SpanId(..),
+                ident: Ident {
+                    name: "f1",
+                    span: Span {
+                        source: File(
+                            "$DIR/print_ctor.rs",
+                        ),
+                        start: 921,
+                        end: 923,
+                    },
+                },
+                expr: IntLit(
+                    IntLitExpr {
+                        data: CommonExprData {
+                            _lifetime: PhantomData<&()>,
+                            id: ExprId(..),
+                            span: SpanId(..),
+                        },
+                        value: 44,
+                        suffix: None,
+                    },
+                ),
+            },
+            CtorField {
+                span: SpanId(..),
+                ident: Ident {
+                    name: "f2",
+                    span: Span {
+                        source: File(
+                            "$DIR/print_ctor.rs",
+                        ),
+                        start: 929,
+                        end: 931,
+                    },
+                },
+                expr: IntLit(
+                    IntLitExpr {
+                        data: CommonExprData {
+                            _lifetime: PhantomData<&()>,
+                            id: ExprId(..),
+                            span: SpanId(..),
+                        },
+                        value: 55,
                         suffix: None,
                     },
                 ),

--- a/marker_lints/tests/ui/print_ctor.stdout
+++ b/marker_lints/tests/ui/print_ctor.stdout
@@ -1,0 +1,127 @@
+Tuple(
+    TupleExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        elements: [
+            IntLit(
+                IntLitExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    value: 1,
+                    suffix: None,
+                },
+            ),
+            IntLit(
+                IntLitExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    value: 2,
+                    suffix: None,
+                },
+            ),
+            IntLit(
+                IntLitExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    value: 3,
+                    suffix: None,
+                },
+            ),
+        ],
+    },
+)
+
+Array(
+    ArrayExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        elements: [
+            IntLit(
+                IntLitExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    value: 1,
+                    suffix: None,
+                },
+            ),
+            IntLit(
+                IntLitExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    value: 2,
+                    suffix: None,
+                },
+            ),
+            IntLit(
+                IntLitExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    value: 3,
+                    suffix: None,
+                },
+            ),
+        ],
+        len_expr: None,
+    },
+)
+
+Array(
+    ArrayExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        elements: [
+            IntLit(
+                IntLitExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    value: 1,
+                    suffix: None,
+                },
+            ),
+        ],
+        len_expr: Some(
+            IntLit(
+                IntLitExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    value: 3,
+                    suffix: None,
+                },
+            ),
+        ),
+    },
+)
+

--- a/marker_lints/tests/ui/print_ctor.stdout
+++ b/marker_lints/tests/ui/print_ctor.stdout
@@ -287,3 +287,477 @@ Range(
     },
 )
 
+Ctor(
+    CtorExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        path: AstQPath {
+            self_ty: None,
+            path_ty: None,
+            path: AstPath {
+                segments: [
+                    AstPathSegment {
+                        ident: Ident {
+                            name: "FieldStruct",
+                            span: Span {
+                                source: File(
+                                    "$DIR/print_ctor.rs",
+                                ),
+                                start: 573,
+                                end: 584,
+                            },
+                        },
+                        generics: GenericArgs {
+                            args: [],
+                        },
+                    },
+                ],
+            },
+            target: Item(
+                ItemId(..),
+            ),
+        },
+        fields: [
+            CtorField {
+                span: SpanId(..),
+                ident: Ident {
+                    name: "a",
+                    span: Span {
+                        source: File(
+                            "$DIR/print_ctor.rs",
+                        ),
+                        start: 587,
+                        end: 588,
+                    },
+                },
+                expr: IntLit(
+                    IntLitExpr {
+                        data: CommonExprData {
+                            _lifetime: PhantomData<&()>,
+                            id: ExprId(..),
+                            span: SpanId(..),
+                        },
+                        value: 1,
+                        suffix: None,
+                    },
+                ),
+            },
+            CtorField {
+                span: SpanId(..),
+                ident: Ident {
+                    name: "b",
+                    span: Span {
+                        source: File(
+                            "$DIR/print_ctor.rs",
+                        ),
+                        start: 593,
+                        end: 594,
+                    },
+                },
+                expr: IntLit(
+                    IntLitExpr {
+                        data: CommonExprData {
+                            _lifetime: PhantomData<&()>,
+                            id: ExprId(..),
+                            span: SpanId(..),
+                        },
+                        value: 2,
+                        suffix: None,
+                    },
+                ),
+            },
+        ],
+        base: None,
+    },
+)
+
+Ctor(
+    CtorExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        path: AstQPath {
+            self_ty: None,
+            path_ty: None,
+            path: AstPath {
+                segments: [
+                    AstPathSegment {
+                        ident: Ident {
+                            name: "FieldStruct",
+                            span: Span {
+                                source: File(
+                                    "$DIR/print_ctor.rs",
+                                ),
+                                start: 623,
+                                end: 634,
+                            },
+                        },
+                        generics: GenericArgs {
+                            args: [],
+                        },
+                    },
+                ],
+            },
+            target: Item(
+                ItemId(..),
+            ),
+        },
+        fields: [
+            CtorField {
+                span: SpanId(..),
+                ident: Ident {
+                    name: "a",
+                    span: Span {
+                        source: File(
+                            "$DIR/print_ctor.rs",
+                        ),
+                        start: 637,
+                        end: 638,
+                    },
+                },
+                expr: IntLit(
+                    IntLitExpr {
+                        data: CommonExprData {
+                            _lifetime: PhantomData<&()>,
+                            id: ExprId(..),
+                            span: SpanId(..),
+                        },
+                        value: 10,
+                        suffix: None,
+                    },
+                ),
+            },
+        ],
+        base: Some(
+            Call(
+                CallExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    operand: Path(
+                        PathExpr {
+                            data: CommonExprData {
+                                _lifetime: PhantomData<&()>,
+                                id: ExprId(..),
+                                span: SpanId(..),
+                            },
+                            path: AstQPath {
+                                self_ty: None,
+                                path_ty: Some(
+                                    Path(
+                                        PathTy {
+                                            data: CommonTyData {
+                                                _lifetime: PhantomData<&()>,
+                                                span: Some(
+                                                    SpanId(..),
+                                                ),
+                                                is_syntactic: true,
+                                            },
+                                            path: AstQPath {
+                                                self_ty: None,
+                                                path_ty: None,
+                                                path: AstPath {
+                                                    segments: [
+                                                        AstPathSegment {
+                                                            ident: Ident {
+                                                                name: "FieldStruct",
+                                                                span: Span {
+                                                                    source: File(
+                                                                        "$DIR/print_ctor.rs",
+                                                                    ),
+                                                                    start: 646,
+                                                                    end: 657,
+                                                                },
+                                                            },
+                                                            generics: GenericArgs {
+                                                                args: [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                target: Item(
+                                                    ItemId(..),
+                                                ),
+                                            },
+                                        },
+                                    ),
+                                ),
+                                path: AstPath {
+                                    segments: [
+                                        AstPathSegment {
+                                            ident: Ident {
+                                                name: "FieldStruct",
+                                                span: Span {
+                                                    source: File(
+                                                        "$DIR/print_ctor.rs",
+                                                    ),
+                                                    start: 646,
+                                                    end: 657,
+                                                },
+                                            },
+                                            generics: GenericArgs {
+                                                args: [],
+                                            },
+                                        },
+                                        AstPathSegment {
+                                            ident: Ident {
+                                                name: "default",
+                                                span: Span {
+                                                    source: File(
+                                                        "$DIR/print_ctor.rs",
+                                                    ),
+                                                    start: 659,
+                                                    end: 666,
+                                                },
+                                            },
+                                            generics: GenericArgs {
+                                                args: [],
+                                            },
+                                        },
+                                    ],
+                                },
+                                target: Item(
+                                    ItemId(..),
+                                ),
+                            },
+                        },
+                    ),
+                    args: [],
+                },
+            ),
+        ),
+    },
+)
+
+Ctor(
+    CtorExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        path: AstQPath {
+            self_ty: None,
+            path_ty: None,
+            path: AstPath {
+                segments: [
+                    AstPathSegment {
+                        ident: Ident {
+                            name: "Union",
+                            span: Span {
+                                source: File(
+                                    "$DIR/print_ctor.rs",
+                                ),
+                                start: 695,
+                                end: 700,
+                            },
+                        },
+                        generics: GenericArgs {
+                            args: [],
+                        },
+                    },
+                ],
+            },
+            target: Item(
+                ItemId(..),
+            ),
+        },
+        fields: [
+            CtorField {
+                span: SpanId(..),
+                ident: Ident {
+                    name: "a",
+                    span: Span {
+                        source: File(
+                            "$DIR/print_ctor.rs",
+                        ),
+                        start: 703,
+                        end: 704,
+                    },
+                },
+                expr: IntLit(
+                    IntLitExpr {
+                        data: CommonExprData {
+                            _lifetime: PhantomData<&()>,
+                            id: ExprId(..),
+                            span: SpanId(..),
+                        },
+                        value: 8,
+                        suffix: None,
+                    },
+                ),
+            },
+        ],
+        base: None,
+    },
+)
+
+Ctor(
+    CtorExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        path: AstQPath {
+            self_ty: None,
+            path_ty: None,
+            path: AstPath {
+                segments: [
+                    AstPathSegment {
+                        ident: Ident {
+                            name: "TupleStruct",
+                            span: Span {
+                                source: File(
+                                    "$DIR/print_ctor.rs",
+                                ),
+                                start: 768,
+                                end: 779,
+                            },
+                        },
+                        generics: GenericArgs {
+                            args: [],
+                        },
+                    },
+                ],
+            },
+            target: Item(
+                ItemId(..),
+            ),
+        },
+        fields: [
+            CtorField {
+                span: SpanId(..),
+                ident: Ident {
+                    name: "0",
+                    span: Span {
+                        source: File(
+                            "$DIR/print_ctor.rs",
+                        ),
+                        start: 782,
+                        end: 783,
+                    },
+                },
+                expr: IntLit(
+                    IntLitExpr {
+                        data: CommonExprData {
+                            _lifetime: PhantomData<&()>,
+                            id: ExprId(..),
+                            span: SpanId(..),
+                        },
+                        value: 3,
+                        suffix: None,
+                    },
+                ),
+            },
+        ],
+        base: Some(
+            Call(
+                CallExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    operand: Path(
+                        PathExpr {
+                            data: CommonExprData {
+                                _lifetime: PhantomData<&()>,
+                                id: ExprId(..),
+                                span: SpanId(..),
+                            },
+                            path: AstQPath {
+                                self_ty: None,
+                                path_ty: Some(
+                                    Path(
+                                        PathTy {
+                                            data: CommonTyData {
+                                                _lifetime: PhantomData<&()>,
+                                                span: Some(
+                                                    SpanId(..),
+                                                ),
+                                                is_syntactic: true,
+                                            },
+                                            path: AstQPath {
+                                                self_ty: None,
+                                                path_ty: None,
+                                                path: AstPath {
+                                                    segments: [
+                                                        AstPathSegment {
+                                                            ident: Ident {
+                                                                name: "TupleStruct",
+                                                                span: Span {
+                                                                    source: File(
+                                                                        "$DIR/print_ctor.rs",
+                                                                    ),
+                                                                    start: 790,
+                                                                    end: 801,
+                                                                },
+                                                            },
+                                                            generics: GenericArgs {
+                                                                args: [],
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                                target: Item(
+                                                    ItemId(..),
+                                                ),
+                                            },
+                                        },
+                                    ),
+                                ),
+                                path: AstPath {
+                                    segments: [
+                                        AstPathSegment {
+                                            ident: Ident {
+                                                name: "TupleStruct",
+                                                span: Span {
+                                                    source: File(
+                                                        "$DIR/print_ctor.rs",
+                                                    ),
+                                                    start: 790,
+                                                    end: 801,
+                                                },
+                                            },
+                                            generics: GenericArgs {
+                                                args: [],
+                                            },
+                                        },
+                                        AstPathSegment {
+                                            ident: Ident {
+                                                name: "default",
+                                                span: Span {
+                                                    source: File(
+                                                        "$DIR/print_ctor.rs",
+                                                    ),
+                                                    start: 803,
+                                                    end: 810,
+                                                },
+                                            },
+                                            generics: GenericArgs {
+                                                args: [],
+                                            },
+                                        },
+                                    ],
+                                },
+                                target: Item(
+                                    ItemId(..),
+                                ),
+                            },
+                        },
+                    ),
+                    args: [],
+                },
+            ),
+        ),
+    },
+)
+

--- a/marker_lints/tests/ui/print_ctor.stdout
+++ b/marker_lints/tests/ui/print_ctor.stdout
@@ -618,8 +618,8 @@ Ctor(
                                 source: File(
                                     "$DIR/print_ctor.rs",
                                 ),
-                                start: 768,
-                                end: 779,
+                                start: 734,
+                                end: 745,
                             },
                         },
                         generics: GenericArgs {
@@ -641,8 +641,95 @@ Ctor(
                         source: File(
                             "$DIR/print_ctor.rs",
                         ),
-                        start: 782,
-                        end: 783,
+                        start: 0,
+                        end: 0,
+                    },
+                },
+                expr: IntLit(
+                    IntLitExpr {
+                        data: CommonExprData {
+                            _lifetime: PhantomData<&()>,
+                            id: ExprId(..),
+                            span: SpanId(..),
+                        },
+                        value: 1,
+                        suffix: None,
+                    },
+                ),
+            },
+            CtorField {
+                span: SpanId(..),
+                ident: Ident {
+                    name: "1",
+                    span: Span {
+                        source: File(
+                            "$DIR/print_ctor.rs",
+                        ),
+                        start: 0,
+                        end: 0,
+                    },
+                },
+                expr: IntLit(
+                    IntLitExpr {
+                        data: CommonExprData {
+                            _lifetime: PhantomData<&()>,
+                            id: ExprId(..),
+                            span: SpanId(..),
+                        },
+                        value: 2,
+                        suffix: None,
+                    },
+                ),
+            },
+        ],
+        base: None,
+    },
+)
+
+Ctor(
+    CtorExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        path: AstQPath {
+            self_ty: None,
+            path_ty: None,
+            path: AstPath {
+                segments: [
+                    AstPathSegment {
+                        ident: Ident {
+                            name: "TupleStruct",
+                            span: Span {
+                                source: File(
+                                    "$DIR/print_ctor.rs",
+                                ),
+                                start: 775,
+                                end: 786,
+                            },
+                        },
+                        generics: GenericArgs {
+                            args: [],
+                        },
+                    },
+                ],
+            },
+            target: Item(
+                ItemId(..),
+            ),
+        },
+        fields: [
+            CtorField {
+                span: SpanId(..),
+                ident: Ident {
+                    name: "0",
+                    span: Span {
+                        source: File(
+                            "$DIR/print_ctor.rs",
+                        ),
+                        start: 789,
+                        end: 790,
                     },
                 },
                 expr: IntLit(
@@ -697,8 +784,8 @@ Ctor(
                                                                     source: File(
                                                                         "$DIR/print_ctor.rs",
                                                                     ),
-                                                                    start: 790,
-                                                                    end: 801,
+                                                                    start: 797,
+                                                                    end: 808,
                                                                 },
                                                             },
                                                             generics: GenericArgs {
@@ -723,8 +810,8 @@ Ctor(
                                                     source: File(
                                                         "$DIR/print_ctor.rs",
                                                     ),
-                                                    start: 790,
-                                                    end: 801,
+                                                    start: 797,
+                                                    end: 808,
                                                 },
                                             },
                                             generics: GenericArgs {
@@ -738,8 +825,8 @@ Ctor(
                                                     source: File(
                                                         "$DIR/print_ctor.rs",
                                                     ),
-                                                    start: 803,
-                                                    end: 810,
+                                                    start: 810,
+                                                    end: 817,
                                                 },
                                             },
                                             generics: GenericArgs {
@@ -758,6 +845,135 @@ Ctor(
                 },
             ),
         ),
+    },
+)
+
+Path(
+    PathExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        path: AstQPath {
+            self_ty: None,
+            path_ty: None,
+            path: AstPath {
+                segments: [
+                    AstPathSegment {
+                        ident: Ident {
+                            name: "Enum",
+                            span: Span {
+                                source: File(
+                                    "$DIR/print_ctor.rs",
+                                ),
+                                start: 846,
+                                end: 850,
+                            },
+                        },
+                        generics: GenericArgs {
+                            args: [],
+                        },
+                    },
+                    AstPathSegment {
+                        ident: Ident {
+                            name: "A",
+                            span: Span {
+                                source: File(
+                                    "$DIR/print_ctor.rs",
+                                ),
+                                start: 852,
+                                end: 853,
+                            },
+                        },
+                        generics: GenericArgs {
+                            args: [],
+                        },
+                    },
+                ],
+            },
+            target: Item(
+                ItemId(..),
+            ),
+        },
+    },
+)
+
+Ctor(
+    CtorExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        path: AstQPath {
+            self_ty: None,
+            path_ty: None,
+            path: AstPath {
+                segments: [
+                    AstPathSegment {
+                        ident: Ident {
+                            name: "Enum",
+                            span: Span {
+                                source: File(
+                                    "$DIR/print_ctor.rs",
+                                ),
+                                start: 877,
+                                end: 881,
+                            },
+                        },
+                        generics: GenericArgs {
+                            args: [],
+                        },
+                    },
+                    AstPathSegment {
+                        ident: Ident {
+                            name: "B",
+                            span: Span {
+                                source: File(
+                                    "$DIR/print_ctor.rs",
+                                ),
+                                start: 883,
+                                end: 884,
+                            },
+                        },
+                        generics: GenericArgs {
+                            args: [],
+                        },
+                    },
+                ],
+            },
+            target: Item(
+                ItemId(..),
+            ),
+        },
+        fields: [
+            CtorField {
+                span: SpanId(..),
+                ident: Ident {
+                    name: "0",
+                    span: Span {
+                        source: File(
+                            "$DIR/print_ctor.rs",
+                        ),
+                        start: 0,
+                        end: 0,
+                    },
+                },
+                expr: IntLit(
+                    IntLitExpr {
+                        data: CommonExprData {
+                            _lifetime: PhantomData<&()>,
+                            id: ExprId(..),
+                            span: SpanId(..),
+                        },
+                        value: 1,
+                        suffix: None,
+                    },
+                ),
+            },
+        ],
+        base: None,
     },
 )
 

--- a/marker_lints/tests/ui/print_ctor.stdout
+++ b/marker_lints/tests/ui/print_ctor.stdout
@@ -125,3 +125,165 @@ Array(
     },
 )
 
+Range(
+    RangeExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        start: Some(
+            IntLit(
+                IntLitExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    value: 11,
+                    suffix: None,
+                },
+            ),
+        ),
+        end: None,
+        is_inclusive: false,
+    },
+)
+
+Range(
+    RangeExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        start: Some(
+            IntLit(
+                IntLitExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    value: 1,
+                    suffix: None,
+                },
+            ),
+        ),
+        end: Some(
+            IntLit(
+                IntLitExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    value: 3,
+                    suffix: None,
+                },
+            ),
+        ),
+        is_inclusive: false,
+    },
+)
+
+Range(
+    RangeExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        start: None,
+        end: Some(
+            IntLit(
+                IntLitExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    value: 3,
+                    suffix: None,
+                },
+            ),
+        ),
+        is_inclusive: false,
+    },
+)
+
+Range(
+    RangeExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        start: None,
+        end: Some(
+            IntLit(
+                IntLitExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    value: 3,
+                    suffix: None,
+                },
+            ),
+        ),
+        is_inclusive: true,
+    },
+)
+
+Range(
+    RangeExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        start: Some(
+            IntLit(
+                IntLitExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    value: 1,
+                    suffix: None,
+                },
+            ),
+        ),
+        end: Some(
+            IntLit(
+                IntLitExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    value: 3,
+                    suffix: None,
+                },
+            ),
+        ),
+        is_inclusive: true,
+    },
+)
+
+Range(
+    RangeExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        start: None,
+        end: None,
+        is_inclusive: false,
+    },
+)
+


### PR DESCRIPTION
Implementing the backend went surprisingly smooth. I really feel like rustc's driver has a good structure now, that supports new additions.

The Ctors being split between `ExprKind::Struct` and `ExprKind::Call` also shows, how marker is more user oriented. I at least feel like marker's representation is way simpler. Though I understand why rustc's representation as well.

---

r? @Niki4tap Would you mind reviewing this? It should hopefully be simple, a lot of these changes (1000+) come from the `print_ctor` test.

cc: #52

follow-up: #110