### PR TITLE
Refactorings and resulting format changes in rustc's driver

### DIFF
--- a/marker_driver_rustc/src/context.rs
+++ b/marker_driver_rustc/src/context.rs
@@ -43,7 +43,7 @@ pub struct RustcContext<'ast, 'tcx> {
 impl<'ast, 'tcx> RustcContext<'ast, 'tcx> {
     pub fn new(rustc_cx: TyCtxt<'tcx>, lint_store: &'tcx LintStore, storage: &'ast Storage<'ast>) -> &'ast Self {
         // Create context
-        let driver_cx = storage.alloc(|| Self {
+        let driver_cx = storage.alloc(Self {
             rustc_cx,
             lint_store,
             storage,
@@ -53,9 +53,9 @@ impl<'ast, 'tcx> RustcContext<'ast, 'tcx> {
         });
 
         // Create and link `AstContext`
-        let callbacks_wrapper = storage.alloc(|| DriverContextWrapper::new(driver_cx));
-        let callbacks = storage.alloc(|| callbacks_wrapper.create_driver_callback());
-        let ast_cx = storage.alloc(|| AstContext::new(callbacks));
+        let callbacks_wrapper = storage.alloc(DriverContextWrapper::new(driver_cx));
+        let callbacks = storage.alloc(callbacks_wrapper.create_driver_callback());
+        let ast_cx = storage.alloc(AstContext::new(callbacks));
         driver_cx.ast_cx.set(ast_cx).unwrap();
 
         driver_cx
@@ -95,7 +95,7 @@ impl<'ast, 'tcx: 'ast> DriverContext<'ast> for RustcContext<'ast, 'tcx> {
             SpanOwner::Item(item) => self.rustc_cx.hir().item(self.rustc_converter.to_item_id(*item)).span,
             SpanOwner::SpecificSpan(span_id) => self.rustc_converter.to_span_from_id(*span_id),
         };
-        self.storage.alloc(|| self.marker_converter.to_span(rustc_span))
+        self.storage.alloc(self.marker_converter.to_span(rustc_span))
     }
 
     fn span_snippet(&self, _span: &Span) -> Option<&'ast str> {

--- a/marker_driver_rustc/src/context.rs
+++ b/marker_driver_rustc/src/context.rs
@@ -12,7 +12,7 @@ use marker_api::{
 use rustc_lint::LintStore;
 use rustc_middle::ty::TyCtxt;
 
-use crate::conversion::{marker::MarkerConverter, rustc::RustcConversionContext};
+use crate::conversion::{marker::MarkerConverter, rustc::RustcConverter};
 
 use self::storage::Storage;
 
@@ -32,7 +32,7 @@ pub struct RustcContext<'ast, 'tcx> {
     pub lint_store: &'tcx LintStore,
     pub storage: &'ast Storage<'ast>,
     pub marker_converter: MarkerConverter<'ast, 'tcx>,
-    pub rustc_converter: RustcConversionContext<'ast, 'tcx>,
+    pub rustc_converter: RustcConverter<'ast, 'tcx>,
 
     /// This is the [`AstContext`] wrapping callbacks to this instance of the
     /// [`RustcContext`]. The once cell will be set immediately after the creation
@@ -48,7 +48,7 @@ impl<'ast, 'tcx> RustcContext<'ast, 'tcx> {
             lint_store,
             storage,
             marker_converter: MarkerConverter::new(rustc_cx, storage),
-            rustc_converter: RustcConversionContext::new(rustc_cx, storage),
+            rustc_converter: RustcConverter::new(rustc_cx, storage),
             ast_cx: OnceCell::new(),
         });
 

--- a/marker_driver_rustc/src/context.rs
+++ b/marker_driver_rustc/src/context.rs
@@ -12,7 +12,7 @@ use marker_api::{
 use rustc_lint::LintStore;
 use rustc_middle::ty::TyCtxt;
 
-use crate::conversion::{marker::MarkerConversionContext, rustc::RustcConversionContext};
+use crate::conversion::{marker::MarkerConverter, rustc::RustcConversionContext};
 
 use self::storage::Storage;
 
@@ -31,7 +31,7 @@ pub struct RustcContext<'ast, 'tcx> {
     pub rustc_cx: TyCtxt<'tcx>,
     pub lint_store: &'tcx LintStore,
     pub storage: &'ast Storage<'ast>,
-    pub marker_converter: MarkerConversionContext<'ast, 'tcx>,
+    pub marker_converter: MarkerConverter<'ast, 'tcx>,
     pub rustc_converter: RustcConversionContext<'ast, 'tcx>,
 
     /// This is the [`AstContext`] wrapping callbacks to this instance of the
@@ -47,7 +47,7 @@ impl<'ast, 'tcx> RustcContext<'ast, 'tcx> {
             rustc_cx,
             lint_store,
             storage,
-            marker_converter: MarkerConversionContext::new(rustc_cx, storage),
+            marker_converter: MarkerConverter::new(rustc_cx, storage),
             rustc_converter: RustcConversionContext::new(rustc_cx, storage),
             ast_cx: OnceCell::new(),
         });

--- a/marker_driver_rustc/src/context/storage.rs
+++ b/marker_driver_rustc/src/context/storage.rs
@@ -24,15 +24,12 @@ impl<'ast> Default for Storage<'ast> {
 
 impl<'ast> Storage<'ast> {
     #[must_use]
-    pub fn alloc<F, T>(&'ast self, f: F) -> &'ast T
-    where
-        F: FnOnce() -> T,
-    {
-        self.buffer.alloc_with(f)
+    pub fn alloc<T>(&'ast self, t: T) -> &'ast T {
+        self.buffer.alloc(t)
     }
 
     #[must_use]
-    pub fn alloc_slice_iter<T, I>(&'ast self, iter: I) -> &'ast [T]
+    pub fn alloc_slice<T, I>(&'ast self, iter: I) -> &'ast [T]
     where
         I: IntoIterator<Item = T>,
         I::IntoIter: ExactSizeIterator,

--- a/marker_driver_rustc/src/conversion/marker.rs
+++ b/marker_driver_rustc/src/conversion/marker.rs
@@ -98,20 +98,17 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     }
 
     #[must_use]
-    fn alloc<F, T>(&self, f: F) -> &'ast T
-    where
-        F: FnOnce() -> T,
-    {
-        self.storage.alloc(f)
+    fn alloc<T>(&self, t: T) -> &'ast T {
+        self.storage.alloc(t)
     }
 
     #[must_use]
-    fn alloc_slice_iter<T, I>(&self, iter: I) -> &'ast [T]
+    fn alloc_slice<T, I>(&self, iter: I) -> &'ast [T]
     where
         I: IntoIterator<Item = T>,
         I::IntoIter: ExactSizeIterator,
     {
-        self.storage.alloc_slice_iter(iter)
+        self.storage.alloc_slice(iter)
     }
 }
 
@@ -122,6 +119,9 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
         rustc_crate_id: hir::def_id::CrateNum,
         rustc_root_mod: &'tcx hir::Mod<'tcx>,
     ) -> &'ast Crate<'ast> {
-        self.alloc(|| Crate::new(self.to_crate_id(rustc_crate_id), self.to_items(rustc_root_mod.item_ids)))
+        self.alloc(Crate::new(
+            self.to_crate_id(rustc_crate_id),
+            self.to_items(rustc_root_mod.item_ids),
+        ))
     }
 }

--- a/marker_driver_rustc/src/conversion/marker.rs
+++ b/marker_driver_rustc/src/conversion/marker.rs
@@ -1,6 +1,6 @@
 //! This module and its sub modules form the translation layer from rustc's
 //! internal representation to markers representation. All conversion methods
-//! are implemented as methods of the [`MarkerConversionContext`] to group them
+//! are implemented as methods of the [`MarkerConverterInner`] to group them
 //! together and share access to common objects easily.
 
 mod common;
@@ -78,7 +78,7 @@ struct MarkerConverterInner<'ast, 'tcx> {
     /// require additional translations.
     rustc_body: RefCell<Option<hir::BodyId>>,
     /// Requested on demand from rustc using a [`hir::BodyId`] see
-    /// [`MarkerConversionContext::rustc_body`] for more information
+    /// [`MarkerConverterInner::rustc_body`] for more information
     rustc_ty_check: RefCell<Option<&'tcx rustc_middle::ty::TypeckResults<'tcx>>>,
 }
 

--- a/marker_driver_rustc/src/conversion/marker/common.rs
+++ b/marker_driver_rustc/src/conversion/marker/common.rs
@@ -14,7 +14,7 @@ use crate::conversion::common::{
 };
 use crate::transmute_id;
 
-use super::MarkerConversionContext;
+use super::MarkerConverterInner;
 
 impl From<hir::def_id::LocalDefId> for GenericIdLayout {
     fn from(value: hir::def_id::LocalDefId) -> Self {
@@ -57,7 +57,7 @@ impl From<hir::def_id::DefId> for ItemIdLayout {
 }
 
 // Ids
-impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
+impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     #[must_use]
     pub fn to_crate_id(&self, rustc_id: hir::def_id::CrateNum) -> CrateId {
         assert_eq!(size_of::<CrateId>(), 4);
@@ -96,6 +96,7 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
     }
 
     #[must_use]
+    #[expect(dead_code, reason = "will be used later")]
     pub fn to_ty_def_id(&self, rustc_id: hir::def_id::DefId) -> TyDefId {
         transmute_id!(
             TyDefIdLayout as TyDefId = TyDefIdLayout {
@@ -145,7 +146,7 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
 }
 
 // Other magical cool things
-impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
+impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     #[must_use]
     pub fn to_ident(&self, ident: rustc_span::symbol::Ident) -> Ident<'ast> {
         Ident::new(self.to_symbol_id(ident.name), self.to_span_id(ident.span))

--- a/marker_driver_rustc/src/conversion/marker/common.rs
+++ b/marker_driver_rustc/src/conversion/marker/common.rs
@@ -186,7 +186,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                     Vec::with_capacity(1)
                 };
                 segments.push(self.to_path_segment(segment));
-                let path = AstPath::new(self.alloc_slice_iter(segments.into_iter()));
+                let path = AstPath::new(self.alloc_slice(segments));
 
                 // Res resolution
                 let res = if segment.res == hir::def::Res::Err {
@@ -327,7 +327,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
 
     #[must_use]
     pub fn to_path<T>(&self, path: &hir::Path<'tcx, T>) -> AstPath<'ast> {
-        AstPath::new(self.alloc_slice_iter(path.segments.iter().map(|seg| self.to_path_segment(seg))))
+        AstPath::new(self.alloc_slice(path.segments.iter().map(|seg| self.to_path_segment(seg))))
     }
 
     #[must_use]
@@ -367,7 +367,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
             rustc_span::FileName::Real(real_name) => match real_name {
                 rustc_span::RealFileName::LocalPath(path)
                 | rustc_span::RealFileName::Remapped { virtual_name: path, .. } => {
-                    SpanSource::File(self.alloc(|| path.clone()))
+                    SpanSource::File(self.alloc(path.clone()))
                 },
             },
             rustc_span::FileName::MacroExpansion(_) => todo!(),

--- a/marker_driver_rustc/src/conversion/marker/expr.rs
+++ b/marker_driver_rustc/src/conversion/marker/expr.rs
@@ -20,7 +20,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
         }
 
         let data = CommonExprData::new(id, self.to_span_id(block.span));
-        let expr = ExprKind::Block(self.alloc(|| self.to_block_expr(data, block)));
+        let expr = ExprKind::Block(self.alloc(self.to_block_expr(data, block)));
 
         self.exprs.borrow_mut().insert(id, expr);
         expr
@@ -28,7 +28,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
 
     #[must_use]
     pub fn to_exprs(&self, exprs: &[hir::Expr<'tcx>]) -> &'ast [ExprKind<'ast>] {
-        self.alloc_slice_iter(exprs.iter().map(|expr| self.to_expr(expr)))
+        self.alloc_slice(exprs.iter().map(|expr| self.to_expr(expr)))
     }
 
     #[must_use]
@@ -39,129 +39,128 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
         }
 
         let data = CommonExprData::new(id, self.to_span_id(expr.span));
-        let expr =
-            match &expr.kind {
-                hir::ExprKind::Lit(spanned_lit) => self.to_expr_from_lit_kind(data, &spanned_lit.node),
-                hir::ExprKind::Block(block, None) => ExprKind::Block(self.alloc(|| self.to_block_expr(data, block))),
-                hir::ExprKind::Call(operand, args) => match &operand.kind {
-                    hir::ExprKind::Path(hir::QPath::LangItem(hir::LangItem::RangeInclusiveNew, _, _)) => {
-                        ExprKind::Range(self.alloc(|| {
-                            RangeExpr::new(data, Some(self.to_expr(&args[0])), Some(self.to_expr(&args[1])), true)
-                        }))
-                    },
-                    hir::ExprKind::Path(
-                        qpath @ hir::QPath::Resolved(
-                            None,
-                            hir::Path {
-                                // The correct def resolution is done by `to_qpath_from_expr`
-                                res: hir::def::Res::Def(hir::def::DefKind::Ctor(_, _), _),
-                                ..
-                            },
-                        ),
-                    ) => {
-                        let fields = self.alloc_slice_iter(args.iter().enumerate().map(|(index, expr)| {
-                            CtorField::new(
-                                self.to_span_id(expr.span),
-                                Ident::new(
-                                    self.to_symbol_id_for_num(
-                                        u32::try_from(index).expect("a index over 2^32 is unexpected"),
-                                    ),
-                                    self.to_span_id(rustc_span::DUMMY_SP),
-                                ),
-                                self.to_expr(expr),
-                            )
-                        }));
-                        ExprKind::Ctor(
-                            self.alloc(|| CtorExpr::new(data, self.to_qpath_from_expr(qpath, expr), fields, None)),
-                        )
-                    },
-
-                    _ => ExprKind::Call(self.alloc(|| CallExpr::new(data, self.to_expr(operand), self.to_exprs(args)))),
+        let expr = match &expr.kind {
+            hir::ExprKind::Lit(spanned_lit) => self.to_expr_from_lit_kind(data, &spanned_lit.node),
+            hir::ExprKind::Block(block, None) => ExprKind::Block(self.alloc(self.to_block_expr(data, block))),
+            hir::ExprKind::Call(operand, args) => match &operand.kind {
+                hir::ExprKind::Path(hir::QPath::LangItem(hir::LangItem::RangeInclusiveNew, _, _)) => {
+                    ExprKind::Range(self.alloc({
+                        RangeExpr::new(data, Some(self.to_expr(&args[0])), Some(self.to_expr(&args[1])), true)
+                    }))
                 },
-                hir::ExprKind::MethodCall(method, receiver, args, _span) => ExprKind::Method(self.alloc(|| {
-                    MethodExpr::new(
-                        data,
-                        self.to_expr(receiver),
-                        self.to_path_segment(method),
-                        self.to_exprs(args),
-                    )
-                })),
                 hir::ExprKind::Path(
-                    path @ hir::QPath::Resolved(
+                    qpath @ hir::QPath::Resolved(
                         None,
                         hir::Path {
-                            res: hir::def::Res::Def(hir::def::DefKind::Ctor(_, _), ..),
+                            // The correct def resolution is done by `to_qpath_from_expr`
+                            res: hir::def::Res::Def(hir::def::DefKind::Ctor(_, _), _),
                             ..
                         },
                     ),
-                ) => ExprKind::Ctor(self.alloc(|| CtorExpr::new(data, self.to_qpath_from_expr(path, expr), &[], None))),
-                hir::ExprKind::Path(qpath) => {
-                    ExprKind::Path(self.alloc(|| PathExpr::new(data, self.to_qpath_from_expr(qpath, expr))))
-                },
-                hir::ExprKind::Tup(exprs) => ExprKind::Tuple(self.alloc(|| TupleExpr::new(data, self.to_exprs(exprs)))),
-                hir::ExprKind::Array(exprs) => {
-                    ExprKind::Array(self.alloc(|| ArrayExpr::new(data, self.to_exprs(exprs), None)))
-                },
-                hir::ExprKind::Repeat(expr, hir::ArrayLen::Body(anon_const)) => {
-                    let len_body = self.to_body(self.rustc_cx.hir().body(anon_const.body));
-                    ExprKind::Array(self.alloc(|| {
-                        ArrayExpr::new(data, self.alloc_slice_iter([self.to_expr(expr)]), Some(len_body.expr()))
-                    }))
-                },
-                hir::ExprKind::Struct(path, fields, base) => match path {
-                    hir::QPath::LangItem(hir::LangItem::RangeFull, _, _) => {
-                        ExprKind::Range(self.alloc(|| RangeExpr::new(data, None, None, false)))
-                    },
-                    hir::QPath::LangItem(hir::LangItem::RangeFrom, _, _) => ExprKind::Range(
-                        self.alloc(|| RangeExpr::new(data, Some(self.to_expr(fields[0].expr)), None, false)),
-                    ),
-                    hir::QPath::LangItem(hir::LangItem::RangeTo, _, _) => ExprKind::Range(
-                        self.alloc(|| RangeExpr::new(data, None, Some(self.to_expr(fields[0].expr)), false)),
-                    ),
-                    hir::QPath::LangItem(hir::LangItem::Range, _, _) => ExprKind::Range(self.alloc(|| {
-                        RangeExpr::new(
-                            data,
-                            Some(self.to_expr(fields[0].expr)),
-                            Some(self.to_expr(fields[1].expr)),
-                            false,
+                ) => {
+                    let fields = self.alloc_slice(args.iter().enumerate().map(|(index, expr)| {
+                        CtorField::new(
+                            self.to_span_id(expr.span),
+                            Ident::new(
+                                self.to_symbol_id_for_num(
+                                    u32::try_from(index).expect("a index over 2^32 is unexpected"),
+                                ),
+                                self.to_span_id(rustc_span::DUMMY_SP),
+                            ),
+                            self.to_expr(expr),
                         )
-                    })),
-                    hir::QPath::LangItem(hir::LangItem::RangeToInclusive, _, _) => ExprKind::Range(
-                        self.alloc(|| RangeExpr::new(data, None, Some(self.to_expr(fields[0].expr)), true)),
-                    ),
-                    _ => {
-                        let ctor_fields = self.alloc_slice_iter(fields.iter().map(|field| {
-                            CtorField::new(
-                                self.to_span_id(field.span),
-                                self.to_ident(field.ident),
-                                self.to_expr(field.expr),
-                            )
-                        }));
+                    }));
+                    ExprKind::Ctor(self.alloc(CtorExpr::new(data, self.to_qpath_from_expr(qpath, expr), fields, None)))
+                },
 
-                        ExprKind::Ctor(self.alloc(|| {
-                            CtorExpr::new(
-                                data,
-                                self.to_qpath_from_expr(path, expr),
-                                ctor_fields,
-                                base.map(|expr| self.to_expr(expr)),
-                            )
-                        }))
+                _ => ExprKind::Call(self.alloc(CallExpr::new(data, self.to_expr(operand), self.to_exprs(args)))),
+            },
+            hir::ExprKind::MethodCall(method, receiver, args, _span) => ExprKind::Method(self.alloc({
+                MethodExpr::new(
+                    data,
+                    self.to_expr(receiver),
+                    self.to_path_segment(method),
+                    self.to_exprs(args),
+                )
+            })),
+            hir::ExprKind::Path(
+                path @ hir::QPath::Resolved(
+                    None,
+                    hir::Path {
+                        res: hir::def::Res::Def(hir::def::DefKind::Ctor(_, _), ..),
+                        ..
                     },
+                ),
+            ) => ExprKind::Ctor(self.alloc(CtorExpr::new(data, self.to_qpath_from_expr(path, expr), &[], None))),
+            hir::ExprKind::Path(qpath) => {
+                ExprKind::Path(self.alloc(PathExpr::new(data, self.to_qpath_from_expr(qpath, expr))))
+            },
+            hir::ExprKind::Tup(exprs) => ExprKind::Tuple(self.alloc(TupleExpr::new(data, self.to_exprs(exprs)))),
+            hir::ExprKind::Array(exprs) => {
+                ExprKind::Array(self.alloc(ArrayExpr::new(data, self.to_exprs(exprs), None)))
+            },
+            hir::ExprKind::Repeat(expr, hir::ArrayLen::Body(anon_const)) => {
+                let len_body = self.to_body(self.rustc_cx.hir().body(anon_const.body));
+                ExprKind::Array(
+                    self.alloc({ ArrayExpr::new(data, self.alloc_slice([self.to_expr(expr)]), Some(len_body.expr())) }),
+                )
+            },
+            hir::ExprKind::Struct(path, fields, base) => match path {
+                hir::QPath::LangItem(hir::LangItem::RangeFull, _, _) => {
+                    ExprKind::Range(self.alloc(RangeExpr::new(data, None, None, false)))
                 },
-                hir::ExprKind::Index(operand, index) => {
-                    ExprKind::Index(self.alloc(|| IndexExpr::new(data, self.to_expr(operand), self.to_expr(index))))
+                hir::QPath::LangItem(hir::LangItem::RangeFrom, _, _) => {
+                    ExprKind::Range(self.alloc(RangeExpr::new(data, Some(self.to_expr(fields[0].expr)), None, false)))
                 },
-                hir::ExprKind::Field(operand, field) => {
-                    ExprKind::Field(self.alloc(|| FieldExpr::new(data, self.to_expr(operand), self.to_ident(*field))))
+                hir::QPath::LangItem(hir::LangItem::RangeTo, _, _) => {
+                    ExprKind::Range(self.alloc(RangeExpr::new(data, None, Some(self.to_expr(fields[0].expr)), false)))
                 },
-                hir::ExprKind::Err => unreachable!("would have triggered a rustc error"),
+                hir::QPath::LangItem(hir::LangItem::Range, _, _) => ExprKind::Range(self.alloc({
+                    RangeExpr::new(
+                        data,
+                        Some(self.to_expr(fields[0].expr)),
+                        Some(self.to_expr(fields[1].expr)),
+                        false,
+                    )
+                })),
+                hir::QPath::LangItem(hir::LangItem::RangeToInclusive, _, _) => {
+                    ExprKind::Range(self.alloc(RangeExpr::new(data, None, Some(self.to_expr(fields[0].expr)), true)))
+                },
                 _ => {
-                    eprintln!("skipping not implemented expr at: {:?}", expr.span);
-                    ExprKind::Unstable(self.alloc(|| {
-                        UnstableExpr::new(data, ExprPrecedence::Unstable(i32::from(expr.precedence().order())))
+                    let ctor_fields = self.alloc_slice(fields.iter().map(|field| {
+                        CtorField::new(
+                            self.to_span_id(field.span),
+                            self.to_ident(field.ident),
+                            self.to_expr(field.expr),
+                        )
+                    }));
+
+                    ExprKind::Ctor(self.alloc({
+                        CtorExpr::new(
+                            data,
+                            self.to_qpath_from_expr(path, expr),
+                            ctor_fields,
+                            base.map(|expr| self.to_expr(expr)),
+                        )
                     }))
                 },
-            };
+            },
+            hir::ExprKind::Index(operand, index) => {
+                ExprKind::Index(self.alloc(IndexExpr::new(data, self.to_expr(operand), self.to_expr(index))))
+            },
+            hir::ExprKind::Field(operand, field) => {
+                ExprKind::Field(self.alloc(FieldExpr::new(data, self.to_expr(operand), self.to_ident(*field))))
+            },
+            hir::ExprKind::Err => unreachable!("would have triggered a rustc error"),
+            _ => {
+                eprintln!("skipping not implemented expr at: {:?}", expr.span);
+                ExprKind::Unstable(
+                    self.alloc({
+                        UnstableExpr::new(data, ExprPrecedence::Unstable(i32::from(expr.precedence().order())))
+                    }),
+                )
+            },
+        };
 
         self.exprs.borrow_mut().insert(id, expr);
         expr
@@ -170,7 +169,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     #[must_use]
     fn to_block_expr(&self, data: CommonExprData<'ast>, block: &hir::Block<'tcx>) -> BlockExpr<'ast> {
         let stmts: Vec<_> = block.stmts.iter().filter_map(|stmt| self.to_stmt(stmt)).collect();
-        let stmts = self.alloc_slice_iter(stmts.into_iter());
+        let stmts = self.alloc_slice(stmts);
         BlockExpr::new(
             data,
             stmts,
@@ -181,24 +180,24 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
 
     fn to_expr_from_lit_kind(&self, data: CommonExprData<'ast>, lit_kind: &rustc_ast::LitKind) -> ExprKind<'ast> {
         match &lit_kind {
-            rustc_ast::LitKind::Str(sym, kind) => ExprKind::StrLit(self.alloc(|| {
+            rustc_ast::LitKind::Str(sym, kind) => ExprKind::StrLit(self.alloc({
                 StrLitExpr::new(
                     data,
                     matches!(kind, rustc_ast::StrStyle::Raw(_)),
                     StrLitData::Sym(self.to_symbol_id(*sym)),
                 )
             })),
-            rustc_ast::LitKind::ByteStr(bytes, kind) => ExprKind::StrLit(self.alloc(|| {
+            rustc_ast::LitKind::ByteStr(bytes, kind) => ExprKind::StrLit(self.alloc({
                 StrLitExpr::new(
                     data,
                     matches!(kind, rustc_ast::StrStyle::Raw(_)),
-                    StrLitData::Bytes(self.alloc_slice_iter(bytes.iter().copied()).into()),
+                    StrLitData::Bytes(self.alloc_slice(bytes.iter().copied()).into()),
                 )
             })),
             rustc_ast::LitKind::Byte(value) => {
-                ExprKind::IntLit(self.alloc(|| IntLitExpr::new(data, u128::from(*value), None)))
+                ExprKind::IntLit(self.alloc(IntLitExpr::new(data, u128::from(*value), None)))
             },
-            rustc_ast::LitKind::Char(value) => ExprKind::CharLit(self.alloc(|| CharLitExpr::new(data, *value))),
+            rustc_ast::LitKind::Char(value) => ExprKind::CharLit(self.alloc(CharLitExpr::new(data, *value))),
             rustc_ast::LitKind::Int(value, kind) => {
                 let suffix = match kind {
                     rustc_ast::LitIntType::Signed(rustc_ast::IntTy::Isize) => Some(IntSuffix::Isize),
@@ -215,7 +214,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                     rustc_ast::LitIntType::Unsigned(rustc_ast::UintTy::U128) => Some(IntSuffix::U128),
                     rustc_ast::LitIntType::Unsuffixed => None,
                 };
-                ExprKind::IntLit(self.alloc(|| IntLitExpr::new(data, *value, suffix)))
+                ExprKind::IntLit(self.alloc(IntLitExpr::new(data, *value, suffix)))
             },
             rustc_ast::LitKind::Float(lit_sym, kind) => {
                 let suffix = match kind {
@@ -224,9 +223,9 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                     rustc_ast::LitFloatType::Unsuffixed => None,
                 };
                 let value = f64::from_str(lit_sym.as_str()).expect("rustc should have validated the literal");
-                ExprKind::FloatLit(self.alloc(|| FloatLitExpr::new(data, value, suffix)))
+                ExprKind::FloatLit(self.alloc(FloatLitExpr::new(data, value, suffix)))
             },
-            rustc_ast::LitKind::Bool(value) => ExprKind::BoolLit(self.alloc(|| BoolLitExpr::new(data, *value))),
+            rustc_ast::LitKind::Bool(value) => ExprKind::BoolLit(self.alloc(BoolLitExpr::new(data, *value))),
             rustc_ast::LitKind::Err => unreachable!("would have triggered a rustc error"),
         }
     }

--- a/marker_driver_rustc/src/conversion/marker/expr.rs
+++ b/marker_driver_rustc/src/conversion/marker/expr.rs
@@ -101,9 +101,11 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
             },
             hir::ExprKind::Repeat(expr, hir::ArrayLen::Body(anon_const)) => {
                 let len_body = self.to_body(self.rustc_cx.hir().body(anon_const.body));
-                ExprKind::Array(
-                    self.alloc({ ArrayExpr::new(data, self.alloc_slice([self.to_expr(expr)]), Some(len_body.expr())) }),
-                )
+                ExprKind::Array(self.alloc(ArrayExpr::new(
+                    data,
+                    self.alloc_slice([self.to_expr(expr)]),
+                    Some(len_body.expr()),
+                )))
             },
             hir::ExprKind::Struct(path, fields, base) => match path {
                 hir::QPath::LangItem(hir::LangItem::RangeFull, _, _) => {

--- a/marker_driver_rustc/src/conversion/marker/expr.rs
+++ b/marker_driver_rustc/src/conversion/marker/expr.rs
@@ -9,9 +9,9 @@ use marker_api::ast::{
 use rustc_hir as hir;
 use std::str::FromStr;
 
-use super::MarkerConversionContext;
+use super::MarkerConverterInner;
 
-impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
+impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     #[must_use]
     pub fn to_expr_from_block(&self, block: &hir::Block<'tcx>) -> ExprKind<'ast> {
         let id = self.to_expr_id(block.hir_id);

--- a/marker_driver_rustc/src/conversion/marker/generics.rs
+++ b/marker_driver_rustc/src/conversion/marker/generics.rs
@@ -40,15 +40,15 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
             .filter_map(|rustc_arg| match rustc_arg {
                 rustc_hir::GenericArg::Lifetime(rust_lt) => self
                     .to_lifetime(rust_lt)
-                    .map(|lifetime| GenericArgKind::Lifetime(self.alloc(|| lifetime))),
-                rustc_hir::GenericArg::Type(r_ty) => Some(GenericArgKind::Ty(self.alloc(|| self.to_ty(*r_ty)))),
+                    .map(|lifetime| GenericArgKind::Lifetime(self.alloc(lifetime))),
+                rustc_hir::GenericArg::Type(r_ty) => Some(GenericArgKind::Ty(self.alloc(self.to_ty(*r_ty)))),
                 rustc_hir::GenericArg::Const(_) => todo!(),
                 rustc_hir::GenericArg::Infer(_) => todo!(),
             })
             .collect();
         args.extend(rustc_args.bindings.iter().map(|binding| match &binding.kind {
             rustc_hir::TypeBindingKind::Equality { term } => match term {
-                rustc_hir::Term::Ty(rustc_ty) => GenericArgKind::Binding(self.alloc(|| {
+                rustc_hir::Term::Ty(rustc_ty) => GenericArgKind::Binding(self.alloc({
                     BindingGenericArg::new(
                         Some(self.to_span_id(binding.span)),
                         self.to_symbol_id(binding.ident.name),
@@ -59,7 +59,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
             },
             rustc_hir::TypeBindingKind::Constraint { .. } => todo!(),
         }));
-        GenericArgs::new(self.alloc_slice_iter(args.drain(..)))
+        GenericArgs::new(self.alloc_slice(args))
     }
 
     pub fn to_generic_params(&self, rustc_generics: &hir::Generics<'tcx>) -> GenericParams<'ast> {
@@ -74,13 +74,13 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                         let params =
                             GenericParams::new(self.to_generic_param_kinds(ty_bound.bound_generic_params), &[]);
                         let ty = self.to_ty(ty_bound.bounded_ty);
-                        Some(WhereClauseKind::Ty(self.alloc(|| {
+                        Some(WhereClauseKind::Ty(self.alloc({
                             TyClause::new(Some(params), ty, self.to_ty_param_bound(predicate.bounds()))
                         })))
                     },
                     hir::WherePredicate::RegionPredicate(lifetime_bound) => {
                         self.to_lifetime(lifetime_bound.lifetime).map(|lifetime| {
-                            WhereClauseKind::Lifetime(self.alloc(|| {
+                            WhereClauseKind::Lifetime(self.alloc({
                                 let bounds: Vec<_> = lifetime_bound
                                     .bounds
                                     .iter()
@@ -90,7 +90,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                                     })
                                     .collect();
                                 let bounds = if bounds.is_empty() {
-                                    self.alloc_slice_iter(bounds.into_iter())
+                                    self.alloc_slice(bounds)
                                 } else {
                                     &[]
                                 };
@@ -104,7 +104,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                 }
             })
             .collect();
-        let clauses = self.alloc_slice_iter(clauses.into_iter());
+        let clauses = self.alloc_slice(clauses);
 
         GenericParams::new(self.to_generic_param_kinds(rustc_generics.params), clauses)
     }
@@ -127,18 +127,20 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                 match rustc_param.kind {
                     hir::GenericParamKind::Lifetime {
                         kind: hir::LifetimeParamKind::Explicit,
-                    } => Some(GenericParamKind::Lifetime(
-                        self.alloc(|| LifetimeParam::new(id, name, Some(span))),
-                    )),
+                    } => Some(GenericParamKind::Lifetime(self.alloc(LifetimeParam::new(
+                        id,
+                        name,
+                        Some(span),
+                    )))),
                     hir::GenericParamKind::Type { synthetic: false, .. } => {
-                        Some(GenericParamKind::Ty(self.alloc(|| TyParam::new(Some(span), name, id))))
+                        Some(GenericParamKind::Ty(self.alloc(TyParam::new(Some(span), name, id))))
                     },
                     _ => None,
                 }
             })
             .collect();
 
-        self.alloc_slice_iter(params.into_iter())
+        self.alloc_slice(params)
     }
 
     #[must_use]
@@ -150,7 +152,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
         let bounds: Vec<_> = bounds
             .iter()
             .filter_map(|bound| match bound {
-                hir::GenericBound::Trait(trait_ref, modifier) => Some(TyParamBound::TraitBound(self.alloc(|| {
+                hir::GenericBound::Trait(trait_ref, modifier) => Some(TyParamBound::TraitBound(self.alloc({
                     TraitBound::new(
                         !matches!(modifier, hir::TraitBoundModifier::None),
                         self.to_trait_ref(&trait_ref.trait_ref),
@@ -160,11 +162,11 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                 hir::GenericBound::LangItemTrait(_, _, _, _) => todo!(),
                 hir::GenericBound::Outlives(rust_lt) => self
                     .to_lifetime(rust_lt)
-                    .map(|api_lt| TyParamBound::Lifetime(self.alloc(|| api_lt))),
+                    .map(|api_lt| TyParamBound::Lifetime(self.alloc(api_lt))),
             })
             .collect();
 
-        self.alloc_slice_iter(bounds.into_iter())
+        self.alloc_slice(bounds)
     }
 
     pub fn to_ty_param_bound_from_hir(
@@ -173,7 +175,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
         rust_lt: &rustc_hir::Lifetime,
     ) -> &'ast [TyParamBound<'ast>] {
         let traits = rust_bounds.iter().map(|rust_trait_ref| {
-            TyParamBound::TraitBound(self.storage.alloc(|| {
+            TyParamBound::TraitBound(self.storage.alloc({
                 TraitBound::new(
                     false,
                     self.to_trait_ref(&rust_trait_ref.trait_ref),
@@ -185,10 +187,10 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
         if let Some(lt) = self.to_lifetime(rust_lt) {
             // alloc_slice_iter requires a const size, which is not possible otherwise
             let mut bounds: Vec<_> = traits.collect();
-            bounds.push(TyParamBound::Lifetime(self.alloc(move || lt)));
-            self.alloc_slice_iter(bounds.drain(..))
+            bounds.push(TyParamBound::Lifetime(self.alloc(lt)));
+            self.alloc_slice(bounds)
         } else {
-            self.alloc_slice_iter(traits)
+            self.alloc_slice(traits)
         }
     }
 }

--- a/marker_driver_rustc/src/conversion/marker/generics.rs
+++ b/marker_driver_rustc/src/conversion/marker/generics.rs
@@ -4,9 +4,9 @@ use marker_api::ast::generic::{
 };
 use rustc_hir as hir;
 
-use super::MarkerConversionContext;
+use super::MarkerConverterInner;
 
-impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
+impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     #[must_use]
     pub fn to_lifetime(&self, rust_lt: &hir::Lifetime) -> Option<Lifetime<'ast>> {
         let kind = match rust_lt.res {

--- a/marker_driver_rustc/src/conversion/marker/item.rs
+++ b/marker_driver_rustc/src/conversion/marker/item.rs
@@ -8,9 +8,9 @@ use marker_api::ast::{
 };
 use rustc_hir as hir;
 
-use super::MarkerConversionContext;
+use super::MarkerConverterInner;
 
-impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
+impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     #[must_use]
     pub fn to_items(&self, items: &[hir::ItemId]) -> &'ast [ItemKind<'ast>] {
         let items: Vec<_> = items

--- a/marker_driver_rustc/src/conversion/marker/pat.rs
+++ b/marker_driver_rustc/src/conversion/marker/pat.rs
@@ -4,9 +4,9 @@ use marker_api::ast::pat::{
 };
 use rustc_hir as hir;
 
-use super::MarkerConversionContext;
+use super::MarkerConverterInner;
 
-impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
+impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     #[must_use]
     pub fn to_pat(&self, pat: &hir::Pat<'tcx>) -> PatKind<'ast> {
         // Here we don't need to take special care for caching, as marker patterns

--- a/marker_driver_rustc/src/conversion/marker/stmts.rs
+++ b/marker_driver_rustc/src/conversion/marker/stmts.rs
@@ -1,9 +1,9 @@
 use marker_api::ast::stmt::{LetStmt, StmtKind};
 use rustc_hir as hir;
 
-use super::MarkerConversionContext;
+use super::MarkerConverterInner;
 
-impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
+impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     pub fn to_stmt(&self, stmt: &hir::Stmt<'tcx>) -> Option<StmtKind<'ast>> {
         match &stmt.kind {
             hir::StmtKind::Local(local) => Some(StmtKind::Let(self.alloc(|| self.to_let_stmt(local)))),

--- a/marker_driver_rustc/src/conversion/marker/stmts.rs
+++ b/marker_driver_rustc/src/conversion/marker/stmts.rs
@@ -6,7 +6,7 @@ use super::MarkerConverterInner;
 impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     pub fn to_stmt(&self, stmt: &hir::Stmt<'tcx>) -> Option<StmtKind<'ast>> {
         match &stmt.kind {
-            hir::StmtKind::Local(local) => Some(StmtKind::Let(self.alloc(|| self.to_let_stmt(local)))),
+            hir::StmtKind::Local(local) => Some(StmtKind::Let(self.alloc(self.to_let_stmt(local)))),
             hir::StmtKind::Item(item) => self.to_item_from_id(*item).map(StmtKind::Item),
             hir::StmtKind::Expr(expr) | hir::StmtKind::Semi(expr) => Some(StmtKind::Expr(self.to_expr(expr))),
         }

--- a/marker_driver_rustc/src/conversion/marker/ty.rs
+++ b/marker_driver_rustc/src/conversion/marker/ty.rs
@@ -7,7 +7,7 @@ use marker_api::ast::{
 };
 use rustc_hir as hir;
 
-use super::MarkerConversionContext;
+use super::MarkerConverterInner;
 
 pub enum TySource<'tcx> {
     Syn(&'tcx hir::Ty<'tcx>),
@@ -19,7 +19,7 @@ impl<'tcx> From<&'tcx hir::Ty<'tcx>> for TySource<'tcx> {
     }
 }
 
-impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
+impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     #[must_use]
     pub fn to_ty(&self, source: impl Into<TySource<'tcx>>) -> TyKind<'ast> {
         let source: TySource<'tcx> = source.into();
@@ -29,7 +29,7 @@ impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
     }
 }
 
-impl<'ast, 'tcx> MarkerConversionContext<'ast, 'tcx> {
+impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     #[must_use]
     fn to_syn_ty(&self, rustc_ty: &'tcx hir::Ty<'tcx>) -> TyKind<'ast> {
         let data = CommonTyData::new_syntactic(self.to_span_id(rustc_ty.span));

--- a/marker_driver_rustc/src/conversion/marker/ty.rs
+++ b/marker_driver_rustc/src/conversion/marker/ty.rs
@@ -39,18 +39,16 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
         // they can't be requested individually over the API. Instead, they're
         // always stored as part of a parent node.
         match &rustc_ty.kind {
-            hir::TyKind::Slice(inner_ty) => TyKind::Slice(self.alloc(|| SliceTy::new(data, self.to_syn_ty(inner_ty)))),
-            hir::TyKind::Array(inner_ty, _) => {
-                TyKind::Array(self.alloc(|| ArrayTy::new(data, self.to_syn_ty(inner_ty))))
-            },
-            hir::TyKind::Ptr(mut_ty) => TyKind::RawPtr(self.alloc(|| {
+            hir::TyKind::Slice(inner_ty) => TyKind::Slice(self.alloc(SliceTy::new(data, self.to_syn_ty(inner_ty)))),
+            hir::TyKind::Array(inner_ty, _) => TyKind::Array(self.alloc(ArrayTy::new(data, self.to_syn_ty(inner_ty)))),
+            hir::TyKind::Ptr(mut_ty) => TyKind::RawPtr(self.alloc({
                 RawPtrTy::new(
                     data,
                     matches!(mut_ty.mutbl, rustc_ast::Mutability::Mut),
                     self.to_syn_ty(mut_ty.ty),
                 )
             })),
-            hir::TyKind::Ref(rust_lt, mut_ty) => TyKind::Ref(self.alloc(|| {
+            hir::TyKind::Ref(rust_lt, mut_ty) => TyKind::Ref(self.alloc({
                 RefTy::new(
                     data,
                     self.to_lifetime(rust_lt),
@@ -58,11 +56,11 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                     self.to_syn_ty(mut_ty.ty),
                 )
             })),
-            hir::TyKind::BareFn(rust_fn) => TyKind::Fn(self.alloc(|| self.to_syn_fn_ty(data, rust_fn))),
-            hir::TyKind::Never => TyKind::Never(self.alloc(|| NeverTy::new(data))),
+            hir::TyKind::BareFn(rust_fn) => TyKind::Fn(self.alloc(self.to_syn_fn_ty(data, rust_fn))),
+            hir::TyKind::Never => TyKind::Never(self.alloc(NeverTy::new(data))),
             hir::TyKind::Tup(rustc_tys) => {
-                let api_tys = self.alloc_slice_iter(rustc_tys.iter().map(|rustc_ty| self.to_syn_ty(rustc_ty)));
-                TyKind::Tuple(self.alloc(|| TupleTy::new(data, api_tys)))
+                let api_tys = self.alloc_slice(rustc_tys.iter().map(|rustc_ty| self.to_syn_ty(rustc_ty)));
+                TyKind::Tuple(self.alloc(TupleTy::new(data, api_tys)))
             },
             hir::TyKind::Path(qpath) => self.to_syn_ty_from_qpath(data, qpath, rustc_ty),
             // Continue ty conversion
@@ -76,12 +74,13 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                 };
                 let rust_bound = self.to_ty_param_bound(opty.bounds);
                 // FIXME: Generics are a bit weird with opaque types
-                TyKind::ImplTrait(self.alloc(|| ImplTraitTy::new(data, rust_bound)))
+                TyKind::ImplTrait(self.alloc(ImplTraitTy::new(data, rust_bound)))
             },
-            hir::TyKind::TraitObject(rust_bounds, rust_lt, _syntax) => TyKind::TraitObj(
-                self.alloc(|| TraitObjTy::new(data, self.to_ty_param_bound_from_hir(rust_bounds, rust_lt))),
-            ),
-            hir::TyKind::Infer => TyKind::Inferred(self.alloc(|| InferredTy::new(data))),
+            hir::TyKind::TraitObject(rust_bounds, rust_lt, _syntax) => TyKind::TraitObj(self.alloc(TraitObjTy::new(
+                data,
+                self.to_ty_param_bound_from_hir(rust_bounds, rust_lt),
+            ))),
+            hir::TyKind::Infer => TyKind::Inferred(self.alloc(InferredTy::new(data))),
         }
     }
 
@@ -100,7 +99,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                     Some(self.to_span_id(name.span)),
                 )
             });
-        let params = self.alloc_slice_iter(params);
+        let params = self.alloc_slice(params);
         let return_ty = if let hir::FnRetTy::Return(rust_ty) = rust_fn.decl.output {
             Some(self.to_syn_ty(rust_ty))
         } else {
@@ -145,7 +144,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                 )
                 | hir::def::Res::SelfTyParam { .. }
                 | hir::def::Res::SelfTyAlias { .. } => {
-                    TyKind::Path(self.alloc(|| PathTy::new(data, self.to_qpath_from_ty(qpath, rustc_ty))))
+                    TyKind::Path(self.alloc(PathTy::new(data, self.to_qpath_from_ty(qpath, rustc_ty))))
                 },
                 hir::def::Res::PrimTy(prim_ty) => self.to_syn_ty_from_prim_ty(data, prim_ty),
                 hir::def::Res::Def(_, _)
@@ -156,7 +155,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                 hir::def::Res::Err => unreachable!("would have triggered a rustc error"),
             },
             hir::QPath::TypeRelative(_, _) => {
-                TyKind::Path(self.alloc(|| PathTy::new(data, self.to_qpath_from_ty(qpath, rustc_ty))))
+                TyKind::Path(self.alloc(PathTy::new(data, self.to_qpath_from_ty(qpath, rustc_ty))))
             },
             hir::QPath::LangItem(_, _, _) => todo!("{qpath:#?}"),
         }
@@ -184,12 +183,12 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                 rustc_ast::FloatTy::F32 => NumKind::F32,
                 rustc_ast::FloatTy::F64 => NumKind::F64,
             },
-            hir::PrimTy::Str => return TyKind::Text(self.alloc(|| TextTy::new(data, TextKind::Str))),
-            hir::PrimTy::Bool => return TyKind::Bool(self.alloc(|| BoolTy::new(data))),
+            hir::PrimTy::Str => return TyKind::Text(self.alloc(TextTy::new(data, TextKind::Str))),
+            hir::PrimTy::Bool => return TyKind::Bool(self.alloc(BoolTy::new(data))),
             hir::PrimTy::Char => {
-                return TyKind::Text(self.alloc(|| TextTy::new(data, TextKind::Char)));
+                return TyKind::Text(self.alloc(TextTy::new(data, TextKind::Char)));
             },
         };
-        TyKind::Num(self.alloc(|| NumTy::new(data, num_kind)))
+        TyKind::Num(self.alloc(NumTy::new(data, num_kind)))
     }
 }

--- a/marker_driver_rustc/src/conversion/rustc.rs
+++ b/marker_driver_rustc/src/conversion/rustc.rs
@@ -8,14 +8,14 @@ use rustc_hash::FxHashMap;
 
 use crate::context::storage::Storage;
 
-pub struct RustcConversionContext<'ast, 'tcx> {
+pub struct RustcConverter<'ast, 'tcx> {
     #[expect(dead_code, reason = "definitely needed later on")]
     rustc_cx: rustc_middle::ty::TyCtxt<'tcx>,
     storage: &'ast Storage<'ast>,
     lints: RefCell<FxHashMap<&'static Lint, &'static rustc_lint::Lint>>,
 }
 
-impl<'ast, 'tcx> RustcConversionContext<'ast, 'tcx> {
+impl<'ast, 'tcx> RustcConverter<'ast, 'tcx> {
     pub fn new(rustc_cx: rustc_middle::ty::TyCtxt<'tcx>, storage: &'ast Storage<'ast>) -> Self {
         Self {
             rustc_cx,

--- a/marker_driver_rustc/src/conversion/rustc/common.rs
+++ b/marker_driver_rustc/src/conversion/rustc/common.rs
@@ -9,7 +9,7 @@ use rustc_hir as hir;
 use crate::conversion::common::{BodyIdLayout, DefIdInfo, GenericIdLayout, ItemIdLayout, TyDefIdLayout};
 use crate::transmute_id;
 
-use super::RustcConversionContext;
+use super::RustcConverter;
 
 macro_rules! impl_into_def_id_for {
     ($id:ty, $layout:ty) => {
@@ -37,7 +37,7 @@ pub struct SpanSourceInfo {
     pub rustc_start_offset: usize,
 }
 
-impl<'ast, 'tcx> RustcConversionContext<'ast, 'tcx> {
+impl<'ast, 'tcx> RustcConverter<'ast, 'tcx> {
     #[must_use]
     pub fn to_crate_num(&self, api_id: CrateId) -> hir::def_id::CrateNum {
         assert_eq!(size_of::<CrateId>(), 4);

--- a/marker_driver_rustc/src/conversion/rustc/unstable.rs
+++ b/marker_driver_rustc/src/conversion/rustc/unstable.rs
@@ -1,8 +1,8 @@
 use marker_api::lint::{Lint, MacroReport};
 
-use super::RustcConversionContext;
+use super::RustcConverter;
 
-impl<'ast, 'tcx> RustcConversionContext<'ast, 'tcx> {
+impl<'ast, 'tcx> RustcConverter<'ast, 'tcx> {
     pub fn to_lint(&self, api_lint: &'static Lint) -> &'static rustc_lint::Lint {
         self.lints.borrow_mut().entry(api_lint).or_insert_with(|| {
             // Not extracted to an extra function, as it's very specific


### PR DESCRIPTION
This PR refactors the signature of the `alloc()` function to take the object instead of a closure and adds a wrapper for `MarkerConverterInner` (previously `MarkerConversionContext`)

---

95% of the changes are superficial. I think it's best if I `r=me`. Functional changes on this base will be done in follow-up PRs :)