### PR TITLE
`if`, `if let` and `match` representations

### DIFF
--- a/marker_api/src/ast/expr.rs
+++ b/marker_api/src/ast/expr.rs
@@ -84,7 +84,7 @@ pub enum ExprPrecedence {
 
     Method = 0x1200_0000,
     Call = 0x1200_0001,
-    // These two are just a guess, as they're not listed in the precedence table
+    // These three are just a guess, as they're not listed in the precedence table
     If = 0x1200_0002,
     Let = 0x1200_0003,
     Match = 0x1200_0004,

--- a/marker_api/src/ast/expr.rs
+++ b/marker_api/src/ast/expr.rs
@@ -4,6 +4,7 @@ use std::{fmt::Debug, marker::PhantomData};
 
 mod block_expr;
 mod call_exprs;
+mod cond_expr;
 mod ctor_expr;
 mod lit_expr;
 mod op_exprs;
@@ -12,6 +13,7 @@ mod place_expr;
 mod unstable_expr;
 pub use block_expr::*;
 pub use call_exprs::*;
+pub use cond_expr::*;
 pub use ctor_expr::*;
 pub use lit_expr::*;
 pub use op_exprs::*;
@@ -57,6 +59,8 @@ pub enum ExprKind<'ast> {
     Range(&'ast RangeExpr<'ast>),
     Index(&'ast IndexExpr<'ast>),
     Field(&'ast FieldExpr<'ast>),
+    If(&'ast IfExpr<'ast>),
+    Let(&'ast LetExpr<'ast>),
     Unstable(&'ast UnstableExpr<'ast>),
 }
 
@@ -79,6 +83,10 @@ pub enum ExprPrecedence {
 
     Method = 0x1200_0000,
     Call = 0x1200_0001,
+    // These two are just a guess, as they're not listed in the precedence table
+    If = 0x1200_0002,
+    Let = 0x1200_0003,
+    Match = 0x1200_0004,
 
     Field = 0x1100_0000,
 
@@ -153,7 +161,9 @@ macro_rules! impl_expr_kind_fn {
         impl_expr_kind_fn!($method() -> $return_ty,
             IntLit, FloatLit, StrLit, CharLit, BoolLit, Block, UnaryOp, Borrow,
             BinaryOp, QuestionMark, As, Path, Call, Method, Array, Tuple, Ctor, Range,
-            Index, Field, Unstable
+            Index, Field,
+            If, Let,
+            Unstable
         );
     };
     ($method:ident () -> $return_ty:ty $(, $kind:ident)+) => {

--- a/marker_api/src/ast/expr.rs
+++ b/marker_api/src/ast/expr.rs
@@ -61,6 +61,7 @@ pub enum ExprKind<'ast> {
     Field(&'ast FieldExpr<'ast>),
     If(&'ast IfExpr<'ast>),
     Let(&'ast LetExpr<'ast>),
+    Match(&'ast MatchExpr<'ast>),
     Unstable(&'ast UnstableExpr<'ast>),
 }
 
@@ -162,7 +163,7 @@ macro_rules! impl_expr_kind_fn {
             IntLit, FloatLit, StrLit, CharLit, BoolLit, Block, UnaryOp, Borrow,
             BinaryOp, QuestionMark, As, Path, Call, Method, Array, Tuple, Ctor, Range,
             Index, Field,
-            If, Let,
+            If, Let, Match,
             Unstable
         );
     };

--- a/marker_api/src/ast/expr/cond_expr.rs
+++ b/marker_api/src/ast/expr/cond_expr.rs
@@ -15,7 +15,7 @@ use super::{CommonExprData, ExprKind};
 /// if cond {
 ///     // then expression
 /// } else {
-///     // els expression
+///     // else expression
 /// }
 ///
 /// # let slice: &[i32] = &[1, 2];
@@ -26,7 +26,7 @@ use super::{CommonExprData, ExprKind};
 /// # let num = 5;
 /// if num == 1 {
 ///     // then expression
