### PR TITLE
Add `MethodExpr` and rustc backend

### DIFF
--- a/marker_adapter/src/context.rs
+++ b/marker_adapter/src/context.rs
@@ -1,7 +1,7 @@
 use marker_api::{
     ast::{
         item::{Body, ItemKind},
-        BodyId, ItemId, Span, SpanOwner, SymbolId,
+        BodyId, ExprId, ItemId, Span, SpanOwner, SymbolId,
     },
     context::DriverCallbacks,
     ffi::{self, FfiOption},
@@ -40,6 +40,7 @@ impl<'ast> DriverContextWrapper<'ast> {
             get_span,
             span_snippet,
             symbol_str,
+            resolve_method_target,
         }
     }
 }
@@ -75,6 +76,11 @@ extern "C" fn symbol_str<'ast>(data: &(), sym: SymbolId) -> ffi::Str<'ast> {
     wrapper.driver_cx.symbol_str(sym).into()
 }
 
+extern "C" fn resolve_method_target(data: &(), id: ExprId) -> ItemId {
+    let wrapper = unsafe { &*(data as *const ()).cast::<DriverContextWrapper>() };
+    wrapper.driver_cx.resolve_method_target(id)
+}
+
 pub trait DriverContext<'ast> {
     fn item(&'ast self, api_id: ItemId) -> Option<ItemKind<'ast>>;
     fn body(&'ast self, api_id: BodyId) -> &'ast Body<'ast>;
@@ -82,4 +88,5 @@ pub trait DriverContext<'ast> {
     fn get_span(&'ast self, owner: &SpanOwner) -> &'ast Span<'ast>;
     fn span_snippet(&'ast self, span: &Span) -> Option<&'ast str>;
     fn symbol_str(&'ast self, api_id: SymbolId) -> &'ast str;
+    fn resolve_method_target(&'ast self, id: ExprId) -> ItemId;
 }

--- a/marker_api/src/ast/expr.rs
+++ b/marker_api/src/ast/expr.rs
@@ -50,6 +50,7 @@ pub enum ExprKind<'ast> {
     As(&'ast AsExpr<'ast>),
     Path(&'ast PathExpr<'ast>),
     Call(&'ast CallExpr<'ast>),
+    Method(&'ast MethodExpr<'ast>),
     Array(&'ast ArrayExpr<'ast>),
     Tuple(&'ast TupleExpr<'ast>),
     Ctor(&'ast CtorExpr<'ast>),
@@ -151,7 +152,7 @@ macro_rules! impl_expr_kind_fn {
     ($method:ident () -> $return_ty:ty) => {
         impl_expr_kind_fn!($method() -> $return_ty,
             IntLit, FloatLit, StrLit, CharLit, BoolLit, Block, UnaryOp, Borrow,
-            BinaryOp, QuestionMark, As, Path, Call, Array, Tuple, Ctor, Range,
+            BinaryOp, QuestionMark, As, Path, Call, Method, Array, Tuple, Ctor, Range,
             Index, Field, Unstable
         );
     };

--- a/marker_api/src/ast/expr/block_expr.rs
+++ b/marker_api/src/ast/expr/block_expr.rs
@@ -11,6 +11,7 @@ pub struct BlockExpr<'ast> {
     data: CommonExprData<'ast>,
     stmts: FfiSlice<'ast, StmtKind<'ast>>,
     expr: FfiOption<ExprKind<'ast>>,
+    is_unsafe: bool,
 }
 
 impl<'ast> BlockExpr<'ast> {
@@ -25,17 +26,27 @@ impl<'ast> BlockExpr<'ast> {
     pub fn expr(&self) -> Option<ExprKind<'ast>> {
         self.expr.copy()
     }
+
+    pub fn is_unsafe(&self) -> bool {
+        self.is_unsafe
+    }
 }
 
 super::impl_expr_data!(BlockExpr<'ast>, Block);
 
 #[cfg(feature = "driver-api")]
 impl<'ast> BlockExpr<'ast> {
-    pub fn new(data: CommonExprData<'ast>, stmts: &'ast [StmtKind<'ast>], expr: Option<ExprKind<'ast>>) -> Self {
+    pub fn new(
+        data: CommonExprData<'ast>,
+        stmts: &'ast [StmtKind<'ast>],
+        expr: Option<ExprKind<'ast>>,
+        is_unsafe: bool,
+    ) -> Self {
         Self {
             data,
             stmts: stmts.into(),
             expr: expr.into(),
+            is_unsafe,
         }
     }
 }

--- a/marker_driver_rustc/src/context.rs
+++ b/marker_driver_rustc/src/context.rs
@@ -4,7 +4,7 @@ use marker_adapter::context::{DriverContext, DriverContextWrapper};
 use marker_api::{
     ast::{
         item::{Body, ItemKind},
-        BodyId, ItemId, Span, SpanOwner, SymbolId,
+        BodyId, ExprId, ItemId, Span, SpanOwner, SymbolId,
     },
     context::AstContext,
     lint::Lint,
@@ -112,5 +112,9 @@ impl<'ast, 'tcx: 'ast> DriverContext<'ast> for RustcContext<'ast, 'tcx> {
         // in combination with the comment above is therefore safe.
         let api_str: &'ast str = unsafe { std::mem::transmute(rustc_str) };
         api_str
+    }
+
+    fn resolve_method_target(&'ast self, _id: ExprId) -> ItemId {
+        todo!()
     }
 }

--- a/marker_driver_rustc/src/conversion/marker/common.rs
+++ b/marker_driver_rustc/src/conversion/marker/common.rs
@@ -329,7 +329,7 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
     }
 
     #[must_use]
-    fn to_path_segment(&self, segment: &hir::PathSegment<'tcx>) -> AstPathSegment<'ast> {
+    pub fn to_path_segment(&self, segment: &hir::PathSegment<'tcx>) -> AstPathSegment<'ast> {
         AstPathSegment::new(self.to_ident(segment.ident), self.to_generic_args(segment.args))
     }
 

--- a/marker_driver_rustc/src/conversion/marker/common.rs
+++ b/marker_driver_rustc/src/conversion/marker/common.rs
@@ -287,6 +287,7 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
                 | hir::def::DefKind::AssocTy
                 | hir::def::DefKind::TraitAlias
                 | hir::def::DefKind::AssocFn
+                | hir::def::DefKind::Const
                 | hir::def::DefKind::Static(_),
                 id,
             ) => AstPathTarget::Item(self.to_item_id(*id)),

--- a/marker_driver_rustc/src/conversion/marker/expr.rs
+++ b/marker_driver_rustc/src/conversion/marker/expr.rs
@@ -171,8 +171,12 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
     fn to_block_expr(&self, data: CommonExprData<'ast>, block: &hir::Block<'tcx>) -> BlockExpr<'ast> {
         let stmts: Vec<_> = block.stmts.iter().filter_map(|stmt| self.to_stmt(stmt)).collect();
         let stmts = self.alloc_slice_iter(stmts.into_iter());
-        let expr = block.expr.map(|expr| self.to_expr(expr));
-        BlockExpr::new(data, stmts, expr)
+        BlockExpr::new(
+            data,
+            stmts,
+            block.expr.map(|expr| self.to_expr(expr)),
+            matches!(block.rules, hir::BlockCheckMode::UnsafeBlock(_)),
+        )
     }
 
     fn to_expr_from_lit_kind(&self, data: CommonExprData<'ast>, lit_kind: &rustc_ast::LitKind) -> ExprKind<'ast> {

--- a/marker_driver_rustc/src/conversion/marker/expr.rs
+++ b/marker_driver_rustc/src/conversion/marker/expr.rs
@@ -1,8 +1,8 @@
 use marker_api::ast::{
     expr::{
         ArrayExpr, BlockExpr, BoolLitExpr, CallExpr, CharLitExpr, CommonExprData, CtorExpr, CtorField, ExprKind,
-        ExprPrecedence, FieldExpr, FloatLitExpr, FloatSuffix, IndexExpr, IntLitExpr, IntSuffix, PathExpr, RangeExpr,
-        StrLitData, StrLitExpr, TupleExpr, UnstableExpr,
+        ExprPrecedence, FieldExpr, FloatLitExpr, FloatSuffix, IndexExpr, IntLitExpr, IntSuffix, MethodExpr, PathExpr,
+        RangeExpr, StrLitData, StrLitExpr, TupleExpr, UnstableExpr,
     },
     Ident,
 };
@@ -78,6 +78,14 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
 
                     _ => ExprKind::Call(self.alloc(|| CallExpr::new(data, self.to_expr(operand), self.to_exprs(args)))),
                 },
+                hir::ExprKind::MethodCall(method, receiver, args, _span) => ExprKind::Method(self.alloc(|| {
+                    MethodExpr::new(
+                        data,
+                        self.to_expr(receiver),
+                        self.to_path_segment(method),
+                        self.to_exprs(args),
+                    )
+                })),
                 hir::ExprKind::Path(
                     path @ hir::QPath::Resolved(
                         None,

--- a/marker_lints/tests/ui/print_let_expr.rs
+++ b/marker_lints/tests/ui/print_let_expr.rs
@@ -1,3 +1,5 @@
+// normalize-stdout-windows: "tests/ui/" -> "$$DIR/"
+
 fn main() {
     let _print_str = r#"Hello"#;
     let _print_byte_str = b"Hello\n";

--- a/marker_lints/tests/ui/print_let_expr.rs
+++ b/marker_lints/tests/ui/print_let_expr.rs
@@ -7,4 +7,5 @@ fn main() {
     let _print_hex_int = 0xcafe;
     let _print_byte = b'D';
     let _print_block_int = { 3 };
+    let _print_unsafe_block = unsafe { 0 };
 }

--- a/marker_lints/tests/ui/print_let_expr.stdout
+++ b/marker_lints/tests/ui/print_let_expr.stdout
@@ -115,6 +115,32 @@ Block(
                 },
             ),
         ),
+        is_unsafe: false,
+    },
+)
+
+Block(
+    BlockExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        stmts: [],
+        expr: Some(
+            IntLit(
+                IntLitExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    value: 0,
+                    suffix: None,
+                },
+            ),
+        ),
+        is_unsafe: true,
     },
 )
 

--- a/marker_lints/tests/ui/print_object_exprs.rs
+++ b/marker_lints/tests/ui/print_object_exprs.rs
@@ -1,0 +1,20 @@
+#[derive(Debug, Default)]
+pub struct Example {
+    a: u32,
+}
+
+impl Example {
+    fn inc(&mut self, b: u32) {
+        self.a += b;
+    }
+
+    fn print(&self) {
+        println!("{self:#?}");
+    }
+}
+
+fn main() {
+    let mut foo = Example::default();
+    let _print_method = foo.print();
+    let _print_method = foo.inc(2);
+}

--- a/marker_lints/tests/ui/print_object_exprs.rs
+++ b/marker_lints/tests/ui/print_object_exprs.rs
@@ -1,3 +1,5 @@
+// normalize-stdout-windows: "tests/ui/" -> "$$DIR/"
+
 #[derive(Debug, Default)]
 pub struct Example {
     a: u32,

--- a/marker_lints/tests/ui/print_object_exprs.stdout
+++ b/marker_lints/tests/ui/print_object_exprs.stdout
@@ -24,8 +24,8 @@ Method(
                                         source: File(
                                             "$DIR/print_object_exprs.rs",
                                         ),
-                                        start: 273,
-                                        end: 276,
+                                        start: 327,
+                                        end: 330,
                                     },
                                 },
                                 generics: GenericArgs {
@@ -47,8 +47,8 @@ Method(
                     source: File(
                         "$DIR/print_object_exprs.rs",
                     ),
-                    start: 277,
-                    end: 282,
+                    start: 331,
+                    end: 336,
                 },
             },
             generics: GenericArgs {
@@ -85,8 +85,8 @@ Method(
                                         source: File(
                                             "$DIR/print_object_exprs.rs",
                                         ),
-                                        start: 310,
-                                        end: 313,
+                                        start: 364,
+                                        end: 367,
                                     },
                                 },
                                 generics: GenericArgs {
@@ -108,8 +108,8 @@ Method(
                     source: File(
                         "$DIR/print_object_exprs.rs",
                     ),
-                    start: 314,
-                    end: 317,
+                    start: 368,
+                    end: 371,
                 },
             },
             generics: GenericArgs {

--- a/marker_lints/tests/ui/print_object_exprs.stdout
+++ b/marker_lints/tests/ui/print_object_exprs.stdout
@@ -1,0 +1,134 @@
+Method(
+    MethodExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        receiver: Path(
+            PathExpr {
+                data: CommonExprData {
+                    _lifetime: PhantomData<&()>,
+                    id: ExprId(..),
+                    span: SpanId(..),
+                },
+                path: AstQPath {
+                    self_ty: None,
+                    path_ty: None,
+                    path: AstPath {
+                        segments: [
+                            AstPathSegment {
+                                ident: Ident {
+                                    name: "foo",
+                                    span: Span {
+                                        source: File(
+                                            "$DIR/print_object_exprs.rs",
+                                        ),
+                                        start: 273,
+                                        end: 276,
+                                    },
+                                },
+                                generics: GenericArgs {
+                                    args: [],
+                                },
+                            },
+                        ],
+                    },
+                    target: Var(
+                        VarId(..),
+                    ),
+                },
+            },
+        ),
+        method: AstPathSegment {
+            ident: Ident {
+                name: "print",
+                span: Span {
+                    source: File(
+                        "$DIR/print_object_exprs.rs",
+                    ),
+                    start: 277,
+                    end: 282,
+                },
+            },
+            generics: GenericArgs {
+                args: [],
+            },
+        },
+        args: [],
+    },
+)
+
+Method(
+    MethodExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        receiver: Path(
+            PathExpr {
+                data: CommonExprData {
+                    _lifetime: PhantomData<&()>,
+                    id: ExprId(..),
+                    span: SpanId(..),
+                },
+                path: AstQPath {
+                    self_ty: None,
+                    path_ty: None,
+                    path: AstPath {
+                        segments: [
+                            AstPathSegment {
+                                ident: Ident {
+                                    name: "foo",
+                                    span: Span {
+                                        source: File(
+                                            "$DIR/print_object_exprs.rs",
+                                        ),
+                                        start: 310,
+                                        end: 313,
+                                    },
+                                },
+                                generics: GenericArgs {
+                                    args: [],
+                                },
+                            },
+                        ],
+                    },
+                    target: Var(
+                        VarId(..),
+                    ),
+                },
+            },
+        ),
+        method: AstPathSegment {
+            ident: Ident {
+                name: "inc",
+                span: Span {
+                    source: File(
+                        "$DIR/print_object_exprs.rs",
+                    ),
+                    start: 314,
+                    end: 317,
+                },
+            },
+            generics: GenericArgs {
+                args: [],
+            },
+        },
+        args: [
+            IntLit(
+                IntLitExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    value: 2,
+                    suffix: None,
+                },
+            ),
+        ],
+    },
+)
+


### PR DESCRIPTION
This PR adds the `ExprKind::Method` variant and supports the representation of unsafe blocks.

---

r? @Niki4tap My understanding is, that you're fine with me pinging you for PRs. If you have the time, I'd value your feedback. :)

cc: #52 