### PR TITLE
Add AssignExpr API represention

### DIFF
--- a/marker_api/src/ast/expr.rs
+++ b/marker_api/src/ast/expr.rs
@@ -49,6 +49,7 @@ pub enum ExprKind<'ast> {
     Ref(&'ast RefExpr<'ast>),
     BinaryOp(&'ast BinaryOpExpr<'ast>),
     QuestionMark(&'ast QuestionMarkExpr<'ast>),
+    Assign(&'ast AssignExpr<'ast>),
     As(&'ast AsExpr<'ast>),
     Path(&'ast PathExpr<'ast>),
     Call(&'ast CallExpr<'ast>),
@@ -79,6 +80,7 @@ pub enum ExprPrecedence {
     Lit = 0x1400_0000,
     Block = 0x1400_0001,
     Ctor = 0x1400_0002,
+    Assign = 0x1400_0003,
 
     Path = 0x1300_0000,
 
@@ -162,7 +164,7 @@ macro_rules! impl_expr_kind_fn {
         impl_expr_kind_fn!($method() -> $return_ty,
             IntLit, FloatLit, StrLit, CharLit, BoolLit,
             Block,
-            UnaryOp, Ref, BinaryOp, QuestionMark, As,
+            UnaryOp, Ref, BinaryOp, QuestionMark, As, Assign,
             Path, Index, Field,
             Call, Method,
             Array, Tuple, Ctor, Range,

--- a/marker_api/src/ast/expr/op_exprs.rs
+++ b/marker_api/src/ast/expr/op_exprs.rs
@@ -1,4 +1,7 @@
-use crate::ast::ty::TyKind;
+use crate::{
+    ast::{pat::PatKind, ty::TyKind},
+    ffi::FfiOption,
+};
 
 use super::{CommonExprData, ExprKind, ExprPrecedence};
 
@@ -238,5 +241,65 @@ impl<'ast> AsExpr<'ast> {
     }
 }
 
-// FIXME: Add Assign expressions, these will require place expressions and a decision
-// if some cases should be represented as patterns or always as expressions.
+/// An expression assigning a value to an assignee expression.
+///
+/// ```
+///     let mut assignee = 20;
+///
+/// //  vvvvvvvv The assignee expression
+///     assignee = 10;
+/// //             ^^ The value expression
+///
+/// //  vvvvvvvvvvvvv A complex assignee expression
+///     [assignee, _] = [2, 3];
+/// //                ^ ^^^^^^ The value expression
+/// //                |
+/// //                No compound operator
+///
+/// //  vvvvvvvv The assignee expression
+///     assignee += 1;
+/// //           ^  ^ The value expression
+/// //           |
+/// //           Plus as a compound operator
+/// ```
+#[repr(C)]
+#[derive(Debug)]
+pub struct AssignExpr<'ast> {
+    data: CommonExprData<'ast>,
+    assignee: PatKind<'ast>,
+    value: ExprKind<'ast>,
+    op: FfiOption<BinaryOpKind>,
+}
+
+impl<'ast> AssignExpr<'ast> {
+    pub fn assignee(&self) -> PatKind<'ast> {
+        self.assignee
+    }
+
+    pub fn value(&self) -> ExprKind<'ast> {
+        self.value
+    }
+
+    pub fn op(&self) -> Option<BinaryOpKind> {
+        self.op.copy()
+    }
+}
+
+super::impl_expr_data!(AssignExpr<'ast>, Assign);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> AssignExpr<'ast> {
+    pub fn new(
+        data: CommonExprData<'ast>,
+        assignee: PatKind<'ast>,
+        value: ExprKind<'ast>,
+        op: Option<BinaryOpKind>,
+    ) -> Self {
+        Self {
+            data,
+            assignee,
+            value,
+            op: op.into(),
+        }
+    }
+}

--- a/marker_driver_rustc/src/conversion/marker/stmts.rs
+++ b/marker_driver_rustc/src/conversion/marker/stmts.rs
@@ -6,19 +6,24 @@ use super::MarkerConverterInner;
 impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     pub fn to_stmt(&self, stmt: &hir::Stmt<'tcx>) -> Option<StmtKind<'ast>> {
         match &stmt.kind {
-            hir::StmtKind::Local(local) => Some(StmtKind::Let(self.alloc(self.to_let_stmt(local)))),
+            hir::StmtKind::Local(local) => match local.source {
+                hir::LocalSource::Normal => Some(StmtKind::Let(self.alloc(LetStmt::new(
+                    self.to_span_id(local.span),
+                    self.to_pat(local.pat),
+                    local.ty.map(|ty| self.to_ty(ty)),
+                    local.init.map(|init| self.to_expr(init)),
+                    local.els.map(|els| self.to_expr_from_block(els)),
+                )))),
+                hir::LocalSource::AssignDesugar(_) => {
+                    unreachable!("this will be handled by the block expr wrapping wrapping the desugar")
+                },
+                hir::LocalSource::AsyncFn | hir::LocalSource::AwaitDesugar => {
+                    eprintln!("skipping not implemented statement at: {:?}", stmt.span);
+                    None
+                },
+            },
             hir::StmtKind::Item(item) => self.to_item_from_id(*item).map(StmtKind::Item),
             hir::StmtKind::Expr(expr) | hir::StmtKind::Semi(expr) => Some(StmtKind::Expr(self.to_expr(expr))),
         }
-    }
-
-    fn to_let_stmt(&self, local: &hir::Local<'tcx>) -> LetStmt<'ast> {
-        LetStmt::new(
-            self.to_span_id(local.span),
-            self.to_pat(local.pat),
-            local.ty.map(|ty| self.to_ty(ty)),
-            local.init.map(|init| self.to_expr(init)),
-            local.els.map(|els| self.to_expr_from_block(els)),
-        )
     }
 }

--- a/marker_driver_rustc/src/main.rs
+++ b/marker_driver_rustc/src/main.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![feature(rustc_private)]
 #![feature(lint_reasons)]
+#![feature(let_chains)]
 #![feature(once_cell)]
 #![warn(rustc::internal)]
 #![warn(clippy::pedantic)]

--- a/marker_lints/tests/ui/print_assign_expr.rs
+++ b/marker_lints/tests/ui/print_assign_expr.rs
@@ -1,5 +1,11 @@
 // normalize-stdout-windows: "tests/ui/" -> "$$DIR/"
 
+#[derive(Debug, Default)]
+struct S {
+    array: [i32; 3],
+    slice: (i32, i32, i32),
+}
+
 fn bar() -> i32 {
     16
 }
@@ -11,6 +17,10 @@ pub fn main() {
         a = bar();
         a += 1;
         [a, b] = [1, 2];
+        S {
+            array: [_, a, ..],
+            slice: (b, ..),
+        } = S::default();
         ()
     };
 }

--- a/marker_lints/tests/ui/print_assign_expr.rs
+++ b/marker_lints/tests/ui/print_assign_expr.rs
@@ -1,0 +1,16 @@
+// normalize-stdout-windows: "tests/ui/" -> "$$DIR/"
+
+fn bar() -> i32 {
+    16
+}
+
+pub fn main() {
+    let mut a = 0;
+    let mut b = 0;
+    let _print_exprs = {
+        a = bar();
+        a += 1;
+        [a, b] = [1, 2];
+        ()
+    };
+}

--- a/marker_lints/tests/ui/print_assign_expr.stdout
+++ b/marker_lints/tests/ui/print_assign_expr.stdout
@@ -14,40 +14,42 @@ Block(
                             id: ExprId(..),
                             span: SpanId(..),
                         },
-                        assignee: Path(
-                            PathExpr {
-                                data: CommonExprData {
-                                    _lifetime: PhantomData<&()>,
-                                    id: ExprId(..),
-                                    span: SpanId(..),
-                                },
-                                path: AstQPath {
-                                    self_ty: None,
-                                    path_ty: None,
-                                    path: AstPath {
-                                        segments: [
-                                            AstPathSegment {
-                                                ident: Ident {
-                                                    name: "x",
-                                                    span: Span {
-                                                        source: File(
-                                                            "$DIR/print_assign_expr.rs",
-                                                        ),
-                                                        start: 150,
-                                                        end: 151,
+                        assignee: Place(
+                            Path(
+                                PathExpr {
+                                    data: CommonExprData {
+                                        _lifetime: PhantomData<&()>,
+                                        id: ExprId(..),
+                                        span: SpanId(..),
+                                    },
+                                    path: AstQPath {
+                                        self_ty: None,
+                                        path_ty: None,
+                                        path: AstPath {
+                                            segments: [
+                                                AstPathSegment {
+                                                    ident: Ident {
+                                                        name: "a",
+                                                        span: Span {
+                                                            source: File(
+                                                                "$DIR/print_assign_expr.rs",
+                                                            ),
+                                                            start: 258,
+                                                            end: 259,
+                                                        },
+                                                    },
+                                                    generics: GenericArgs {
+                                                        args: [],
                                                     },
                                                 },
-                                                generics: GenericArgs {
-                                                    args: [],
-                                                },
-                                            },
-                                        ],
+                                            ],
+                                        },
+                                        target: Var(
+                                            VarId(..),
+                                        ),
                                     },
-                                    target: Var(
-                                        VarId(..),
-                                    ),
                                 },
-                            },
+                            ),
                         ),
                         value: Call(
                             CallExpr {
@@ -75,8 +77,8 @@ Block(
                                                                 source: File(
                                                                     "$DIR/print_assign_expr.rs",
                                                                 ),
-                                                                start: 154,
-                                                                end: 157,
+                                                                start: 262,
+                                                                end: 265,
                                                             },
                                                         },
                                                         generics: GenericArgs {
@@ -106,40 +108,42 @@ Block(
                             id: ExprId(..),
                             span: SpanId(..),
                         },
-                        assignee: Path(
-                            PathExpr {
-                                data: CommonExprData {
-                                    _lifetime: PhantomData<&()>,
-                                    id: ExprId(..),
-                                    span: SpanId(..),
-                                },
-                                path: AstQPath {
-                                    self_ty: None,
-                                    path_ty: None,
-                                    path: AstPath {
-                                        segments: [
-                                            AstPathSegment {
-                                                ident: Ident {
-                                                    name: "x",
-                                                    span: Span {
-                                                        source: File(
-                                                            "$DIR/print_assign_expr.rs",
-                                                        ),
-                                                        start: 169,
-                                                        end: 170,
+                        assignee: Place(
+                            Path(
+                                PathExpr {
+                                    data: CommonExprData {
+                                        _lifetime: PhantomData<&()>,
+                                        id: ExprId(..),
+                                        span: SpanId(..),
+                                    },
+                                    path: AstQPath {
+                                        self_ty: None,
+                                        path_ty: None,
+                                        path: AstPath {
+                                            segments: [
+                                                AstPathSegment {
+                                                    ident: Ident {
+                                                        name: "a",
+                                                        span: Span {
+                                                            source: File(
+                                                                "$DIR/print_assign_expr.rs",
+                                                            ),
+                                                            start: 277,
+                                                            end: 278,
+                                                        },
+                                                    },
+                                                    generics: GenericArgs {
+                                                        args: [],
                                                     },
                                                 },
-                                                generics: GenericArgs {
-                                                    args: [],
-                                                },
-                                            },
-                                        ],
+                                            ],
+                                        },
+                                        target: Var(
+                                            VarId(..),
+                                        ),
                                     },
-                                    target: Var(
-                                        VarId(..),
-                                    ),
                                 },
-                            },
+                            ),
                         ),
                         value: IntLit(
                             IntLitExpr {
@@ -155,6 +159,402 @@ Block(
                         op: Some(
                             Add,
                         ),
+                    },
+                ),
+            ),
+            Expr(
+                Assign(
+                    AssignExpr {
+                        data: CommonExprData {
+                            _lifetime: PhantomData<&()>,
+                            id: ExprId(..),
+                            span: SpanId(..),
+                        },
+                        assignee: Slice(
+                            SlicePat {
+                                data: CommonPatData {
+                                    _lifetime: PhantomData<&()>,
+                                    span: SpanId(..),
+                                },
+                                elements: [
+                                    Place(
+                                        Path(
+                                            PathExpr {
+                                                data: CommonExprData {
+                                                    _lifetime: PhantomData<&()>,
+                                                    id: ExprId(..),
+                                                    span: SpanId(..),
+                                                },
+                                                path: AstQPath {
+                                                    self_ty: None,
+                                                    path_ty: None,
+                                                    path: AstPath {
+                                                        segments: [
+                                                            AstPathSegment {
+                                                                ident: Ident {
+                                                                    name: "a",
+                                                                    span: Span {
+                                                                        source: File(
+                                                                            "$DIR/print_assign_expr.rs",
+                                                                        ),
+                                                                        start: 294,
+                                                                        end: 295,
+                                                                    },
+                                                                },
+                                                                generics: GenericArgs {
+                                                                    args: [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    target: Var(
+                                                        VarId(..),
+                                                    ),
+                                                },
+                                            },
+                                        ),
+                                    ),
+                                    Place(
+                                        Path(
+                                            PathExpr {
+                                                data: CommonExprData {
+                                                    _lifetime: PhantomData<&()>,
+                                                    id: ExprId(..),
+                                                    span: SpanId(..),
+                                                },
+                                                path: AstQPath {
+                                                    self_ty: None,
+                                                    path_ty: None,
+                                                    path: AstPath {
+                                                        segments: [
+                                                            AstPathSegment {
+                                                                ident: Ident {
+                                                                    name: "b",
+                                                                    span: Span {
+                                                                        source: File(
+                                                                            "$DIR/print_assign_expr.rs",
+                                                                        ),
+                                                                        start: 297,
+                                                                        end: 298,
+                                                                    },
+                                                                },
+                                                                generics: GenericArgs {
+                                                                    args: [],
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    target: Var(
+                                                        VarId(..),
+                                                    ),
+                                                },
+                                            },
+                                        ),
+                                    ),
+                                ],
+                            },
+                        ),
+                        value: Array(
+                            ArrayExpr {
+                                data: CommonExprData {
+                                    _lifetime: PhantomData<&()>,
+                                    id: ExprId(..),
+                                    span: SpanId(..),
+                                },
+                                elements: [
+                                    IntLit(
+                                        IntLitExpr {
+                                            data: CommonExprData {
+                                                _lifetime: PhantomData<&()>,
+                                                id: ExprId(..),
+                                                span: SpanId(..),
+                                            },
+                                            value: 1,
+                                            suffix: None,
+                                        },
+                                    ),
+                                    IntLit(
+                                        IntLitExpr {
+                                            data: CommonExprData {
+                                                _lifetime: PhantomData<&()>,
+                                                id: ExprId(..),
+                                                span: SpanId(..),
+                                            },
+                                            value: 2,
+                                            suffix: None,
+                                        },
+                                    ),
+                                ],
+                                len_expr: None,
+                            },
+                        ),
+                        op: None,
+                    },
+                ),
+            ),
+            Expr(
+                Assign(
+                    AssignExpr {
+                        data: CommonExprData {
+                            _lifetime: PhantomData<&()>,
+                            id: ExprId(..),
+                            span: SpanId(..),
+                        },
+                        assignee: Struct(
+                            StructPat {
+                                data: CommonPatData {
+                                    _lifetime: PhantomData<&()>,
+                                    span: SpanId(..),
+                                },
+                                path: AstPath {
+                                    segments: [
+                                        AstPathSegment {
+                                            ident: Ident {
+                                                name: "S",
+                                                span: Span {
+                                                    source: File(
+                                                        "$DIR/print_assign_expr.rs",
+                                                    ),
+                                                    start: 318,
+                                                    end: 319,
+                                                },
+                                            },
+                                            generics: GenericArgs {
+                                                args: [],
+                                            },
+                                        },
+                                    ],
+                                },
+                                fields: [
+                                    StructFieldPat {
+                                        span: SpanId(..),
+                                        ident: SymbolId(..),
+                                        pat: Slice(
+                                            SlicePat {
+                                                data: CommonPatData {
+                                                    _lifetime: PhantomData<&()>,
+                                                    span: SpanId(..),
+                                                },
+                                                elements: [
+                                                    Wildcard(
+                                                        WildcardPat {
+                                                            data: CommonPatData {
+                                                                _lifetime: PhantomData<&()>,
+                                                                span: SpanId(..),
+                                                            },
+                                                        },
+                                                    ),
+                                                    Place(
+                                                        Path(
+                                                            PathExpr {
+                                                                data: CommonExprData {
+                                                                    _lifetime: PhantomData<&()>,
+                                                                    id: ExprId(..),
+                                                                    span: SpanId(..),
+                                                                },
+                                                                path: AstQPath {
+                                                                    self_ty: None,
+                                                                    path_ty: None,
+                                                                    path: AstPath {
+                                                                        segments: [
+                                                                            AstPathSegment {
+                                                                                ident: Ident {
+                                                                                    name: "a",
+                                                                                    span: Span {
+                                                                                        source: File(
+                                                                                            "$DIR/print_assign_expr.rs",
+                                                                                        ),
+                                                                                        start: 345,
+                                                                                        end: 346,
+                                                                                    },
+                                                                                },
+                                                                                generics: GenericArgs {
+                                                                                    args: [],
+                                                                                },
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                    target: Var(
+                                                                        VarId(..),
+                                                                    ),
+                                                                },
+                                                            },
+                                                        ),
+                                                    ),
+                                                    Rest(
+                                                        RestPat {
+                                                            data: CommonPatData {
+                                                                _lifetime: PhantomData<&()>,
+                                                                span: SpanId(..),
+                                                            },
+                                                        },
+                                                    ),
+                                                ],
+                                            },
+                                        ),
+                                    },
+                                    StructFieldPat {
+                                        span: SpanId(..),
+                                        ident: SymbolId(..),
+                                        pat: Tuple(
+                                            TuplePat {
+                                                data: CommonPatData {
+                                                    _lifetime: PhantomData<&()>,
+                                                    span: SpanId(..),
+                                                },
+                                                elements: [
+                                                    Place(
+                                                        Path(
+                                                            PathExpr {
+                                                                data: CommonExprData {
+                                                                    _lifetime: PhantomData<&()>,
+                                                                    id: ExprId(..),
+                                                                    span: SpanId(..),
+                                                                },
+                                                                path: AstQPath {
+                                                                    self_ty: None,
+                                                                    path_ty: None,
+                                                                    path: AstPath {
+                                                                        segments: [
+                                                                            AstPathSegment {
+                                                                                ident: Ident {
+                                                                                    name: "b",
+                                                                                    span: Span {
+                                                                                        source: File(
+                                                                                            "$DIR/print_assign_expr.rs",
+                                                                                        ),
+                                                                                        start: 373,
+                                                                                        end: 374,
+                                                                                    },
+                                                                                },
+                                                                                generics: GenericArgs {
+                                                                                    args: [],
+                                                                                },
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                    target: Var(
+                                                                        VarId(..),
+                                                                    ),
+                                                                },
+                                                            },
+                                                        ),
+                                                    ),
+                                                    Rest(
+                                                        RestPat {
+                                                            data: CommonPatData {
+                                                                _lifetime: PhantomData<&()>,
+                                                                span: SpanId(..),
+                                                            },
+                                                        },
+                                                    ),
+                                                ],
+                                            },
+                                        ),
+                                    },
+                                ],
+                                is_non_exhaustive: false,
+                            },
+                        ),
+                        value: Call(
+                            CallExpr {
+                                data: CommonExprData {
+                                    _lifetime: PhantomData<&()>,
+                                    id: ExprId(..),
+                                    span: SpanId(..),
+                                },
+                                operand: Path(
+                                    PathExpr {
+                                        data: CommonExprData {
+                                            _lifetime: PhantomData<&()>,
+                                            id: ExprId(..),
+                                            span: SpanId(..),
+                                        },
+                                        path: AstQPath {
+                                            self_ty: None,
+                                            path_ty: Some(
+                                                Path(
+                                                    PathTy {
+                                                        data: CommonTyData {
+                                                            _lifetime: PhantomData<&()>,
+                                                            span: Some(
+                                                                SpanId(..),
+                                                            ),
+                                                            is_syntactic: true,
+                                                        },
+                                                        path: AstQPath {
+                                                            self_ty: None,
+                                                            path_ty: None,
+                                                            path: AstPath {
+                                                                segments: [
+                                                                    AstPathSegment {
+                                                                        ident: Ident {
+                                                                            name: "S",
+                                                                            span: Span {
+                                                                                source: File(
+                                                                                    "$DIR/print_assign_expr.rs",
+                                                                                ),
+                                                                                start: 393,
+                                                                                end: 394,
+                                                                            },
+                                                                        },
+                                                                        generics: GenericArgs {
+                                                                            args: [],
+                                                                        },
+                                                                    },
+                                                                ],
+                                                            },
+                                                            target: Item(
+                                                                ItemId(..),
+                                                            ),
+                                                        },
+                                                    },
+                                                ),
+                                            ),
+                                            path: AstPath {
+                                                segments: [
+                                                    AstPathSegment {
+                                                        ident: Ident {
+                                                            name: "S",
+                                                            span: Span {
+                                                                source: File(
+                                                                    "$DIR/print_assign_expr.rs",
+                                                                ),
+                                                                start: 393,
+                                                                end: 394,
+                                                            },
+                                                        },
+                                                        generics: GenericArgs {
+                                                            args: [],
+                                                        },
+                                                    },
+                                                    AstPathSegment {
+                                                        ident: Ident {
+                                                            name: "default",
+                                                            span: Span {
+                                                                source: File(
+                                                                    "$DIR/print_assign_expr.rs",
+                                                                ),
+                                                                start: 396,
+                                                                end: 403,
+                                                            },
+                                                        },
+                                                        generics: GenericArgs {
+                                                            args: [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            target: Item(
+                                                ItemId(..),
+                                            ),
+                                        },
+                                    },
+                                ),
+                                args: [],
+                            },
+                        ),
+                        op: None,
                     },
                 ),
             ),

--- a/marker_lints/tests/ui/print_assign_expr.stdout
+++ b/marker_lints/tests/ui/print_assign_expr.stdout
@@ -1,0 +1,177 @@
+Block(
+    BlockExpr {
+        data: CommonExprData {
+            _lifetime: PhantomData<&()>,
+            id: ExprId(..),
+            span: SpanId(..),
+        },
+        stmts: [
+            Expr(
+                Assign(
+                    AssignExpr {
+                        data: CommonExprData {
+                            _lifetime: PhantomData<&()>,
+                            id: ExprId(..),
+                            span: SpanId(..),
+                        },
+                        assignee: Path(
+                            PathExpr {
+                                data: CommonExprData {
+                                    _lifetime: PhantomData<&()>,
+                                    id: ExprId(..),
+                                    span: SpanId(..),
+                                },
+                                path: AstQPath {
+                                    self_ty: None,
+                                    path_ty: None,
+                                    path: AstPath {
+                                        segments: [
+                                            AstPathSegment {
+                                                ident: Ident {
+                                                    name: "x",
+                                                    span: Span {
+                                                        source: File(
+                                                            "$DIR/print_assign_expr.rs",
+                                                        ),
+                                                        start: 150,
+                                                        end: 151,
+                                                    },
+                                                },
+                                                generics: GenericArgs {
+                                                    args: [],
+                                                },
+                                            },
+                                        ],
+                                    },
+                                    target: Var(
+                                        VarId(..),
+                                    ),
+                                },
+                            },
+                        ),
+                        value: Call(
+                            CallExpr {
+                                data: CommonExprData {
+                                    _lifetime: PhantomData<&()>,
+                                    id: ExprId(..),
+                                    span: SpanId(..),
+                                },
+                                operand: Path(
+                                    PathExpr {
+                                        data: CommonExprData {
+                                            _lifetime: PhantomData<&()>,
+                                            id: ExprId(..),
+                                            span: SpanId(..),
+                                        },
+                                        path: AstQPath {
+                                            self_ty: None,
+                                            path_ty: None,
+                                            path: AstPath {
+                                                segments: [
+                                                    AstPathSegment {
+                                                        ident: Ident {
+                                                            name: "bar",
+                                                            span: Span {
+                                                                source: File(
+                                                                    "$DIR/print_assign_expr.rs",
+                                                                ),
+                                                                start: 154,
+                                                                end: 157,
+                                                            },
+                                                        },
+                                                        generics: GenericArgs {
+                                                            args: [],
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                            target: Item(
+                                                ItemId(..),
+                                            ),
+                                        },
+                                    },
+                                ),
+                                args: [],
+                            },
+                        ),
+                        op: None,
+                    },
+                ),
+            ),
+            Expr(
+                Assign(
+                    AssignExpr {
+                        data: CommonExprData {
+                            _lifetime: PhantomData<&()>,
+                            id: ExprId(..),
+                            span: SpanId(..),
+                        },
+                        assignee: Path(
+                            PathExpr {
+                                data: CommonExprData {
+                                    _lifetime: PhantomData<&()>,
+                                    id: ExprId(..),
+                                    span: SpanId(..),
+                                },
+                                path: AstQPath {
+                                    self_ty: None,
+                                    path_ty: None,
+                                    path: AstPath {
+                                        segments: [
+                                            AstPathSegment {
+                                                ident: Ident {
+                                                    name: "x",
+                                                    span: Span {
+                                                        source: File(
+                                                            "$DIR/print_assign_expr.rs",
+                                                        ),
+                                                        start: 169,
+                                                        end: 170,
+                                                    },
+                                                },
+                                                generics: GenericArgs {
+                                                    args: [],
+                                                },
+                                            },
+                                        ],
+                                    },
+                                    target: Var(
+                                        VarId(..),
+                                    ),
+                                },
+                            },
+                        ),
+                        value: IntLit(
+                            IntLitExpr {
+                                data: CommonExprData {
+                                    _lifetime: PhantomData<&()>,
+                                    id: ExprId(..),
+                                    span: SpanId(..),
+                                },
+                                value: 1,
+                                suffix: None,
+                            },
+                        ),
+                        op: Some(
+                            Add,
+                        ),
+                    },
+                ),
+            ),
+        ],
+        expr: Some(
+            Tuple(
+                TupleExpr {
+                    data: CommonExprData {
+                        _lifetime: PhantomData<&()>,
+                        id: ExprId(..),
+                        span: SpanId(..),
+                    },
+                    elements: [],
+                },
+            ),
+        ),
+        is_unsafe: false,
+    },
+)
+


### PR DESCRIPTION
This PR adds the assign expression to the API. The implementation was a bit complicated design wise, I created https://github.com/rust-marker/design/issues/35 to discuss other solutions and review this representation before v1.0.0.

Before reviewing this, I suggest checking this [Playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=0da87ed83a1f80c61b026f54bf75d077) with *Show HIR* to see how rustc desugars some assign expressions. `#[clippy::dump]` and then *Tools > Clippy* can also always be helpful.

I also appreciate feedback on the design.

---

r? @Niki4tap Would you mind giving this a review? We can also wait a few days to see if we get any feedback on the design issue. On the other hand, we can always revert these changes :). Besides that, I'm trying to document all new nodes added to the API, we'll see how that goes ^^.

#52 