-/// } else /* `IfLet` as an else expression */ if num == 2 {
+/// } else /* `IfExpr` as an else expression */ if num == 2 {
 ///     // then expression of the else expression
 /// } else {
 ///     // else expression of the else expression
@@ -50,6 +50,10 @@ impl<'ast> IfExpr<'ast> {
         self.then
     }
 
+    /// This returns the `else` expression of this `if` expression, this will
+    /// either be a [`BlockExpr`](super::BlockExpr) or [`IfExpr`].
+    ///
+    /// `els` is an abbreviation for `else`, which is a reserved keyword in Rust.
     pub fn els(&self) -> Option<ExprKind<'ast>> {
         self.els.copy()
     }
@@ -74,8 +78,8 @@ impl<'ast> IfExpr<'ast> {
     }
 }
 
-/// A `let` expression used in conditional statements, to check if a pattern
-/// matches the scrutinee.
+/// A `let` expression used in conditional statements, to check if the value
+/// of the scrutinee matches the pattern.
 ///
 /// ```
 /// # let slice: &[i32] = &[1, 2];

--- a/marker_api/src/ast/expr/cond_expr.rs
+++ b/marker_api/src/ast/expr/cond_expr.rs
@@ -1,0 +1,117 @@
+use crate::{ast::pat::PatKind, ffi::FfiOption};
+
+use super::{CommonExprData, ExprKind};
+
+/// An if expression. If let expressions are expressed as an [`IfExpr`] with an
+/// [`LetExpr`] as the conditional expression.
+///
+/// ```
+/// # let cond = true;
+/// // vvvv the condition
+/// if cond {
+///     // then expression
+/// } else {
+///     // els expression
+/// }
+///
+/// # let slice: &[i32] = &[1, 2];
+/// if let [x] = slice {
+///     // then expression
+/// } // No else expression
+///
+/// # let num = 5;
+/// if num == 1 {
+///     // then expression
+/// } else /* `IfLet` as an else expression */ if num == 2 {
+///     // then expression of the else expression
+/// } else {
+///     // else expression of the else expression
+/// }
+/// ```
+#[repr(C)]
+#[derive(Debug)]
+pub struct IfExpr<'ast> {
+    data: CommonExprData<'ast>,
+    condition: ExprKind<'ast>,
+    then: ExprKind<'ast>,
+    els: FfiOption<ExprKind<'ast>>,
+}
+
+impl<'ast> IfExpr<'ast> {
+    pub fn condition(&self) -> ExprKind<'ast> {
+        self.condition
+    }
+
+    pub fn then(&self) -> ExprKind<'ast> {
+        self.then
+    }
+
+    pub fn els(&self) -> Option<ExprKind<'ast>> {
+        self.els.copy()
+    }
+}
+
+super::impl_expr_data!(IfExpr<'ast>, If);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> IfExpr<'ast> {
+    pub fn new(
+        data: CommonExprData<'ast>,
+        condition: ExprKind<'ast>,
+        then: ExprKind<'ast>,
+        els: Option<ExprKind<'ast>>,
+    ) -> Self {
+        Self {
+            data,
+            condition,
+            then,
+            els: els.into(),
+        }
+    }
+}
+
+/// A `let` expression used in conditional statements, to check if a pattern
+/// matches the scrutinee.
+///
+/// ```
+/// # let slice: &[i32] = &[1, 2];
+/// //     vvv The pattern
+/// if let [x] = slice {
+/// //           ^^^^^ The scrutinee
+///     // ...
+/// }
+///
+/// # let mut opt = Some(1);
+/// //        vvvvvvv The pattern
+/// while let Some(_) = opt {
+/// //                  ^^^ The scrutinee
+///     // ...
+///     # opt = None;
+/// }
+/// ```
+#[repr(C)]
+#[derive(Debug)]
+pub struct LetExpr<'ast> {
+    data: CommonExprData<'ast>,
+    pat: PatKind<'ast>,
+    scrutinee: ExprKind<'ast>,
+}
+
+impl<'ast> LetExpr<'ast> {
+    pub fn pat(&self) -> PatKind {
+        self.pat
+    }
+
+    pub fn scrutinee(&self) -> ExprKind {
+        self.scrutinee
+    }
+}
+
+super::impl_expr_data!(LetExpr<'ast>, Let);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> LetExpr<'ast> {
+    pub fn new(data: CommonExprData<'ast>, pat: PatKind<'ast>, scrutinee: ExprKind<'ast>) -> Self {
+        Self { data, pat, scrutinee }
+    }
+}

--- a/marker_api/src/ast/stmt.rs
+++ b/marker_api/src/ast/stmt.rs
@@ -17,8 +17,8 @@ pub struct LetStmt<'ast> {
     span: SpanId,
     pat: PatKind<'ast>,
     ty: FfiOption<TyKind<'ast>>,
-    init_expr: FfiOption<ExprKind<'ast>>,
-    else_expr: FfiOption<ExprKind<'ast>>,
+    init: FfiOption<ExprKind<'ast>>,
+    els: FfiOption<ExprKind<'ast>>,
 }
 
 impl<'ast> LetStmt<'ast> {
@@ -35,12 +35,15 @@ impl<'ast> LetStmt<'ast> {
         self.ty.copy()
     }
 
-    pub fn init_expr(&self) -> Option<ExprKind<'ast>> {
-        self.init_expr.copy()
+    pub fn init(&self) -> Option<ExprKind<'ast>> {
+        self.init.copy()
     }
 
