### PR TITLE
Emit lints using a diagnostic builder

### DIFF
--- a/marker_adapter/src/context.rs
+++ b/marker_adapter/src/context.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::needless_lifetimes, reason = "the lifetimes are destroyed by unsafe, but help with readability")]
+
 use marker_api::{
     ast::{
         item::{Body, ItemKind},
@@ -56,7 +58,7 @@ extern "C" fn lint_level_at(data: &(), lint: &'static Lint, node: EmissionNode) 
 
 extern "C" fn emit_diag<'a, 'ast>(data: &(), diag: &Diagnostic<'a, 'ast>) {
     let wrapper = unsafe { &*(data as *const ()).cast::<DriverContextWrapper>() };
-    wrapper.driver_cx.emit_diag(diag)
+    wrapper.driver_cx.emit_diag(diag);
 }
 
 #[allow(improper_ctypes_definitions, reason = "fp because `ItemKind` is non-exhaustive")]

--- a/marker_adapter/src/context.rs
+++ b/marker_adapter/src/context.rs
@@ -4,8 +4,9 @@ use marker_api::{
         BodyId, ExprId, ItemId, Span, SpanOwner, SymbolId,
     },
     context::DriverCallbacks,
+    diagnostic::{Diagnostic, EmissionNode},
     ffi::{self, FfiOption},
-    lint::Lint,
+    lint::{Level, Lint},
 };
 
 /// ### Safety
@@ -34,6 +35,8 @@ impl<'ast> DriverContextWrapper<'ast> {
     pub fn create_driver_callback(&'ast self) -> DriverCallbacks<'ast> {
         DriverCallbacks {
             driver_context: unsafe { &*(self as *const DriverContextWrapper).cast::<()>() },
+            lint_level_at,
+            emit_diag,
             emit_lint,
             item,
             body,
@@ -43,6 +46,17 @@ impl<'ast> DriverContextWrapper<'ast> {
             resolve_method_target,
         }
     }
+}
+
+#[allow(improper_ctypes_definitions, reason = "fp because `EmissionNode` are non-exhaustive")]
+extern "C" fn lint_level_at(data: &(), lint: &'static Lint, node: EmissionNode) -> Level {
+    let wrapper = unsafe { &*(data as *const ()).cast::<DriverContextWrapper>() };
+    wrapper.driver_cx.lint_level_at(lint, node)
+}
+
+extern "C" fn emit_diag<'a, 'ast>(data: &(), diag: &Diagnostic<'a, 'ast>) {
+    let wrapper = unsafe { &*(data as *const ()).cast::<DriverContextWrapper>() };
+    wrapper.driver_cx.emit_diag(diag)
 }
 
 #[allow(improper_ctypes_definitions, reason = "fp because `ItemKind` is non-exhaustive")]
@@ -56,7 +70,7 @@ extern "C" fn body<'ast>(data: &(), id: BodyId) -> &'ast Body<'ast> {
     wrapper.driver_cx.body(id)
 }
 
-extern "C" fn emit_lint(data: &(), lint: &'static Lint, msg: ffi::Str, span: &Span<'_>) {
+extern "C" fn emit_lint(data: &(), lint: &'static Lint, msg: ffi::FfiStr, span: &Span<'_>) {
     let wrapper = unsafe { &*(data as *const ()).cast::<DriverContextWrapper>() };
     wrapper.driver_cx.emit_lint(lint, (&msg).into(), span);
 }
@@ -66,12 +80,12 @@ extern "C" fn get_span<'ast>(data: &(), owner: &SpanOwner) -> &'ast Span<'ast> {
     wrapper.driver_cx.get_span(owner)
 }
 
-extern "C" fn span_snippet<'ast>(data: &(), span: &Span) -> ffi::FfiOption<ffi::Str<'ast>> {
+extern "C" fn span_snippet<'ast>(data: &(), span: &Span) -> ffi::FfiOption<ffi::FfiStr<'ast>> {
     let wrapper = unsafe { &*(data as *const ()).cast::<DriverContextWrapper>() };
     wrapper.driver_cx.span_snippet(span).map(Into::into).into()
 }
 
-extern "C" fn symbol_str<'ast>(data: &(), sym: SymbolId) -> ffi::Str<'ast> {
+extern "C" fn symbol_str<'ast>(data: &(), sym: SymbolId) -> ffi::FfiStr<'ast> {
     let wrapper = unsafe { &*(data as *const ()).cast::<DriverContextWrapper>() };
     wrapper.driver_cx.symbol_str(sym).into()
 }
@@ -82,6 +96,9 @@ extern "C" fn resolve_method_target(data: &(), id: ExprId) -> ItemId {
 }
 
 pub trait DriverContext<'ast> {
+    fn lint_level_at(&'ast self, lint: &'static Lint, node: EmissionNode) -> Level;
+    fn emit_diag(&'ast self, diag: &Diagnostic<'_, 'ast>);
+
     fn item(&'ast self, api_id: ItemId) -> Option<ItemKind<'ast>>;
     fn body(&'ast self, api_id: BodyId) -> &'ast Body<'ast>;
     fn emit_lint(&'ast self, lint: &'static Lint, msg: &str, span: &Span<'ast>);

--- a/marker_adapter/src/context.rs
+++ b/marker_adapter/src/context.rs
@@ -1,4 +1,7 @@
-#![allow(clippy::needless_lifetimes, reason = "the lifetimes are destroyed by unsafe, but help with readability")]
+#![allow(
+    clippy::needless_lifetimes,
+    reason = "the lifetimes are destroyed by unsafe, but help with readability"
+)]
 
 use marker_api::{
     ast::{
@@ -39,7 +42,6 @@ impl<'ast> DriverContextWrapper<'ast> {
             driver_context: unsafe { &*(self as *const DriverContextWrapper).cast::<()>() },
             lint_level_at,
             emit_diag,
-            emit_lint,
             item,
             body,
             get_span,
@@ -72,11 +74,6 @@ extern "C" fn body<'ast>(data: &(), id: BodyId) -> &'ast Body<'ast> {
     wrapper.driver_cx.body(id)
 }
 
-extern "C" fn emit_lint(data: &(), lint: &'static Lint, msg: ffi::FfiStr, span: &Span<'_>) {
-    let wrapper = unsafe { &*(data as *const ()).cast::<DriverContextWrapper>() };
-    wrapper.driver_cx.emit_lint(lint, (&msg).into(), span);
-}
-
 extern "C" fn get_span<'ast>(data: &(), owner: &SpanOwner) -> &'ast Span<'ast> {
     let wrapper = unsafe { &*(data as *const ()).cast::<DriverContextWrapper>() };
     wrapper.driver_cx.get_span(owner)
@@ -103,7 +100,6 @@ pub trait DriverContext<'ast> {
 
     fn item(&'ast self, api_id: ItemId) -> Option<ItemKind<'ast>>;
     fn body(&'ast self, api_id: BodyId) -> &'ast Body<'ast>;
-    fn emit_lint(&'ast self, lint: &'static Lint, msg: &str, span: &Span<'ast>);
     fn get_span(&'ast self, owner: &SpanOwner) -> &'ast Span<'ast>;
     fn span_snippet(&'ast self, span: &Span) -> Option<&'ast str>;
     fn symbol_str(&'ast self, api_id: SymbolId) -> &'ast str;

--- a/marker_api/src/ast/common.rs
+++ b/marker_api/src/ast/common.rs
@@ -19,31 +19,6 @@ pub enum Edition {
     Edition2021,
 }
 
-// FIXME: This will need to be updated according to rust-lang/rustfix#200
-#[non_exhaustive]
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub enum Applicability {
-    /// The suggestion is definitely what the user intended, or maintains the exact meaning of the
-    /// code. This suggestion should be automatically applied.
-    ///
-    /// In case of multiple `MachineApplicable` suggestions (whether as part of
-    /// the same `multipart_suggestion` or not), all of them should be
-    /// automatically applied.
-    MachineApplicable,
-
-    /// The suggestion may be what the user intended, but it is uncertain. The suggestion should
-    /// result in valid Rust code if it is applied.
-    MaybeIncorrect,
-
-    /// The suggestion contains placeholders like `(...)` or `{ /* fields */ }`. The suggestion
-    /// cannot be applied automatically because it will not result in valid Rust code. The user
-    /// will need to fill in the placeholders.
-    HasPlaceholders,
-
-    /// The suggestion can not be automatically applied or the applicability is unknown.
-    Unspecified,
-}
-
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum Abi {

--- a/marker_api/src/ast/common/id.rs
+++ b/marker_api/src/ast/common/id.rs
@@ -133,6 +133,7 @@ impl StmtId {
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "driver-api", visibility::make(pub))]
+#[allow(clippy::exhaustive_enums)] // Only driver public
 pub(crate) enum StmtIdInner {
     Expr(ExprId),
     Item(ItemId),

--- a/marker_api/src/ast/common/id.rs
+++ b/marker_api/src/ast/common/id.rs
@@ -55,6 +55,11 @@ new_id! {
 }
 
 new_id! {
+    ///  This ID uniquely identifies a field inside a struct during linting.
+    pub FieldId: u64
+}
+
+new_id! {
     /// This ID uniquely identifies a user defined type during linting.
     pub TyDefId: u64
 }
@@ -110,4 +115,35 @@ new_id! {
     /// use. Lint crates should always get [`String`] or `&str`.
     #[cfg_attr(feature = "driver-api", visibility::make(pub))]
     pub(crate) SymbolId: u32
+}
+
+new_id! {
+    /// This ID uniquely identifies a statement during linting.
+    pub StmtId: StmtIdInner
+}
+
+impl StmtId {
+    /// This is an extra constructor for api internal use. The `new_id` macro
+    /// only generates methods for drivers.
+    pub(crate) fn ast_new(data: StmtIdInner) -> Self {
+        Self { data }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "driver-api", visibility::make(pub))]
+pub(crate) enum StmtIdInner {
+    Expr(ExprId),
+    Item(ItemId),
+    LetStmt(LetStmtId),
+}
+
+new_id! {
+    /// **Unstable**
+    ///
+    /// This id is used to identify a `let` statement. It's intended to be used
+    /// inside [`StmtIdInner`]
+    #[cfg_attr(feature = "driver-api", visibility::make(pub))]
+    pub(crate) LetStmtId: u64
 }

--- a/marker_api/src/ast/common/id.rs
+++ b/marker_api/src/ast/common/id.rs
@@ -55,7 +55,7 @@ new_id! {
 }
 
 new_id! {
-    ///  This ID uniquely identifies a field inside a struct during linting.
+    /// This ID uniquely identifies a field inside a struct during linting.
     pub FieldId: u64
 }
 

--- a/marker_api/src/ast/common/span.rs
+++ b/marker_api/src/ast/common/span.rs
@@ -1,8 +1,8 @@
 use std::{marker::PhantomData, path::PathBuf};
 
-use crate::context::with_cx;
+use crate::{context::with_cx, diagnostic::Applicability};
 
-use super::{Applicability, AstPath, ItemId, SpanId, SymbolId};
+use super::{AstPath, ItemId, SpanId, SymbolId};
 
 #[repr(C)]
 #[doc(hidden)]

--- a/marker_api/src/ast/item.rs
+++ b/marker_api/src/ast/item.rs
@@ -224,6 +224,12 @@ macro_rules! impl_item_data {
                 todo!()
             }
         }
+
+        impl<'ast> From<&'ast $self_name<'ast>> for crate::ast::item::ItemKind<'ast> {
+            fn from(value: &'ast $self_name<'ast>) -> Self {
+                $crate::ast::item::ItemKind::$enum_name(value)
+            }
+        }
     };
 }
 

--- a/marker_api/src/ast/item/adt_item.rs
+++ b/marker_api/src/ast/item/adt_item.rs
@@ -1,6 +1,6 @@
 use crate::ast::generic::GenericParams;
 use crate::ast::ty::TyKind;
-use crate::ast::{Span, SpanId, SymbolId, VariantId};
+use crate::ast::{FieldId, Span, SpanId, SymbolId, VariantId};
 use crate::context::with_cx;
 use crate::ffi::FfiSlice;
 
@@ -263,6 +263,7 @@ impl<'ast> AdtKind<'ast> {
 #[repr(C)]
 #[derive(Debug)]
 pub struct Field<'ast> {
+    id: FieldId,
     vis: Visibility<'ast>,
     ident: SymbolId,
     ty: TyKind<'ast>,
@@ -270,6 +271,10 @@ pub struct Field<'ast> {
 }
 
 impl<'ast> Field<'ast> {
+    pub fn id(&self) -> FieldId {
+        self.id
+    }
+
     /// The [`Visibility`] of this item.
     pub fn visibility(&self) -> &Visibility<'ast> {
         &self.vis
@@ -294,7 +299,13 @@ impl<'ast> Field<'ast> {
 
 #[cfg(feature = "driver-api")]
 impl<'ast> Field<'ast> {
-    pub fn new(vis: Visibility<'ast>, ident: SymbolId, ty: TyKind<'ast>, span: SpanId) -> Self {
-        Self { vis, ident, ty, span }
+    pub fn new(id: FieldId, vis: Visibility<'ast>, ident: SymbolId, ty: TyKind<'ast>, span: SpanId) -> Self {
+        Self {
+            id,
+            vis,
+            ident,
+            ty,
+            span,
+        }
     }
 }

--- a/marker_api/src/ast/stmt.rs
+++ b/marker_api/src/ast/stmt.rs
@@ -1,6 +1,6 @@
 use crate::{context::with_cx, ffi::FfiOption};
 
-use super::{expr::ExprKind, item::ItemKind, pat::PatKind, ty::TyKind, Span, SpanId};
+use super::{expr::ExprKind, item::ItemKind, pat::PatKind, ty::TyKind, LetStmtId, Span, SpanId, StmtId};
 
 #[repr(C)]
 #[non_exhaustive]
@@ -14,6 +14,7 @@ pub enum StmtKind<'ast> {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct LetStmt<'ast> {
+    id: LetStmtId,
     span: SpanId,
     pat: PatKind<'ast>,
     ty: FfiOption<TyKind<'ast>>,
@@ -22,6 +23,10 @@ pub struct LetStmt<'ast> {
 }
 
 impl<'ast> LetStmt<'ast> {
+    pub fn id(&self) -> StmtId {
+        StmtId::ast_new(super::StmtIdInner::LetStmt(self.id))
+    }
+
     pub fn span(&self) -> &Span<'ast> {
         with_cx(self, |cx| cx.get_span(self.span))
     }
@@ -50,6 +55,7 @@ impl<'ast> LetStmt<'ast> {
 #[cfg(feature = "driver-api")]
 impl<'ast> LetStmt<'ast> {
     pub fn new(
+        id: LetStmtId,
         span: SpanId,
         pat: PatKind<'ast>,
         ty: Option<TyKind<'ast>>,
@@ -57,6 +63,7 @@ impl<'ast> LetStmt<'ast> {
         els: Option<ExprKind<'ast>>,
     ) -> Self {
         Self {
+            id,
             span,
             pat,
             ty: ty.into(),

--- a/marker_api/src/ast/stmt.rs
+++ b/marker_api/src/ast/stmt.rs
@@ -1,6 +1,6 @@
 use crate::{context::with_cx, ffi::FfiOption};
 
-use super::{expr::ExprKind, item::ItemKind, pat::PatKind, ty::TyKind, LetStmtId, Span, SpanId, StmtId};
+use super::{expr::ExprKind, item::ItemKind, pat::PatKind, ty::TyKind, LetStmtId, Span, SpanId, StmtId, StmtIdInner};
 
 #[repr(C)]
 #[non_exhaustive]
@@ -9,6 +9,24 @@ pub enum StmtKind<'ast> {
     Item(ItemKind<'ast>),
     Let(&'ast LetStmt<'ast>),
     Expr(ExprKind<'ast>),
+}
+
+impl<'ast> StmtKind<'ast> {
+    pub fn id(&self) -> StmtId {
+        match self {
+            StmtKind::Item(node) => StmtId::ast_new(StmtIdInner::Item(node.id())),
+            StmtKind::Let(node) => node.id(),
+            StmtKind::Expr(node) => StmtId::ast_new(StmtIdInner::Expr(node.id())),
+        }
+    }
+
+    pub fn span(&self) -> &Span<'ast> {
+        match self {
+            StmtKind::Item(node) => node.span(),
+            StmtKind::Let(node) => node.span(),
+            StmtKind::Expr(node) => node.span(),
+        }
+    }
 }
 
 #[repr(C)]
@@ -24,7 +42,7 @@ pub struct LetStmt<'ast> {
 
 impl<'ast> LetStmt<'ast> {
     pub fn id(&self) -> StmtId {
-        StmtId::ast_new(super::StmtIdInner::LetStmt(self.id))
+        StmtId::ast_new(StmtIdInner::LetStmt(self.id))
     }
 
     pub fn span(&self) -> &Span<'ast> {

--- a/marker_api/src/context.rs
+++ b/marker_api/src/context.rs
@@ -133,21 +133,6 @@ impl<'ast> AstContext<'ast> {
         self.driver.call_emit_diagnostic(diag);
     }
 
-    /// This function emits a lint at the current node with the given
-    /// message and span.
-    ///
-    /// For rustc the text output will look roughly to this:
-    /// ```text
-    /// error: ducks can't talk
-    ///  --> $DIR/file.rs:17:5
-    ///    |
-    /// 17 |     println!("The duck said: 'Hello, World!'");
-    ///    |
-    /// ```
-    pub fn emit_lint_old(&self, lint: &'static Lint, msg: &str, span: &Span<'ast>) {
-        self.driver.call_emit_lint(lint, msg, span);
-    }
-
     /// This returns the [`ItemKind`] belonging to the given [`ItemId`]. It can
     /// return `None` in special cases depending on the used driver.
     ///
@@ -210,7 +195,6 @@ struct DriverCallbacks<'ast> {
     pub emit_diag: for<'a> extern "C" fn(&'ast (), &'a Diagnostic<'a, 'ast>),
 
     // Public utility
-    pub emit_lint: for<'a> extern "C" fn(&'ast (), &'static Lint, ffi::FfiStr<'a>, &Span<'ast>),
     pub item: extern "C" fn(&'ast (), id: ItemId) -> ffi::FfiOption<ItemKind<'ast>>,
     pub body: extern "C" fn(&'ast (), id: BodyId) -> &'ast Body<'ast>,
 
@@ -230,9 +214,6 @@ impl<'ast> DriverCallbacks<'ast> {
         (self.emit_diag)(self.driver_context, diag);
     }
 
-    fn call_emit_lint(&self, lint: &'static Lint, msg: &str, span: &Span<'ast>) {
-        (self.emit_lint)(self.driver_context, lint, msg.into(), span);
-    }
     fn call_item(&self, id: ItemId) -> Option<ItemKind<'ast>> {
         (self.item)(self.driver_context, id).copy()
     }

--- a/marker_api/src/context.rs
+++ b/marker_api/src/context.rs
@@ -5,8 +5,9 @@ use crate::{
         item::{Body, ItemKind},
         BodyId, ExprId, ItemId, Span, SpanOwner, SymbolId,
     },
+    diagnostic::{Diagnostic, DiagnosticBuilder, EmissionNode},
     ffi,
-    lint::Lint,
+    lint::{Level, Lint},
 };
 
 thread_local! {
@@ -105,6 +106,32 @@ impl<'ast> AstContext<'ast> {
 }
 
 impl<'ast> AstContext<'ast> {
+    pub fn lint_level_at(&self, lint: &'static Lint, node: impl Into<EmissionNode>) -> Level {
+        self.driver.call_lint_level_at(lint, node.into())
+    }
+
+    pub fn emit_lint<F>(
+        &self,
+        lint: &'static Lint,
+        node: impl Into<EmissionNode>,
+        msg: impl ToString,
+        span: &Span<'ast>,
+        decorate: F,
+    ) where
+        F: FnOnce(&mut DiagnosticBuilder<'ast>),
+    {
+        let node = node.into();
+        if self.lint_level_at(lint, node) != Level::Allow {
+            let mut builder = DiagnosticBuilder::new(lint, node, msg.to_string(), span.clone());
+            decorate(&mut builder);
+            builder.emit(self)
+        }
+    }
+
+    pub(crate) fn emit_diagnostic<'a>(&self, diag: &'a Diagnostic<'a, 'ast>) {
+        self.driver.call_emit_diagnostic(diag)
+    }
+
     /// This function emits a lint at the current node with the given
     /// message and span.
     ///
@@ -116,7 +143,7 @@ impl<'ast> AstContext<'ast> {
     /// 17 |     println!("The duck said: 'Hello, World!'");
     ///    |
     /// ```
-    pub fn emit_lint(&self, lint: &'static Lint, msg: &str, span: &Span<'ast>) {
+    pub fn emit_lint_old(&self, lint: &'static Lint, msg: &str, span: &Span<'ast>) {
         self.driver.call_emit_lint(lint, msg, span);
     }
 
@@ -177,19 +204,31 @@ struct DriverCallbacks<'ast> {
     /// get its own context.
     pub driver_context: &'ast (),
 
+    // Lint emission and information
+    pub lint_level_at: extern "C" fn(&'ast (), &'static Lint, EmissionNode) -> Level,
+    pub emit_diag: for<'a> extern "C" fn(&'ast (), &'a Diagnostic<'a, 'ast>),
+
     // Public utility
-    pub emit_lint: for<'a> extern "C" fn(&'ast (), &'static Lint, ffi::Str<'a>, &Span<'ast>),
+    pub emit_lint: for<'a> extern "C" fn(&'ast (), &'static Lint, ffi::FfiStr<'a>, &Span<'ast>),
     pub item: extern "C" fn(&'ast (), id: ItemId) -> ffi::FfiOption<ItemKind<'ast>>,
     pub body: extern "C" fn(&'ast (), id: BodyId) -> &'ast Body<'ast>,
 
     // Internal utility
     pub get_span: extern "C" fn(&'ast (), &SpanOwner) -> &'ast Span<'ast>,
-    pub span_snippet: extern "C" fn(&'ast (), &Span) -> ffi::FfiOption<ffi::Str<'ast>>,
-    pub symbol_str: extern "C" fn(&'ast (), SymbolId) -> ffi::Str<'ast>,
+    pub span_snippet: extern "C" fn(&'ast (), &Span) -> ffi::FfiOption<ffi::FfiStr<'ast>>,
+    pub symbol_str: extern "C" fn(&'ast (), SymbolId) -> ffi::FfiStr<'ast>,
     pub resolve_method_target: extern "C" fn(&'ast (), ExprId) -> ItemId,
 }
 
 impl<'ast> DriverCallbacks<'ast> {
+    fn call_lint_level_at(&self, lint: &'static Lint, node: EmissionNode) -> Level {
+        (self.lint_level_at)(self.driver_context, lint, node)
+    }
+
+    fn call_emit_diagnostic<'a>(&self, diag: &'a Diagnostic<'a, 'ast>) {
+        (self.emit_diag)(self.driver_context, diag)
+    }
+
     fn call_emit_lint(&self, lint: &'static Lint, msg: &str, span: &Span<'ast>) {
         (self.emit_lint)(self.driver_context, lint, msg.into(), span);
     }
@@ -200,7 +239,7 @@ impl<'ast> DriverCallbacks<'ast> {
         (self.get_span)(self.driver_context, span_owner)
     }
     fn call_span_snippet(&self, span: &Span) -> Option<String> {
-        let result: Option<ffi::Str> = (self.span_snippet)(self.driver_context, span).into();
+        let result: Option<ffi::FfiStr> = (self.span_snippet)(self.driver_context, span).into();
         result.map(|x| x.to_string())
     }
     fn call_symbol_str(&self, sym: SymbolId) -> &'ast str {

--- a/marker_api/src/context.rs
+++ b/marker_api/src/context.rs
@@ -110,6 +110,7 @@ impl<'ast> AstContext<'ast> {
         self.driver.call_lint_level_at(lint, node.into())
     }
 
+    #[allow(clippy::needless_pass_by_value)] // `&impl ToSting`
     pub fn emit_lint<F>(
         &self,
         lint: &'static Lint,
@@ -124,12 +125,12 @@ impl<'ast> AstContext<'ast> {
         if self.lint_level_at(lint, node) != Level::Allow {
             let mut builder = DiagnosticBuilder::new(lint, node, msg.to_string(), span.clone());
             decorate(&mut builder);
-            builder.emit(self)
+            builder.emit(self);
         }
     }
 
     pub(crate) fn emit_diagnostic<'a>(&self, diag: &'a Diagnostic<'a, 'ast>) {
-        self.driver.call_emit_diagnostic(diag)
+        self.driver.call_emit_diagnostic(diag);
     }
 
     /// This function emits a lint at the current node with the given
@@ -226,7 +227,7 @@ impl<'ast> DriverCallbacks<'ast> {
     }
 
     fn call_emit_diagnostic<'a>(&self, diag: &'a Diagnostic<'a, 'ast>) {
-        (self.emit_diag)(self.driver_context, diag)
+        (self.emit_diag)(self.driver_context, diag);
     }
 
     fn call_emit_lint(&self, lint: &'static Lint, msg: &str, span: &Span<'ast>) {

--- a/marker_api/src/context.rs
+++ b/marker_api/src/context.rs
@@ -110,7 +110,7 @@ impl<'ast> AstContext<'ast> {
         self.driver.call_lint_level_at(lint, node.into())
     }
 
-    #[allow(clippy::needless_pass_by_value)] // `&impl ToSting`
+    #[allow(clippy::needless_pass_by_value)] // `&impl ToString`
     pub fn emit_lint<F>(
         &self,
         lint: &'static Lint,

--- a/marker_api/src/diagnostic.rs
+++ b/marker_api/src/diagnostic.rs
@@ -1,0 +1,300 @@
+use crate::{
+    ast::{ExprId, FieldId, ItemId, Span, StmtId, VariantId},
+    context::AstContext,
+    ffi::{FfiSlice, FfiStr},
+    lint::Lint,
+};
+
+/// This builder creates the diagnostic object which will be emitted by the driver.
+/// The documentation will showcase the messages in rustc's console emission style,
+/// the actual display depends on the driver.
+pub struct DiagnosticBuilder<'ast> {
+    lint: &'static Lint,
+    msg: String,
+    node: EmissionNode,
+    span: Span<'ast>,
+    parts: Vec<DiagnosticPart<String, Span<'ast>>>,
+}
+
+impl<'ast> DiagnosticBuilder<'ast> {
+    pub(crate) fn new(lint: &'static Lint, node: EmissionNode, msg: String, span: Span<'ast>) -> Self {
+        Self {
+            lint,
+            msg,
+            node,
+            span,
+            parts: vec![],
+        }
+    }
+
+    /// This function adds a note to the diagnostic message. Notes are intended
+    /// to provide additional context or explanations about the diagnostic.
+    ///
+    /// From rustc a text note would be displayed like this:
+    /// ```text
+    ///  warning: <lint message>
+    ///  --> path/file.rs:1:1
+    ///   |
+    /// 1 | expression
+    ///   | ^^^^^^^^^^
+    ///   |
+    ///   = note: <text>               <-- The note added by this function
+    /// ```
+    ///
+    /// [`Self::span_note`] can be used to highlight a relevant [`Span`].
+    pub fn note(&mut self, msg: impl ToString) {
+        self.parts.push(DiagnosticPart::Note { msg: msg.to_string() });
+    }
+
+    /// This function adds a note with a [`Span`] to the diagnostic message.
+    /// Spanned notes are intended to highlight relevant code snippets or
+    /// help with explanations.
+    ///
+    /// From rustc a spanned note would be displayed like this:
+    /// ```text
+    ///  warning: <lint message>
+    ///  --> path/file.rs:1:1
+    ///   |
+    /// 1 | expression
+    ///   | ^^^^^^^^^^
+    ///   |
+    /// note: <text>                   <--
+    ///  --> path/file.rs:2:1          <--
+    ///   |                            <-- The spanned note added by this function
+    /// 1 | context                    <--
+    ///   | ^^^^^^^                    <--
+    /// ```
+    ///
+    /// [`Self::note`] can be used to add text notes without a span.
+    pub fn span_note(&mut self, msg: impl ToString, span: &Span<'ast>) {
+        self.parts.push(DiagnosticPart::NoteSpan {
+            msg: msg.to_string(),
+            span: span.clone(),
+        });
+    }
+
+    /// This function adds a help message. Help messages are intended to provide
+    /// additional information about how the issue can be solved.
+    ///
+    /// From rustc a text help message would be displayed like this:
+    /// ```text
+    ///  warning: <lint message>
+    ///  --> path/file.rs:1:1
+    ///   |
+    /// 1 | expression
+    ///   | ^^^^^^^^^^
+    ///   |
+    ///   = help: <text>               <-- The help message added by this function
+    /// ```
+    ///
+    /// [`Self::span_help`] can be used to highlight a relevant [`Span`].
+    /// [`Self::span_suggestion`] can be used to add a help message with a suggestion.
+    pub fn help(&mut self, msg: impl ToString) -> &mut Self {
+        self.parts.push(DiagnosticPart::Help { msg: msg.to_string() });
+        self
+    }
+
+    /// This function adds a help message with a [`Span`]. Spanned help messages
+    /// are intended to highlight relevant code snippets that can be adapted to
+    /// potentualy solve the problem.
+    ///
+    /// From rustc a spanned help message would be displayed like this:
+    /// ```text
+    ///  warning: <lint message>
+    ///  --> path/file.rs:1:1
+    ///   |
+    /// 1 | expression
+    ///   | ^^^^^^^^^^
+    ///   |
+    /// help: <text>                   <--
+    ///  --> path/file.rs:2:1          <--
+    ///   |                            <-- The spanned note added by this function
+    /// 1 | code_to_change             <--
+    ///   | ^^^^^^^^^^^^^^             <--
+    /// ```
+    ///
+    /// [`Self::help`] can be used to add a text help message without a [`Span`].
+    /// [`Self::span_suggestion`] can be used to add a help message with a suggestion.
+    pub fn span_help(&mut self, msg: impl ToString, span: &Span<'ast>) {
+        self.parts.push(DiagnosticPart::HelpSpan {
+            msg: msg.to_string(),
+            span: span.clone(),
+        });
+    }
+
+    /// This function adds a spanned help message with a suggestion. The suggestion
+    /// is a string which can be used to replace the marked [`Span`]. The confidence
+    /// of a suggestion is expressed with the [`Applicability`].
+    ///
+    /// From rustc a suggestion would be displayed like this:
+    /// ```text
+    ///  warning: <lint message>
+    ///  --> path/file.rs:1:1
+    ///   |
+    /// 1 | expression
+    ///   | ^^^^^^^^^^ help: <msg>: `<suggestion>`      <-- The suggestion added by this function
+    ///   |
+    /// ```
+    ///
+    /// It's common to use `try` as a short suggestion message, if no further
+    /// explanation is required.
+    pub fn span_suggestion(
+        &mut self,
+        msg: impl ToString,
+        span: &Span<'ast>,
+        suggestion: impl ToString,
+        app: Applicability,
+    ) {
+        self.parts.push(DiagnosticPart::Suggestion {
+            msg: msg.to_string(),
+            span: span.clone(),
+            sugg: suggestion.to_string(),
+            app,
+        });
+    }
+
+    pub(crate) fn emit<'builder>(&'builder self, cx: &AstContext<'ast>) {
+        let parts: Vec<_> = self
+            .parts
+            .iter()
+            .map(|builder_part| builder_part.to_ffi_part())
+            .collect();
+        let diag = Diagnostic {
+            lint: self.lint,
+            msg: self.msg.as_str().into(),
+            node: self.node,
+            span: &self.span,
+            parts: parts.as_slice().into(),
+        };
+        cx.emit_diagnostic(&diag)
+    }
+}
+
+#[repr(C)]
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy)]
+pub enum EmissionNode {
+    Expr(ExprId),
+    Item(ItemId),
+    Stmt(StmtId),
+    Field(FieldId),
+    Variant(VariantId),
+}
+
+macro_rules! impl_into_emission_node_for {
+    ($variant:ident, $ty:ty) => {
+        impl From<$ty> for EmissionNode {
+            fn from(value: $ty) -> Self {
+                EmissionNode::$variant(value)
+            }
+        }
+
+        impl From<&$ty> for EmissionNode {
+            fn from(value: &$ty) -> Self {
+                EmissionNode::$variant(*value)
+            }
+        }
+    };
+}
+
+use impl_into_emission_node_for;
+
+impl_into_emission_node_for!(Expr, ExprId);
+impl_into_emission_node_for!(Item, ItemId);
+impl_into_emission_node_for!(Stmt, StmtId);
+impl_into_emission_node_for!(Field, FieldId);
+impl_into_emission_node_for!(Variant, VariantId);
+
+#[repr(C)]
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "driver-api", visibility::make(pub))]
+pub(crate) enum DiagnosticPart<St, Sp> {
+    Help {
+        msg: St,
+    },
+    HelpSpan {
+        msg: St,
+        span: Sp,
+    },
+    Note {
+        msg: St,
+    },
+    NoteSpan {
+        msg: St,
+        span: Sp,
+    },
+    Suggestion {
+        msg: St,
+        span: Sp,
+        sugg: St,
+        app: Applicability,
+    },
+}
+
+impl<'ast> DiagnosticPart<String, Span<'ast>> {
+    fn to_ffi_part<'part>(&'part self) -> DiagnosticPart<FfiStr<'part>, &'part Span<'ast>> {
+        match self {
+            DiagnosticPart::Help { msg } => DiagnosticPart::Help { msg: msg.into() },
+            DiagnosticPart::HelpSpan { msg, span } => DiagnosticPart::HelpSpan { msg: msg.into(), span },
+            DiagnosticPart::Note { msg } => DiagnosticPart::Note { msg: msg.into() },
+            DiagnosticPart::NoteSpan { msg, span } => DiagnosticPart::NoteSpan { msg: msg.into(), span },
+            DiagnosticPart::Suggestion { msg, span, sugg, app } => DiagnosticPart::Suggestion {
+                msg: msg.into(),
+                span,
+                sugg: sugg.into(),
+                app: *app,
+            },
+        }
+    }
+}
+
+/// Indicates the confidence in the correctness of a suggestion.
+///
+/// All suggestions are marked with an `Applicability`. Tools use the applicability of a
+/// suggestion to determine whether it should be automatically applied or if the user
+/// should be consulted before applying the suggestion.
+#[repr(C)]
+#[non_exhaustive]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+// FIXME: This will need to be updated according to rust-lang/rustfix#200
+pub enum Applicability {
+    /// The suggestion is definitely what the user intended, or maintains the exact
+    /// meaning of the code. This suggestion should be automatically applied.
+    ///
+    /// In case of multiple `MachineApplicable` suggestions (whether as part of
+    /// the same `multipart_suggestion` or not), all of them should be
+    /// automatically applied.
+    MachineApplicable,
+
+    /// The suggestion may be what the user intended, but it is uncertain. The suggestion
+    /// should result in valid Rust code if it is applied.
+    MaybeIncorrect,
+
+    /// The suggestion contains placeholders like `(...)` or `{ /* fields */ }`. The
+    /// suggestion cannot be applied automatically because it will not result in
+    /// valid Rust code. The user will need to fill in the placeholders.
+    HasPlaceholders,
+
+    /// The applicability of the suggestion is unknown.
+    Unspecified,
+}
+
+/// This is the diagnostic object for the lint emission. It is constructed
+/// with by the [`DiagnosticBuilder`].
+#[repr(C)]
+#[derive(Debug)]
+#[cfg_attr(feature = "driver-api", visibility::make(pub))]
+pub(crate) struct Diagnostic<'builder, 'ast> {
+    pub lint: &'static Lint,
+    pub msg: FfiStr<'builder>,
+    pub node: EmissionNode,
+    pub span: &'builder Span<'ast>,
+    pub parts: FfiSlice<'builder, DiagnosticPart<FfiStr<'builder>, &'builder Span<'ast>>>,
+}
+
+impl<'builder, 'ast> Diagnostic<'builder, 'ast> {
+    pub fn msg(&self) -> &str {
+        self.msg.get()
+    }
+}

--- a/marker_api/src/diagnostic.rs
+++ b/marker_api/src/diagnostic.rs
@@ -16,7 +16,7 @@ pub struct DiagnosticBuilder<'ast> {
     parts: Vec<DiagnosticPart<String, Span<'ast>>>,
 }
 
-#[allow(clippy::needless_pass_by_value)] // `&impl String` doesn't work
+#[allow(clippy::needless_pass_by_value)] // `&impl ToString` doesn't work
 impl<'ast> DiagnosticBuilder<'ast> {
     pub(crate) fn new(lint: &'static Lint, node: EmissionNode, msg: String, span: Span<'ast>) -> Self {
         Self {
@@ -193,8 +193,6 @@ macro_rules! impl_into_emission_node_for {
         }
     };
 }
-
-use impl_into_emission_node_for;
 
 impl_into_emission_node_for!(Expr, ExprId);
 impl_into_emission_node_for!(Item, ItemId);

--- a/marker_api/src/diagnostic.rs
+++ b/marker_api/src/diagnostic.rs
@@ -155,11 +155,7 @@ impl<'ast> DiagnosticBuilder<'ast> {
     }
 
     pub(crate) fn emit<'builder>(&'builder self, cx: &AstContext<'ast>) {
-        let parts: Vec<_> = self
-            .parts
-            .iter()
-            .map(DiagnosticPart::to_ffi_part)
-            .collect();
+        let parts: Vec<_> = self.parts.iter().map(DiagnosticPart::to_ffi_part).collect();
         let diag = Diagnostic {
             lint: self.lint,
             msg: self.msg.as_str().into(),

--- a/marker_api/src/diagnostic.rs
+++ b/marker_api/src/diagnostic.rs
@@ -16,6 +16,7 @@ pub struct DiagnosticBuilder<'ast> {
     parts: Vec<DiagnosticPart<String, Span<'ast>>>,
 }
 
+#[allow(clippy::needless_pass_by_value)] // `&impl String` doesn't work
 impl<'ast> DiagnosticBuilder<'ast> {
     pub(crate) fn new(lint: &'static Lint, node: EmissionNode, msg: String, span: Span<'ast>) -> Self {
         Self {
@@ -157,7 +158,7 @@ impl<'ast> DiagnosticBuilder<'ast> {
         let parts: Vec<_> = self
             .parts
             .iter()
-            .map(|builder_part| builder_part.to_ffi_part())
+            .map(DiagnosticPart::to_ffi_part)
             .collect();
         let diag = Diagnostic {
             lint: self.lint,
@@ -166,7 +167,7 @@ impl<'ast> DiagnosticBuilder<'ast> {
             span: &self.span,
             parts: parts.as_slice().into(),
         };
-        cx.emit_diagnostic(&diag)
+        cx.emit_diagnostic(&diag);
     }
 }
 

--- a/marker_api/src/ffi.rs
+++ b/marker_api/src/ffi.rs
@@ -14,13 +14,13 @@ use std::{marker::PhantomData, slice};
 
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct Str<'a> {
+pub struct FfiStr<'a> {
     _lifetime: PhantomData<&'a ()>,
     data: *const u8,
     len: usize,
 }
 
-impl<'a> From<&'a str> for Str<'a> {
+impl<'a> From<&'a str> for FfiStr<'a> {
     fn from(source: &'a str) -> Self {
         Self {
             _lifetime: PhantomData,
@@ -30,7 +30,13 @@ impl<'a> From<&'a str> for Str<'a> {
     }
 }
 
-impl<'a> Str<'a> {
+impl<'a> From<&'a String> for FfiStr<'a> {
+    fn from(source: &'a String) -> Self {
+        source.as_str().into()
+    }
+}
+
+impl<'a> FfiStr<'a> {
     pub fn get(&self) -> &'a str {
         unsafe {
             let data = slice::from_raw_parts(self.data, self.len);
@@ -39,8 +45,8 @@ impl<'a> Str<'a> {
     }
 }
 
-impl<'a> From<&Str<'a>> for &'a str {
-    fn from(src: &Str<'a>) -> Self {
+impl<'a> From<&FfiStr<'a>> for &'a str {
+    fn from(src: &FfiStr<'a>) -> Self {
         unsafe {
             let data = slice::from_raw_parts(src.data, src.len);
 
@@ -49,10 +55,16 @@ impl<'a> From<&Str<'a>> for &'a str {
     }
 }
 
-impl<'a> ToString for Str<'a> {
+impl<'a> ToString for FfiStr<'a> {
     fn to_string(&self) -> String {
         let base: &str = self.into();
         base.to_string()
+    }
+}
+
+impl std::fmt::Debug for FfiStr<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.get())
     }
 }
 

--- a/marker_api/src/lib.rs
+++ b/marker_api/src/lib.rs
@@ -12,6 +12,7 @@ pub static MARKER_API_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub mod ast;
 pub mod context;
+pub mod diagnostic;
 pub mod interface;
 pub mod lint;
 

--- a/marker_api/src/lint.rs
+++ b/marker_api/src/lint.rs
@@ -28,7 +28,7 @@ pub struct Lint {
     /// Description of the lint or the issue it detects.
     ///
     /// e.g., "imports that are never used"
-    pub explaination: &'static str,
+    pub explanation: &'static str,
 
     /// The level of macro reporting.
     ///
@@ -52,38 +52,10 @@ pub enum MacroReport {
     All,
 }
 
-/// Indicates the confidence in the correctness of a suggestion.
-///
-/// All suggestions are marked with an `Applicability`. Tools use the applicability of a
-/// suggestion to determine whether it should be automatically applied or if the user
-/// should be consulted before applying the suggestion.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-#[non_exhaustive]
-pub enum Applicability {
-    /// The suggestion is definitely what the user intended, or maintains the exact
-    /// meaning of the code. This suggestion should be automatically applied.
-    ///
-    /// In case of multiple `MachineApplicable` suggestions (whether as part of
-    /// the same `multipart_suggestion` or not), all of them should be
-    /// automatically applied.
-    MachineApplicable,
-
-    /// The suggestion may be what the user intended, but it is uncertain. The suggestion
-    /// should result in valid Rust code if it is applied.
-    MaybeIncorrect,
-
-    /// The suggestion contains placeholders like `(...)` or `{ /* fields */ }`. The
-    /// suggestion cannot be applied automatically because it will not result in
-    /// valid Rust code. The user will need to fill in the placeholders.
-    HasPlaceholders,
-
-    /// The applicability of the suggestion is unknown.
-    Unspecified,
-}
-
 /// Setting for how to handle a lint.
-#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
+#[repr(C)]
 #[non_exhaustive]
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
 pub enum Level {
     /// The lint is allowed. A created diagnostic will not be emitted to the user by default.
     /// This level can be overridden. It's useful for rather strict lints.
@@ -112,17 +84,17 @@ pub enum Level {
 
 #[macro_export]
 macro_rules! declare_lint {
-    ($(#[$attr:meta])* $NAME: ident, $LEVEL: ident, $EXPLAINATION: literal $(,)?) => {
-        $crate::lint::declare_lint!{$(#[$attr])* $NAME, $LEVEL, $EXPLAINATION, $crate::lint::MacroReport::No }
+    ($(#[$attr:meta])* $NAME: ident, $LEVEL: ident, $EXPLANATION: literal $(,)?) => {
+        $crate::lint::declare_lint!{$(#[$attr])* $NAME, $LEVEL, $EXPLANATION, $crate::lint::MacroReport::No }
     };
     ($(#[$attr:meta])* $NAME: ident, $LEVEL: ident,
-        $EXPLAINATION: literal, $REPORT_IN_MACRO: expr $(,)?
+        $EXPLANATION: literal, $REPORT_IN_MACRO: expr $(,)?
     ) => {
         $(#[$attr])*
         pub static $NAME: &$crate::lint::Lint = &$crate::lint::Lint {
             name: concat!("marker::", stringify!($NAME)),
             default_level: $crate::lint::Level::$LEVEL,
-            explaination: $EXPLAINATION,
+            explanation: $EXPLANATION,
             report_in_macro: $REPORT_IN_MACRO,
         };
     };

--- a/marker_driver_rustc/src/context.rs
+++ b/marker_driver_rustc/src/context.rs
@@ -7,7 +7,8 @@ use marker_api::{
         BodyId, ExprId, ItemId, Span, SpanOwner, SymbolId,
     },
     context::AstContext,
-    lint::Lint,
+    diagnostic::{Diagnostic, EmissionNode},
+    lint::{Level, Lint},
 };
 use rustc_lint::LintStore;
 use rustc_middle::ty::TyCtxt;
@@ -68,6 +69,57 @@ impl<'ast, 'tcx> RustcContext<'ast, 'tcx> {
 }
 
 impl<'ast, 'tcx: 'ast> DriverContext<'ast> for RustcContext<'ast, 'tcx> {
+    fn lint_level_at(&'ast self, api_lint: &'static Lint, node: EmissionNode) -> Level {
+        if let Some(id) = self.rustc_converter.try_to_hir_id_from_emission_node(node) {
+            let lint = self.rustc_converter.to_lint(api_lint);
+            let level = self.rustc_cx.lint_level_at_node(lint, id).0;
+            self.marker_converter.to_lint_level(level)
+        } else {
+            Level::Allow
+        }
+    }
+
+    fn emit_diag(&'ast self, diag: &Diagnostic<'_, 'ast>) {
+        let Some(id) = self.rustc_converter.try_to_hir_id_from_emission_node(diag.node) else {
+            return;
+        };
+        let lint = self.rustc_converter.to_lint(diag.lint);
+        self.rustc_cx.struct_span_lint_hir(
+            lint,
+            id,
+            self.rustc_converter.to_span(diag.span),
+            diag.msg(),
+            |builder| {
+                for part in diag.parts.get() {
+                    match part {
+                        marker_api::diagnostic::DiagnosticPart::Help { msg } => {
+                            builder.help(msg.get());
+                        },
+                        marker_api::diagnostic::DiagnosticPart::HelpSpan { msg, span } => {
+                            builder.span_help(self.rustc_converter.to_span(span), msg.get());
+                        },
+                        marker_api::diagnostic::DiagnosticPart::Note { msg } => {
+                            builder.note(msg.get());
+                        },
+                        marker_api::diagnostic::DiagnosticPart::NoteSpan { msg, span } => {
+                            builder.span_note(self.rustc_converter.to_span(span), msg.get());
+                        },
+                        marker_api::diagnostic::DiagnosticPart::Suggestion { msg, span, sugg, app } => {
+                            builder.span_suggestion(
+                                self.rustc_converter.to_span(span),
+                                msg.get(),
+                                sugg.get(),
+                                self.rustc_converter.to_applicability(*app),
+                            );
+                        },
+                        _ => todo!(),
+                    }
+                }
+                builder
+            },
+        );
+    }
+
     fn emit_lint(&'ast self, api_lint: &'static Lint, msg: &str, api_span: &Span<'ast>) {
         let rustc_lint = self.rustc_converter.to_lint(api_lint);
         self.rustc_cx.struct_span_lint_hir(

--- a/marker_driver_rustc/src/context.rs
+++ b/marker_driver_rustc/src/context.rs
@@ -120,17 +120,6 @@ impl<'ast, 'tcx: 'ast> DriverContext<'ast> for RustcContext<'ast, 'tcx> {
         );
     }
 
-    fn emit_lint(&'ast self, api_lint: &'static Lint, msg: &str, api_span: &Span<'ast>) {
-        let rustc_lint = self.rustc_converter.to_lint(api_lint);
-        self.rustc_cx.struct_span_lint_hir(
-            rustc_lint,
-            rustc_hir::CRATE_HIR_ID,
-            self.rustc_converter.to_span(api_span),
-            msg,
-            |diag| diag,
-        );
-    }
-
     fn item(&'ast self, api_id: ItemId) -> Option<ItemKind<'ast>> {
         let rustc_id = self.rustc_converter.to_item_id(api_id);
         let rust_item = self.rustc_cx.hir().item(rustc_id);

--- a/marker_driver_rustc/src/conversion/common.rs
+++ b/marker_driver_rustc/src/conversion/common.rs
@@ -11,6 +11,12 @@ pub struct TyDefIdLayout {
 }
 
 #[repr(C)]
+pub struct DefIdLayout {
+    pub krate: u32,
+    pub index: u32,
+}
+
+#[repr(C)]
 pub struct ItemIdLayout {
     pub krate: u32,
     pub index: u32,
@@ -33,7 +39,14 @@ pub struct DefIdInfo {
     pub krate: u32,
 }
 
+#[repr(C)]
 pub struct ExprIdLayout {
+    pub owner: u32,
+    pub index: u32,
+}
+
+#[repr(C)]
+pub struct HirIdLayout {
     pub owner: u32,
     pub index: u32,
 }

--- a/marker_driver_rustc/src/conversion/marker.rs
+++ b/marker_driver_rustc/src/conversion/marker.rs
@@ -14,10 +14,13 @@ mod ty;
 use std::cell::RefCell;
 
 use crate::context::storage::Storage;
-use marker_api::ast::{
-    expr::ExprKind,
-    item::{Body, ItemKind},
-    BodyId, Crate, ExprId, ItemId, Span, SymbolId,
+use marker_api::{
+    ast::{
+        expr::ExprKind,
+        item::{Body, ItemKind},
+        BodyId, Crate, ExprId, ItemId, Span, SymbolId,
+    },
+    lint::Level,
 };
 use rustc_hash::FxHashMap;
 use rustc_hir as hir;
@@ -39,6 +42,7 @@ impl<'ast, 'tcx> MarkerConverter<'ast, 'tcx> {
         }
     }
 
+    forward_to_inner!(pub fn to_lint_level(&self, level: rustc_lint::Level) -> Level);
     forward_to_inner!(pub fn to_item(&self, rustc_item: &'tcx hir::Item<'tcx>) -> Option<ItemKind<'ast>>);
     forward_to_inner!(pub fn to_body(&self, body: &hir::Body<'tcx>) -> &'ast Body<'ast>);
     forward_to_inner!(pub fn to_span(&self, rustc_span: rustc_span::Span) -> Span<'ast>);

--- a/marker_driver_rustc/src/conversion/marker/item.rs
+++ b/marker_driver_rustc/src/conversion/marker/item.rs
@@ -189,6 +189,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
             // FIXME update Visibility creation to use the stored local def id inside the
             // field after the next sync. See #55
             Field::new(
+                self.to_field_id(field.hir_id),
                 Visibility::new(self.to_item_id(field.def_id)),
                 self.to_symbol_id(field.ident.name),
                 self.to_ty(field.ty),

--- a/marker_driver_rustc/src/conversion/marker/stmts.rs
+++ b/marker_driver_rustc/src/conversion/marker/stmts.rs
@@ -8,6 +8,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
         match &stmt.kind {
             hir::StmtKind::Local(local) => match local.source {
                 hir::LocalSource::Normal => Some(StmtKind::Let(self.alloc(LetStmt::new(
+                    self.to_let_stmt_id(local.hir_id),
                     self.to_span_id(local.span),
                     self.to_pat(local.pat),
                     local.ty.map(|ty| self.to_ty(ty)),

--- a/marker_driver_rustc/src/conversion/rustc.rs
+++ b/marker_driver_rustc/src/conversion/rustc.rs
@@ -9,7 +9,6 @@ use rustc_hash::FxHashMap;
 use crate::context::storage::Storage;
 
 pub struct RustcConverter<'ast, 'tcx> {
-    #[expect(dead_code, reason = "definitely needed later on")]
     rustc_cx: rustc_middle::ty::TyCtxt<'tcx>,
     storage: &'ast Storage<'ast>,
     lints: RefCell<FxHashMap<&'static Lint, &'static rustc_lint::Lint>>,

--- a/marker_driver_rustc/src/conversion/rustc/common.rs
+++ b/marker_driver_rustc/src/conversion/rustc/common.rs
@@ -1,12 +1,19 @@
 use std::mem::{size_of, transmute};
 
 use marker_api::{
-    ast::{BodyId, CrateId, GenericId, ItemId, Span, SpanId, SymbolId, TyDefId},
+    ast::{
+        BodyId, CrateId, ExprId, FieldId, GenericId, ItemId, LetStmtId, Span, SpanId, StmtIdInner, SymbolId, TyDefId,
+        VarId, VariantId,
+    },
+    diagnostic::{Applicability, EmissionNode},
     lint::Level,
 };
 use rustc_hir as hir;
 
-use crate::conversion::common::{BodyIdLayout, DefIdInfo, GenericIdLayout, ItemIdLayout, TyDefIdLayout};
+use crate::conversion::common::{
+    BodyIdLayout, DefIdInfo, DefIdLayout, ExprIdLayout, GenericIdLayout, HirIdLayout, ItemIdLayout, TyDefIdLayout,
+    VarIdLayout,
+};
 use crate::transmute_id;
 
 use super::RustcConverter;
@@ -30,6 +37,31 @@ use impl_into_def_id_for;
 impl_into_def_id_for!(GenericId, GenericIdLayout);
 impl_into_def_id_for!(ItemId, ItemIdLayout);
 impl_into_def_id_for!(TyDefId, TyDefIdLayout);
+impl_into_def_id_for!(FieldId, DefIdLayout);
+impl_into_def_id_for!(VariantId, DefIdLayout);
+
+pub struct HirIdInfo {
+    pub owner: u32,
+    pub index: u32,
+}
+
+macro_rules! impl_into_hir_id_for {
+    ($id:ty, $layout:ty) => {
+        impl From<$id> for HirIdInfo {
+            fn from(value: $id) -> Self {
+                let layout = transmute_id!($id as $layout = value);
+                HirIdInfo {
+                    owner: layout.owner,
+                    index: layout.index,
+                }
+            }
+        }
+    };
+}
+
+impl_into_hir_id_for!(ExprId, ExprIdLayout);
+impl_into_hir_id_for!(VarId, VarIdLayout);
+impl_into_hir_id_for!(LetStmtId, HirIdLayout);
 
 #[derive(Debug, Clone, Copy)]
 pub struct SpanSourceInfo {
@@ -94,11 +126,44 @@ impl<'ast, 'tcx> RustcConverter<'ast, 'tcx> {
     }
 
     #[must_use]
-    pub fn to_def_id(api_id: impl Into<DefIdInfo>) -> hir::def_id::DefId {
+    pub fn to_def_id(&self, api_id: impl Into<DefIdInfo>) -> hir::def_id::DefId {
         let info: DefIdInfo = api_id.into();
         hir::def_id::DefId {
             index: hir::def_id::DefIndex::from_u32(info.index),
             krate: hir::def_id::CrateNum::from_u32(info.krate),
+        }
+    }
+
+    #[must_use]
+    pub fn try_to_hir_id_from_emission_node(&self, node: EmissionNode) -> Option<hir::HirId> {
+        let def_id = match node {
+            EmissionNode::Expr(id) => return Some(self.to_hir_id(id)),
+            EmissionNode::Item(id) => self.to_def_id(id),
+            EmissionNode::Stmt(stmt_id) => match stmt_id.data() {
+                StmtIdInner::Expr(id) => return Some(self.to_hir_id(id)),
+                StmtIdInner::Item(id) => self.to_def_id(id),
+                StmtIdInner::LetStmt(id) => return Some(self.to_hir_id(id)),
+            },
+            EmissionNode::Field(id) => self.to_def_id(id),
+            EmissionNode::Variant(id) => self.to_def_id(id),
+            _ => todo!(),
+        };
+
+        def_id
+            .as_local()
+            .map(|id| self.rustc_cx.hir().local_def_id_to_hir_id(id))
+    }
+
+    #[must_use]
+    pub fn to_hir_id(&self, api_id: impl Into<HirIdInfo>) -> hir::HirId {
+        let info: HirIdInfo = api_id.into();
+        hir::HirId {
+            owner: hir::OwnerId {
+                def_id: hir::def_id::LocalDefId {
+                    local_def_index: hir::def_id::DefIndex::from_u32(info.owner),
+                },
+            },
+            local_id: hir::hir_id::ItemLocalId::from_u32(info.index),
         }
     }
 
@@ -110,6 +175,16 @@ impl<'ast, 'tcx> RustcConverter<'ast, 'tcx> {
             Level::Deny => rustc_lint::Level::Deny,
             Level::Forbid => rustc_lint::Level::Forbid,
             _ => unreachable!(),
+        }
+    }
+
+    pub(crate) fn to_applicability(&self, app: Applicability) -> rustc_errors::Applicability {
+        match app {
+            Applicability::MachineApplicable => rustc_errors::Applicability::MachineApplicable,
+            Applicability::MaybeIncorrect => rustc_errors::Applicability::MaybeIncorrect,
+            Applicability::HasPlaceholders => rustc_errors::Applicability::HasPlaceholders,
+            Applicability::Unspecified => rustc_errors::Applicability::Unspecified,
+            _ => todo!(),
         }
     }
 

--- a/marker_driver_rustc/src/conversion/rustc/common.rs
+++ b/marker_driver_rustc/src/conversion/rustc/common.rs
@@ -32,12 +32,9 @@ macro_rules! impl_into_def_id_for {
     };
 }
 
-use impl_into_def_id_for;
-
 impl_into_def_id_for!(GenericId, GenericIdLayout);
 impl_into_def_id_for!(ItemId, ItemIdLayout);
 impl_into_def_id_for!(TyDefId, TyDefIdLayout);
-impl_into_def_id_for!(FieldId, DefIdLayout);
 impl_into_def_id_for!(VariantId, DefIdLayout);
 
 pub struct HirIdInfo {
@@ -62,6 +59,7 @@ macro_rules! impl_into_hir_id_for {
 impl_into_hir_id_for!(ExprId, ExprIdLayout);
 impl_into_hir_id_for!(VarId, VarIdLayout);
 impl_into_hir_id_for!(LetStmtId, HirIdLayout);
+impl_into_hir_id_for!(FieldId, HirIdLayout);
 
 #[derive(Debug, Clone, Copy)]
 pub struct SpanSourceInfo {
@@ -144,7 +142,7 @@ impl<'ast, 'tcx> RustcConverter<'ast, 'tcx> {
                 StmtIdInner::Item(id) => self.to_def_id(id),
                 StmtIdInner::LetStmt(id) => return Some(self.to_hir_id(id)),
             },
-            EmissionNode::Field(id) => self.to_def_id(id),
+            EmissionNode::Field(id) => return Some(self.to_hir_id(id)),
             EmissionNode::Variant(id) => self.to_def_id(id),
             _ => todo!(),
         };

--- a/marker_driver_rustc/src/conversion/rustc/unstable.rs
+++ b/marker_driver_rustc/src/conversion/rustc/unstable.rs
@@ -15,7 +15,7 @@ impl<'ast, 'tcx> RustcConverter<'ast, 'tcx> {
             Box::leak(Box::new(rustc_lint::Lint {
                 name: api_lint.name,
                 default_level: self.to_lint_level(api_lint.default_level),
-                desc: api_lint.explaination,
+                desc: api_lint.explanation,
                 edition_lint_opts: None,
                 report_in_external_macro,
                 future_incompatible: None,

--- a/marker_lints/src/lib.rs
+++ b/marker_lints/src/lib.rs
@@ -145,7 +145,7 @@ impl LintPass for TestLintPass {
                 // the tests.
                 // I only want to enable this after the PR has been approved, as it
                 // adds a lot of superficial changes (+3810|-3498) which would
-                // complicate the review. 
+                // complicate the review.
                 //
                 // cx.emit_lint(TEST_LINT, stmt.id(), "print test", stmt.span(), |diag| {
                 //     diag.note(format!("{expr:#?}"))

--- a/marker_lints/src/lib.rs
+++ b/marker_lints/src/lib.rs
@@ -66,9 +66,9 @@ impl LintPass for TestLintPass {
                         diag.help("a help");
                         diag.span_note("a spanned note", item.span());
                         diag.span_help("a spanned help", item.span());
-                        diag.span_suggestion("try", item.span(), "duck", Applicability::Unspecified)
+                        diag.span_suggestion("try", item.span(), "duck", Applicability::Unspecified);
                     },
-                )
+                );
             } else if name == "FOO" {
                 emit_foo_lint(cx, item.id(), "a static item", item.span());
             }
@@ -132,7 +132,7 @@ impl LintPass for TestLintPass {
         }
     }
 
-    fn check_stmt<'ast>(&mut self, cx: &'ast AstContext<'ast>, stmt: StmtKind<'ast>) {
+    fn check_stmt<'ast>(&mut self, _cx: &'ast AstContext<'ast>, stmt: StmtKind<'ast>) {
         // I didn't realize that `let_chains` are still unstable. This makes the
         // code significantly less readable -.-
         if let StmtKind::Let(lets) = stmt {

--- a/marker_lints/tests/ui/find_item.stderr
+++ b/marker_lints/tests/ui/find_item.stderr
@@ -2,8 +2,20 @@ warning: hey there is a static item here
  --> $DIR/find_item.rs:1:1
   |
 1 | static FIND_ITEM: u32 = 4;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `duck`
   |
+  = note: a note
+  = help: a help
+note: a spanned note
+ --> $DIR/find_item.rs:1:1
+  |
+1 | static FIND_ITEM: u32 = 4;
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: a spanned help
+ --> $DIR/find_item.rs:1:1
+  |
+1 | static FIND_ITEM: u32 = 4;
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
   = note: `#[warn(marker::test_lint)]` on by default
 
 warning: 1 warning emitted

--- a/marker_lints/tests/ui/foo_items.stderr
+++ b/marker_lints/tests/ui/foo_items.stderr
@@ -20,12 +20,6 @@ warning: a struct named `foo`, consider using a more meaningful name
 8 | |     }
   | |_____^
 
-warning: a field named `foo`, consider using a more meaningful name
- --> $DIR/foo_items.rs:7:9
-  |
-7 |         foo: i32,
-  |         ^^^^^^^^
-
 warning: a module named `foo`, consider using a more meaningful name
   --> $DIR/foo_items.rs:11:1
    |
@@ -64,5 +58,5 @@ warning: an enum variant named `foo`, consider using a more meaningful name
 17 |         Foo,
    |         ^^^
 
-warning: 9 warnings emitted
+warning: 8 warnings emitted
 

--- a/marker_lints/tests/ui/foo_items.stderr
+++ b/marker_lints/tests/ui/foo_items.stderr
@@ -20,6 +20,12 @@ warning: a struct named `foo`, consider using a more meaningful name
 8 | |     }
   | |_____^
 
+warning: a field named `foo`, consider using a more meaningful name
+ --> $DIR/foo_items.rs:7:9
+  |
+7 |         foo: i32,
+  |         ^^^^^^^^
+
 warning: a module named `foo`, consider using a more meaningful name
   --> $DIR/foo_items.rs:11:1
    |
@@ -58,5 +64,5 @@ warning: an enum variant named `foo`, consider using a more meaningful name
 17 |         Foo,
    |         ^^^
 
-warning: 8 warnings emitted
+warning: 9 warnings emitted
 


### PR DESCRIPTION
This PR adds a new `DiagnosticBuilder` to the API to create beautiful diagnostics with help and note messages. This will also allow us to include the expression span, in the print tests. Generally, I'm pretty happy with the concept :)

---

Adding new context callbacks to the API currently requires a lot of boilerplate code. I doubt that we can avoid that right now, but I'll try to look at options to generate a part of it. That would at least help with the implementation and review part.

---

r? @Niki4tap Sorry for requesting this review direction after the last one. You are welcome to take your time or pass the review if you don't have time. It's also totally fine, if you just review the API and doc changes. The backend is mostly verified by the tests :)

Closes #47
Closes #92 (This PR adds the `id()` and `span()` method to `StmtKind`)