-    pub fn else_expr(&self) -> Option<ExprKind> {
-        self.else_expr.copy()
+    /// This returns the optional `else` expression of the let statement.
+    ///
+    /// `els` is an abbreviation for `else`, which is a reserved keyword in Rust.
+    pub fn els(&self) -> Option<ExprKind> {
+        self.els.copy()
     }
 }
 
@@ -50,15 +53,15 @@ impl<'ast> LetStmt<'ast> {
         span: SpanId,
         pat: PatKind<'ast>,
         ty: Option<TyKind<'ast>>,
-        init_expr: Option<ExprKind<'ast>>,
-        else_expr: Option<ExprKind<'ast>>,
+        init: Option<ExprKind<'ast>>,
+        els: Option<ExprKind<'ast>>,
     ) -> Self {
         Self {
             span,
             pat,
             ty: ty.into(),
-            init_expr: init_expr.into(),
-            else_expr: else_expr.into(),
+            init: init.into(),
+            els: els.into(),
         }
     }
 }

--- a/marker_lints/src/lib.rs
+++ b/marker_lints/src/lib.rs
@@ -114,7 +114,7 @@ impl LintPass for TestLintPass {
         if let StmtKind::Let(lets) = stmt {
             let PatKind::Ident(ident) = lets.pat() else { return };
             if ident.name().starts_with("_print") {
-                let Some(expr) = lets.init_expr() else { return };
+                let Some(expr) = lets.init() else { return };
 
                 println!("{expr:#?}\n");
             }

--- a/marker_lints/tests/ui/print_cond_expr.rs
+++ b/marker_lints/tests/ui/print_cond_expr.rs
@@ -1,0 +1,45 @@
+// normalize-stdout-windows: "tests/ui/" -> "$$DIR/"
+
+fn ifs() {
+    let cond = true;
+    let _print_if = if cond {
+        // The simple if condition sadly has to be printed as a sub expression
+        // as only `let _print*` triggers the print lint
+        if cond {}
+        1
+    } else {
+        2
+    };
+
+    let opt = Some(1);
+    let _print_if_let = if let Some(_) = opt { "some" } else { "none" };
+
+    let a = true;
+    let b = true;
+    let _print_else_if = if a {
+        1
+    } else if b {
+        2
+    } else {
+        3
+    };
+}
+
+fn matches(scrutinee: &[i32]) {
+    let _print_match = match scrutinee {
+        [] => 1,
+        [x] if check(x) => 2,
+        _ => {
+            // A block as the arm expression
+            3
+        },
+    };
+}
+
+fn check(_: &i32) -> bool {
+    true
+}
+
+fn main() {
+    ifs();
+}

--- a/marker_lints/tests/ui/print_cond_expr.stdout
+++ b/marker_lints/tests/ui/print_cond_expr.stdout
@@ -1,0 +1,697 @@
+If(
+    IfExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        condition: Path(
+            PathExpr {
+                data: CommonExprData {
+                    _lifetime: PhantomData<&()>,
+                    id: ExprId(..),
+                    span: SpanId(..),
+                },
+                path: AstQPath {
+                    self_ty: None,
+                    path_ty: None,
+                    path: AstPath {
+                        segments: [
+                            AstPathSegment {
+                                ident: Ident {
+                                    name: "cond",
+                                    span: Span {
+                                        source: File(
+                                            "$DIR/print_cond_expr.rs",
+                                        ),
+                                        start: 109,
+                                        end: 113,
+                                    },
+                                },
+                                generics: GenericArgs {
+                                    args: [],
+                                },
+                            },
+                        ],
+                    },
+                    target: Var(
+                        VarId(..),
+                    ),
+                },
+            },
+        ),
+        then: Block(
+            BlockExpr {
+                data: CommonExprData {
+                    _lifetime: PhantomData<&()>,
+                    id: ExprId(..),
+                    span: SpanId(..),
+                },
+                stmts: [
+                    Expr(
+                        If(
+                            IfExpr {
+                                data: CommonExprData {
+                                    _lifetime: PhantomData<&()>,
+                                    id: ExprId(..),
+                                    span: SpanId(..),
+                                },
+                                condition: Path(
+                                    PathExpr {
+                                        data: CommonExprData {
+                                            _lifetime: PhantomData<&()>,
+                                            id: ExprId(..),
+                                            span: SpanId(..),
+                                        },
+                                        path: AstQPath {
+                                            self_ty: None,
+                                            path_ty: None,
+                                            path: AstPath {
+                                                segments: [
+                                                    AstPathSegment {
+                                                        ident: Ident {
+                                                            name: "cond",
+                                                            span: Span {
+                                                                source: File(
+                                                                    "$DIR/print_cond_expr.rs",
+                                                                ),
+                                                                start: 263,
+                                                                end: 267,
+                                                            },
+                                                        },
+                                                        generics: GenericArgs {
+                                                            args: [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            target: Var(
+                                                VarId(..),
+                                            ),
+                                        },
+                                    },
+                                ),
+                                then: Block(
+                                    BlockExpr {
+                                        data: CommonExprData {
+                                            _lifetime: PhantomData<&()>,
+                                            id: ExprId(..),
+                                            span: SpanId(..),
+                                        },
+                                        stmts: [],
+                                        expr: None,
+                                        is_unsafe: false,
+                                    },
+                                ),
+                                els: None,
+                            },
+                        ),
+                    ),
+                ],
+                expr: Some(
+                    IntLit(
+                        IntLitExpr {
+                            data: CommonExprData {
+                                _lifetime: PhantomData<&()>,
+                                id: ExprId(..),
+                                span: SpanId(..),
+                            },
+                            value: 1,
+                            suffix: None,
+                        },
+                    ),
+                ),
+                is_unsafe: false,
+            },
+        ),
+        els: Some(
+            Block(
+                BlockExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    stmts: [],
+                    expr: Some(
+                        IntLit(
+                            IntLitExpr {
+                                data: CommonExprData {
+                                    _lifetime: PhantomData<&()>,
+                                    id: ExprId(..),
+                                    span: SpanId(..),
+                                },
+                                value: 2,
+                                suffix: None,
+                            },
+                        ),
+                    ),
+                    is_unsafe: false,
+                },
+            ),
+        ),
+    },
+)
+
+If(
+    IfExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        condition: Let(
+            LetExpr {
+                data: CommonExprData {
+                    _lifetime: PhantomData<&()>,
+                    id: ExprId(..),
+                    span: SpanId(..),
+                },
+                pat: Struct(
+                    StructPat {
+                        data: CommonPatData {
+                            _lifetime: PhantomData<&()>,
+                            span: SpanId(..),
+                        },
+                        path: AstPath {
+                            segments: [
+                                AstPathSegment {
+                                    ident: Ident {
+                                        name: "Some",
+                                        span: Span {
+                                            source: File(
+                                                "$DIR/print_cond_expr.rs",
+                                            ),
+                                            start: 366,
+                                            end: 370,
+                                        },
+                                    },
+                                    generics: GenericArgs {
+                                        args: [],
+                                    },
+                                },
+                            ],
+                        },
+                        fields: [
+                            StructFieldPat {
+                                span: SpanId(..),
+                                ident: SymbolId(..),
+                                pat: Wildcard(
+                                    WildcardPat {
+                                        data: CommonPatData {
+                                            _lifetime: PhantomData<&()>,
+                                            span: SpanId(..),
+                                        },
+                                    },
+                                ),
+                            },
+                        ],
+                        is_non_exhaustive: false,
+                    },
+                ),
+                scrutinee: Path(
+                    PathExpr {
+                        data: CommonExprData {
+                            _lifetime: PhantomData<&()>,
+                            id: ExprId(..),
+                            span: SpanId(..),
+                        },
+                        path: AstQPath {
+                            self_ty: None,
+                            path_ty: None,
+                            path: AstPath {
+                                segments: [
+                                    AstPathSegment {
+                                        ident: Ident {
+                                            name: "opt",
+                                            span: Span {
+                                                source: File(
+                                                    "$DIR/print_cond_expr.rs",
+                                                ),
+                                                start: 376,
+                                                end: 379,
+                                            },
+                                        },
+                                        generics: GenericArgs {
+                                            args: [],
+                                        },
+                                    },
+                                ],
+                            },
+                            target: Var(
+                                VarId(..),
+                            ),
+                        },
+                    },
+                ),
+            },
+        ),
+        then: Block(
+            BlockExpr {
+                data: CommonExprData {
+                    _lifetime: PhantomData<&()>,
+                    id: ExprId(..),
+                    span: SpanId(..),
+                },
+                stmts: [],
+                expr: Some(
+                    StrLit(
+                        StrLitExpr {
+                            data: CommonExprData {
+                                _lifetime: PhantomData<&()>,
+                                id: ExprId(..),
+                                span: SpanId(..),
+                            },
+                            is_raw: false,
+                            str_data: Sym(
+                                SymbolId(..),
+                            ),
+                        },
+                    ),
+                ),
+                is_unsafe: false,
+            },
+        ),
+        els: Some(
+            Block(
+                BlockExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    stmts: [],
+                    expr: Some(
+                        StrLit(
+                            StrLitExpr {
+                                data: CommonExprData {
+                                    _lifetime: PhantomData<&()>,
+                                    id: ExprId(..),
+                                    span: SpanId(..),
+                                },
+                                is_raw: false,
+                                str_data: Sym(
+                                    SymbolId(..),
+                                ),
+                            },
+                        ),
+                    ),
+                    is_unsafe: false,
+                },
+            ),
+        ),
+    },
+)
+
+If(
+    IfExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        condition: Path(
+            PathExpr {
+                data: CommonExprData {
+                    _lifetime: PhantomData<&()>,
+                    id: ExprId(..),
+                    span: SpanId(..),
+                },
+                path: AstQPath {
+                    self_ty: None,
+                    path_ty: None,
+                    path: AstPath {
+                        segments: [
+                            AstPathSegment {
+                                ident: Ident {
+                                    name: "a",
+                                    span: Span {
+                                        source: File(
+                                            "$DIR/print_cond_expr.rs",
+                                        ),
+                                        start: 473,
+                                        end: 474,
+                                    },
+                                },
+                                generics: GenericArgs {
+                                    args: [],
+                                },
+                            },
+                        ],
+                    },
+                    target: Var(
+                        VarId(..),
+                    ),
+                },
+            },
+        ),
+        then: Block(
+            BlockExpr {
+                data: CommonExprData {
+                    _lifetime: PhantomData<&()>,
+                    id: ExprId(..),
+                    span: SpanId(..),
+                },
+                stmts: [],
+                expr: Some(
+                    IntLit(
+                        IntLitExpr {
+                            data: CommonExprData {
+                                _lifetime: PhantomData<&()>,
+                                id: ExprId(..),
+                                span: SpanId(..),
+                            },
+                            value: 1,
+                            suffix: None,
+                        },
+                    ),
+                ),
+                is_unsafe: false,
+            },
+        ),
+        els: Some(
+            If(
+                IfExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    condition: Path(
+                        PathExpr {
+                            data: CommonExprData {
+                                _lifetime: PhantomData<&()>,
+                                id: ExprId(..),
+                                span: SpanId(..),
+                            },
+                            path: AstQPath {
+                                self_ty: None,
+                                path_ty: None,
+                                path: AstPath {
+                                    segments: [
+                                        AstPathSegment {
+                                            ident: Ident {
+                                                name: "b",
+                                                span: Span {
+                                                    source: File(
+                                                        "$DIR/print_cond_expr.rs",
+                                                    ),
+                                                    start: 501,
+                                                    end: 502,
+                                                },
+                                            },
+                                            generics: GenericArgs {
+                                                args: [],
+                                            },
+                                        },
+                                    ],
+                                },
+                                target: Var(
+                                    VarId(..),
+                                ),
+                            },
+                        },
+                    ),
+                    then: Block(
+                        BlockExpr {
+                            data: CommonExprData {
+                                _lifetime: PhantomData<&()>,
+                                id: ExprId(..),
+                                span: SpanId(..),
+                            },
+                            stmts: [],
+                            expr: Some(
+                                IntLit(
+                                    IntLitExpr {
+                                        data: CommonExprData {
+                                            _lifetime: PhantomData<&()>,
+                                            id: ExprId(..),
+                                            span: SpanId(..),
+                                        },
+                                        value: 2,
+                                        suffix: None,
+                                    },
+                                ),
+                            ),
+                            is_unsafe: false,
+                        },
+                    ),
+                    els: Some(
+                        Block(
+                            BlockExpr {
+                                data: CommonExprData {
+                                    _lifetime: PhantomData<&()>,
+                                    id: ExprId(..),
+                                    span: SpanId(..),
+                                },
+                                stmts: [],
+                                expr: Some(
+                                    IntLit(
+                                        IntLitExpr {
+                                            data: CommonExprData {
+                                                _lifetime: PhantomData<&()>,
+                                                id: ExprId(..),
+                                                span: SpanId(..),
+                                            },
+                                            value: 3,
+                                            suffix: None,
+                                        },
+                                    ),
+                                ),
+                                is_unsafe: false,
+                            },
+                        ),
+                    ),
+                },
+            ),
+        ),
+    },
+)
+
+Match(
+    MatchExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        scrutinee: Path(
+            PathExpr {
+                data: CommonExprData {
+                    _lifetime: PhantomData<&()>,
+                    id: ExprId(..),
+                    span: SpanId(..),
+                },
+                path: AstQPath {
+                    self_ty: None,
+                    path_ty: None,
+                    path: AstPath {
+                        segments: [
+                            AstPathSegment {
+                                ident: Ident {
+                                    name: "scrutinee",
+                                    span: Span {
+                                        source: File(
+                                            "$DIR/print_cond_expr.rs",
+                                        ),
+                                        start: 609,
+                                        end: 618,
+                                    },
+                                },
+                                generics: GenericArgs {
+                                    args: [],
+                                },
+                            },
+                        ],
+                    },
+                    target: Var(
+                        VarId(..),
+                    ),
+                },
+            },
+        ),
+        arms: [
+            MatchArm {
+                span: SpanId(..),
+                pat: Slice(
+                    SlicePat {
+                        data: CommonPatData {
+                            _lifetime: PhantomData<&()>,
+                            span: SpanId(..),
+                        },
+                        elements: [],
+                    },
+                ),
+                guard: None,
+                expr: IntLit(
+                    IntLitExpr {
+                        data: CommonExprData {
+                            _lifetime: PhantomData<&()>,
+                            id: ExprId(..),
+                            span: SpanId(..),
+                        },
+                        value: 1,
+                        suffix: None,
+                    },
+                ),
+            },
+            MatchArm {
+                span: SpanId(..),
+                pat: Slice(
+                    SlicePat {
+                        data: CommonPatData {
+                            _lifetime: PhantomData<&()>,
+                            span: SpanId(..),
+                        },
+                        elements: [
+                            Ident(
+                                IdentPat {
+                                    data: CommonPatData {
+                                        _lifetime: PhantomData<&()>,
+                                        span: SpanId(..),
+                                    },
+                                    name: SymbolId(..),
+                                    var: VarId(..),
+                                    is_mut: false,
+                                    is_ref: false,
+                                    binding_pat: None,
+                                },
+                            ),
+                        ],
+                    },
+                ),
+                guard: Some(
+                    Call(
+                        CallExpr {
+                            data: CommonExprData {
+                                _lifetime: PhantomData<&()>,
+                                id: ExprId(..),
+                                span: SpanId(..),
+                            },
+                            operand: Path(
+                                PathExpr {
+                                    data: CommonExprData {
+                                        _lifetime: PhantomData<&()>,
+                                        id: ExprId(..),
+                                        span: SpanId(..),
+                                    },
+                                    path: AstQPath {
+                                        self_ty: None,
+                                        path_ty: None,
+                                        path: AstPath {
+                                            segments: [
+                                                AstPathSegment {
+                                                    ident: Ident {
+                                                        name: "check",
+                                                        span: Span {
+                                                            source: File(
+                                                                "$DIR/print_cond_expr.rs",
+                                                            ),
+                                                            start: 653,
+                                                            end: 658,
+                                                        },
+                                                    },
+                                                    generics: GenericArgs {
+                                                        args: [],
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                        target: Item(
+                                            ItemId(..),
+                                        ),
+                                    },
+                                },
+                            ),
+                            args: [
+                                Path(
+                                    PathExpr {
+                                        data: CommonExprData {
+                                            _lifetime: PhantomData<&()>,
+                                            id: ExprId(..),
+                                            span: SpanId(..),
+                                        },
+                                        path: AstQPath {
+                                            self_ty: None,
+                                            path_ty: None,
+                                            path: AstPath {
+                                                segments: [
+                                                    AstPathSegment {
+                                                        ident: Ident {
+                                                            name: "x",
+                                                            span: Span {
+                                                                source: File(
+                                                                    "$DIR/print_cond_expr.rs",
+                                                                ),
+                                                                start: 659,
+                                                                end: 660,
+                                                            },
+                                                        },
+                                                        generics: GenericArgs {
+                                                            args: [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            target: Var(
+                                                VarId(..),
+                                            ),
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                ),
+                expr: IntLit(
+                    IntLitExpr {
+                        data: CommonExprData {
+                            _lifetime: PhantomData<&()>,
+                            id: ExprId(..),
+                            span: SpanId(..),
+                        },
+                        value: 2,
+                        suffix: None,
+                    },
+                ),
+            },
+            MatchArm {
+                span: SpanId(..),
+                pat: Wildcard(
+                    WildcardPat {
+                        data: CommonPatData {
+                            _lifetime: PhantomData<&()>,
+                            span: SpanId(..),
+                        },
+                    },
+                ),
+                guard: None,
+                expr: Block(
+                    BlockExpr {
+                        data: CommonExprData {
+                            _lifetime: PhantomData<&()>,
+                            id: ExprId(..),
+                            span: SpanId(..),
+                        },
+                        stmts: [],
+                        expr: Some(
+                            IntLit(
+                                IntLitExpr {
+                                    data: CommonExprData {
+                                        _lifetime: PhantomData<&()>,
+                                        id: ExprId(..),
+                                        span: SpanId(..),
+                                    },
+                                    value: 3,
+                                    suffix: None,
+                                },
+                            ),
+                        ),
+                        is_unsafe: false,
+                    },
+                ),
+            },
+        ],
+    },
+)
+


### PR DESCRIPTION
This adds API representations for `if`, `if let` and `match` expressions, getting us one step closer.

As always, most of the changes are just UI test output.

---

cc: #52

r? @Niki4tap Would you mind taking a look at this? :)