### PR TITLE
Dogfood finally passes :tada: 

### DIFF
--- a/marker_api/src/ast/common/ast_path.rs
+++ b/marker_api/src/ast/common/ast_path.rs
@@ -220,8 +220,9 @@ pub enum AstPathTarget {
     Var(VarId),
     /// The path target is a generic type, identified by the [`GenericId`].
     Generic(GenericId),
-    /// The target wasn't resolved, but should be available in the future.
-    Wip,
+    /// The target can't be resolved in the current context. This can happen
+    /// for paths in generic bounds.
+    Unresolved,
 }
 
 #[repr(C)]

--- a/marker_api/src/ast/expr.rs
+++ b/marker_api/src/ast/expr.rs
@@ -45,6 +45,7 @@ pub enum ExprKind<'ast> {
     CharLit(&'ast CharLitExpr<'ast>),
     BoolLit(&'ast BoolLitExpr<'ast>),
     Block(&'ast BlockExpr<'ast>),
+    Closure(&'ast ClosureExpr<'ast>),
     UnaryOp(&'ast UnaryOpExpr<'ast>),
     Ref(&'ast RefExpr<'ast>),
     BinaryOp(&'ast BinaryOpExpr<'ast>),
@@ -218,7 +219,7 @@ macro_rules! impl_expr_kind_fn {
     (ExprKind: $method:ident () -> $return_ty:ty) => {
         impl_expr_kind_fn!((ExprKind) $method() -> $return_ty,
             IntLit, FloatLit, StrLit, CharLit, BoolLit,
-            Block,
+            Block, Closure,
             UnaryOp, Ref, BinaryOp, QuestionMark, As, Assign,
             Path, Index, Field,
             Call, Method,

--- a/marker_api/src/ast/expr/block_expr.rs
+++ b/marker_api/src/ast/expr/block_expr.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ast::{stmt::StmtKind, BodyId, CommonCallableData, Ident, impl_callable_data_trait},
+    ast::{impl_callable_data_trait, stmt::StmtKind, BodyId, CommonCallableData, Ident},
     ffi::{FfiOption, FfiSlice},
 };
 
@@ -101,9 +101,9 @@ impl<'ast> BlockExpr<'ast> {
 #[derive(Debug)]
 pub struct ClosureExpr<'ast> {
     data: CommonExprData<'ast>,
-    capture_kind: CaptureKind,
     callable_data: CommonCallableData<'ast>,
-    body: FfiOption<BodyId>,
+    capture_kind: CaptureKind,
+    body: BodyId,
 }
 
 impl<'ast> ClosureExpr<'ast> {
@@ -111,8 +111,8 @@ impl<'ast> ClosureExpr<'ast> {
         self.capture_kind
     }
 
-    pub fn body(&self) -> Option<BodyId> {
-        self.body.copy()
+    pub fn body(&self) -> BodyId {
+        self.body
     }
 }
 
@@ -124,15 +124,15 @@ impl_callable_data_trait!(ClosureExpr<'ast>);
 impl<'ast> ClosureExpr<'ast> {
     pub fn new(
         data: CommonExprData<'ast>,
-        capture_kind: CaptureKind,
         callable_data: CommonCallableData<'ast>,
-        body: Option<BodyId>,
+        capture_kind: CaptureKind,
+        body: BodyId,
     ) -> Self {
         Self {
             data,
-            capture_kind,
             callable_data,
-            body: body.into(),
+            capture_kind,
+            body,
         }
     }
 }

--- a/marker_api/src/ast/expr/block_expr.rs
+++ b/marker_api/src/ast/expr/block_expr.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ast::{stmt::StmtKind, Ident},
+    ast::{stmt::StmtKind, BodyId, CommonCallableData, Ident, impl_callable_data_trait},
     ffi::{FfiOption, FfiSlice},
 };
 
@@ -81,4 +81,66 @@ impl<'ast> BlockExpr<'ast> {
             is_unsafe,
         }
     }
+}
+
+/// A closure expression
+///
+/// ```
+/// //          vvvvvvvvvvvvvvvvvvvvvvvvvvvvv A Closure expression
+/// let print = |name| println!("Hey {name}");
+/// //           ^^^^  ^^^^^^^^^^^^^^^^^^^^^ The body of the closure
+/// //           |
+/// //           A named argument
+///
+/// //          vvvv The `move` keyword specifying the capture kind of the closure
+/// let msger = move || {
+///     print("Marker")
+/// };
+/// ```
+#[repr(C)]
+#[derive(Debug)]
+pub struct ClosureExpr<'ast> {
+    data: CommonExprData<'ast>,
+    capture_kind: CaptureKind,
+    callable_data: CommonCallableData<'ast>,
+    body: FfiOption<BodyId>,
+}
+
+impl<'ast> ClosureExpr<'ast> {
+    pub fn capture_kind(&self) -> CaptureKind {
+        self.capture_kind
+    }
+
+    pub fn body(&self) -> Option<BodyId> {
+        self.body.copy()
+    }
+}
+
+super::impl_expr_data!(ClosureExpr<'ast>, Closure);
+
+impl_callable_data_trait!(ClosureExpr<'ast>);
+
+#[cfg(feature = "driver-api")]
+impl<'ast> ClosureExpr<'ast> {
+    pub fn new(
+        data: CommonExprData<'ast>,
+        capture_kind: CaptureKind,
+        callable_data: CommonCallableData<'ast>,
+        body: Option<BodyId>,
+    ) -> Self {
+        Self {
+            data,
+            capture_kind,
+            callable_data,
+            body: body.into(),
+        }
+    }
+}
+
+#[repr(C)]
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy)]
+pub enum CaptureKind {
+    Default,
+    Move,
 }

--- a/marker_driver_rustc/src/conversion/marker.rs
+++ b/marker_driver_rustc/src/conversion/marker.rs
@@ -136,6 +136,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
         let list = [
             (hir::LangItem::FormatArguments, self.to_symbol_id(Symbol::intern("FormatArguments"))),
             (hir::LangItem::FormatArgument, self.to_symbol_id(Symbol::intern("FormatArgument"))),
+            (hir::LangItem::TryTraitBranch, self.to_symbol_id(Symbol::intern("Try::branch"))),
         ];
 
         self.lang_item_map.borrow_mut().extend(list);

--- a/marker_driver_rustc/src/conversion/marker/expr.rs
+++ b/marker_driver_rustc/src/conversion/marker/expr.rs
@@ -1,13 +1,13 @@
 use marker_api::ast::{
     expr::{
-        ArrayExpr, AssignExpr, BinaryOpExpr, BinaryOpKind, BlockExpr, BoolLitExpr, BreakExpr, CallExpr, CharLitExpr,
-        CommonExprData, ContinueExpr, CtorExpr, CtorField, ExprKind, ExprPrecedence, FieldExpr, FloatLitExpr,
-        FloatSuffix, ForExpr, IfExpr, IndexExpr, IntLitExpr, IntSuffix, LetExpr, LoopExpr, MatchArm, MatchExpr,
-        MethodExpr, PathExpr, RangeExpr, RefExpr, ReturnExpr, StrLitData, StrLitExpr, TupleExpr, UnaryOpExpr,
-        UnaryOpKind, UnstableExpr, WhileExpr,
+        ArrayExpr, AssignExpr, BinaryOpExpr, BinaryOpKind, BlockExpr, BoolLitExpr, BreakExpr, CallExpr, CaptureKind,
+        CharLitExpr, ClosureExpr, CommonExprData, ContinueExpr, CtorExpr, CtorField, ExprKind, ExprPrecedence,
+        FieldExpr, FloatLitExpr, FloatSuffix, ForExpr, IfExpr, IndexExpr, IntLitExpr, IntSuffix, LetExpr, LoopExpr,
+        MatchArm, MatchExpr, MethodExpr, PathExpr, RangeExpr, RefExpr, ReturnExpr, StrLitData, StrLitExpr, TupleExpr,
+        UnaryOpExpr, UnaryOpKind, UnstableExpr, WhileExpr,
     },
     pat::PatKind,
-    Ident,
+    CommonCallableData, Ident, Parameter,
 };
 use rustc_hash::FxHashMap;
 use rustc_hir as hir;
@@ -236,6 +236,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                 hir::LoopSource::While => ExprKind::While(self.alloc(self.to_while_loop_from_desugar(expr))),
                 hir::LoopSource::ForLoop => unreachable!("is desugared at a higher node level"),
             },
+            hir::ExprKind::Closure(closure) => ExprKind::Closure(self.alloc(self.to_closure_expr(data, closure))),
             // `DropTemps` is an rustc internal construct to tweak the drop
             // order during HIR lowering. Marker can for now ignore this and
             // convert the inner expression directly
@@ -383,6 +384,46 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
             guard,
             self.to_expr(arm.body),
         )
+    }
+
+    fn to_closure_expr(&self, data: CommonExprData<'ast>, closure: &hir::Closure<'tcx>) -> ClosureExpr<'ast> {
+        let fn_decl = closure.fn_decl;
+
+        let params = self.alloc_slice(fn_decl.inputs.iter().map(|ty| {
+            // FIXME: The name should be a pattern retrieved from the body, but
+            // that requires adjustments in `Parameter`.
+            Parameter::new(None, Some(self.to_ty(ty)), None)
+        }));
+        let return_ty = if let hir::FnRetTy::Return(rust_ty) = fn_decl.output {
+            Some(self.to_ty(rust_ty))
+        } else {
+            None
+        };
+
+        let call = CommonCallableData::new(
+            false,
+            false,
+            false,
+            false,
+            marker_api::ast::Abi::Default,
+            false,
+            params,
+            return_ty,
+        );
+
+        ClosureExpr::new(
+            data,
+            call,
+            self.to_capture_kind(closure.capture_clause),
+            self.to_body_id(closure.body),
+        )
+    }
+
+    fn to_capture_kind(&self, capture: hir::CaptureBy) -> CaptureKind {
+        match capture {
+            rustc_ast::CaptureBy::Value => CaptureKind::Move,
+            rustc_ast::CaptureBy::Ref => CaptureKind::Default,
+        }
     }
 
     #[must_use]

--- a/marker_lints/tests/ui/print_closure_expr.rs
+++ b/marker_lints/tests/ui/print_closure_expr.rs
@@ -1,0 +1,11 @@
+// normalize-stderr-windows: "tests/ui/" -> "$$DIR/"
+
+fn main() {
+    let a = "Hey".to_string();
+
+    let _print_simple_closure = || {
+        1 + 1;
+    };
+    let _print_with_args = |x: u32, y: u32| x + y;
+    let _print_move = move || a;
+}

--- a/marker_lints/tests/ui/print_closure_expr.stderr
+++ b/marker_lints/tests/ui/print_closure_expr.stderr
@@ -1,0 +1,108 @@
+warning: print test
+ --> $DIR/print_closure_expr.rs:6:5
+  |
+6 | /     let _print_simple_closure = || {
+7 | |         1 + 1;
+8 | |     };
+  | |______^
+  |
+  = note: Closure(
+              ClosureExpr {
+                  data: CommonExprData {
+                      _lifetime: PhantomData<&()>,
+                      id: ExprId(..),
+                      span: SpanId(..),
+                  },
+                  callable_data: CommonCallableData {
+                      is_const: false,
+                      is_async: false,
+                      is_unsafe: false,
+                      is_extern: false,
+                      abi: Default,
+                      has_self: false,
+                      params: [],
+                      return_ty: None,
+                  },
+                  capture_kind: Default,
+                  body: BodyId(..),
+              },
+          )
+  = note: `#[warn(marker::test_lint)]` on by default
+
+warning: print test
+ --> $DIR/print_closure_expr.rs:9:5
+  |
+9 |     let _print_with_args = |x: u32, y: u32| x + y;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: Closure(
+              ClosureExpr {
+                  data: CommonExprData {
+                      _lifetime: PhantomData<&()>,
+                      id: ExprId(..),
+                      span: SpanId(..),
+                  },
+                  callable_data: CommonCallableData {
+                      is_const: false,
+                      is_async: false,
+                      is_unsafe: false,
+                      is_extern: false,
+                      abi: Default,
+                      has_self: false,
+                      params: [
+                          Parameter {
+                              name: None,
+                              ty: Some(
+                                  Num(
+                                      u32,
+                                  ),
+                              ),
+                              span: None,
+                          },
+                          Parameter {
+                              name: None,
+                              ty: Some(
+                                  Num(
+                                      u32,
+                                  ),
+                              ),
+                              span: None,
+                          },
+                      ],
+                      return_ty: None,
+                  },
+                  capture_kind: Default,
+                  body: BodyId(..),
+              },
+          )
+
+warning: print test
+  --> $DIR/print_closure_expr.rs:10:5
+   |
+10 |     let _print_move = move || a;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: Closure(
+               ClosureExpr {
+                   data: CommonExprData {
+                       _lifetime: PhantomData<&()>,
+                       id: ExprId(..),
+                       span: SpanId(..),
+                   },
+                   callable_data: CommonCallableData {
+                       is_const: false,
+                       is_async: false,
+                       is_unsafe: false,
+                       is_extern: false,
+                       abi: Default,
+                       has_self: false,
+                       params: [],
+                       return_ty: None,
+                   },
+                   capture_kind: Move,
+                   body: BodyId(..),
+               },
+           )
+
+warning: 3 warnings emitted
+

--- a/marker_lints/tests/ui/print_cond_expr.rs
+++ b/marker_lints/tests/ui/print_cond_expr.rs
@@ -43,10 +43,22 @@ fn matches(scrutinee: &[i32]) {
     };
 }
 
+mod question_mark {
+    fn kanske_option() -> Option<i32> {
+        let x = Some(1);
+        let _print_option_match = x?;
+        None
+    }
+
+    fn kanske_result() -> Result<i32, i32> {
+        let x: Result<i32, i32> = Ok(1);
+        let _print_option_match = x?;
+        Err(4)
+    }
+}
+
 fn check(_: &i32) -> bool {
     true
 }
 
-fn main() {
-    ifs();
-}
+fn main() {}

--- a/marker_lints/tests/ui/print_cond_expr.stderr
+++ b/marker_lints/tests/ui/print_cond_expr.stderr
@@ -974,5 +974,199 @@ warning: print test
                },
            )
 
-warning: 5 warnings emitted
+warning: print test
+  --> $DIR/print_cond_expr.rs:49:9
+   |
+49 |         let _print_option_match = x?;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: QuestionMark(
+               QuestionMarkExpr {
+                   data: CommonExprData {
+                       _lifetime: PhantomData<&()>,
+                       id: ExprId(..),
+                       span: SpanId(..),
+                   },
+                   expr: Call(
+                       CallExpr {
+                           data: CommonExprData {
+                               _lifetime: PhantomData<&()>,
+                               id: ExprId(..),
+                               span: SpanId(..),
+                           },
+                           operand: Path(
+                               PathExpr {
+                                   data: CommonExprData {
+                                       _lifetime: PhantomData<&()>,
+                                       id: ExprId(..),
+                                       span: SpanId(..),
+                                   },
+                                   path: AstQPath {
+                                       self_ty: None,
+                                       path_ty: None,
+                                       path: AstPath {
+                                           segments: [
+                                               AstPathSegment {
+                                                   ident: Ident {
+                                                       name: "Try::branch",
+                                                       span: Span {
+                                                           source: File(
+                                                               "$DIR/print_cond_expr.rs",
+                                                           ),
+                                                           start: 1024,
+                                                           end: 1026,
+                                                       },
+                                                   },
+                                                   generics: GenericArgs {
+                                                       args: [],
+                                                   },
+                                               },
+                                           ],
+                                       },
+                                       target: Item(
+                                           ItemId(..),
+                                       ),
+                                   },
+                               },
+                           ),
+                           args: [
+                               Path(
+                                   PathExpr {
+                                       data: CommonExprData {
+                                           _lifetime: PhantomData<&()>,
+                                           id: ExprId(..),
+                                           span: SpanId(..),
+                                       },
+                                       path: AstQPath {
+                                           self_ty: None,
+                                           path_ty: None,
+                                           path: AstPath {
+                                               segments: [
+                                                   AstPathSegment {
+                                                       ident: Ident {
+                                                           name: "x",
+                                                           span: Span {
+                                                               source: File(
+                                                                   "$DIR/print_cond_expr.rs",
+                                                               ),
+                                                               start: 1024,
+                                                               end: 1025,
+                                                           },
+                                                       },
+                                                       generics: GenericArgs {
+                                                           args: [],
+                                                       },
+                                                   },
+                                               ],
+                                           },
+                                           target: Var(
+                                               VarId(..),
+                                           ),
+                                       },
+                                   },
+                               ),
+                           ],
+                       },
+                   ),
+               },
+           )
+
+warning: print test
+  --> $DIR/print_cond_expr.rs:55:9
+   |
+55 |         let _print_option_match = x?;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: QuestionMark(
+               QuestionMarkExpr {
+                   data: CommonExprData {
+                       _lifetime: PhantomData<&()>,
+                       id: ExprId(..),
+                       span: SpanId(..),
+                   },
+                   expr: Call(
+                       CallExpr {
+                           data: CommonExprData {
+                               _lifetime: PhantomData<&()>,
+                               id: ExprId(..),
+                               span: SpanId(..),
+                           },
+                           operand: Path(
+                               PathExpr {
+                                   data: CommonExprData {
+                                       _lifetime: PhantomData<&()>,
+                                       id: ExprId(..),
+                                       span: SpanId(..),
+                                   },
+                                   path: AstQPath {
+                                       self_ty: None,
+                                       path_ty: None,
+                                       path: AstPath {
+                                           segments: [
+                                               AstPathSegment {
+                                                   ident: Ident {
+                                                       name: "Try::branch",
+                                                       span: Span {
+                                                           source: File(
+                                                               "$DIR/print_cond_expr.rs",
+                                                           ),
+                                                           start: 1168,
+                                                           end: 1170,
+                                                       },
+                                                   },
+                                                   generics: GenericArgs {
+                                                       args: [],
+                                                   },
+                                               },
+                                           ],
+                                       },
+                                       target: Item(
+                                           ItemId(..),
+                                       ),
+                                   },
+                               },
+                           ),
+                           args: [
+                               Path(
+                                   PathExpr {
+                                       data: CommonExprData {
+                                           _lifetime: PhantomData<&()>,
+                                           id: ExprId(..),
+                                           span: SpanId(..),
+                                       },
+                                       path: AstQPath {
+                                           self_ty: None,
+                                           path_ty: None,
+                                           path: AstPath {
+                                               segments: [
+                                                   AstPathSegment {
+                                                       ident: Ident {
+                                                           name: "x",
+                                                           span: Span {
+                                                               source: File(
+                                                                   "$DIR/print_cond_expr.rs",
+                                                               ),
+                                                               start: 1168,
+                                                               end: 1169,
+                                                           },
+                                                       },
+                                                       generics: GenericArgs {
+                                                           args: [],
+                                                       },
+                                                   },
+                                               ],
+                                           },
+                                           target: Var(
+                                               VarId(..),
+                                           ),
+                                       },
+                                   },
+                               ),
+                           ],
+                       },
+                   ),
+               },
+           )
+
+warning: 7 warnings emitted
 

--- a/marker_lints/tests/ui/print_op.rs
+++ b/marker_lints/tests/ui/print_op.rs
@@ -1,5 +1,9 @@
 // normalize-stderr-windows: "tests/ui/" -> "$$DIR/"
 
+fn as_casts() {
+    let _print_cast = 16 as u32;
+}
+
 fn main() {
     let mut value = 20;
     let _print_alg_ops = 1 + 2 * -3;

--- a/marker_lints/tests/ui/print_op.stderr
+++ b/marker_lints/tests/ui/print_op.stderr
@@ -1,7 +1,38 @@
 warning: print test
- --> $DIR/print_op.rs:5:5
+ --> $DIR/print_op.rs:4:5
   |
-5 |     let _print_alg_ops = 1 + 2 * -3;
+4 |     let _print_cast = 16 as u32;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: As(
+              AsExpr {
+                  data: CommonExprData {
+                      _lifetime: PhantomData<&()>,
+                      id: ExprId(..),
+                      span: SpanId(..),
+                  },
+                  expr: IntLit(
+                      IntLitExpr {
+                          data: CommonExprData {
+                              _lifetime: PhantomData<&()>,
+                              id: ExprId(..),
+                              span: SpanId(..),
+                          },
+                          value: 16,
+                          suffix: None,
+                      },
+                  ),
+                  ty: Num(
+                      u32,
+                  ),
+              },
+          )
+  = note: `#[warn(marker::test_lint)]` on by default
+
+warning: print test
+ --> $DIR/print_op.rs:9:5
+  |
+9 |     let _print_alg_ops = 1 + 2 * -3;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: BinaryOp(
@@ -67,126 +98,125 @@ warning: print test
                   kind: Add,
               },
           )
-  = note: `#[warn(marker::test_lint)]` on by default
 
 warning: print test
- --> $DIR/print_op.rs:6:5
-  |
-6 |     let _print_bool_ops = true && false || !true;
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: BinaryOp(
-              BinaryOpExpr {
-                  data: CommonExprData {
-                      _lifetime: PhantomData<&()>,
-                      id: ExprId(..),
-                      span: SpanId(..),
-                  },
-                  left: BinaryOp(
-                      BinaryOpExpr {
-                          data: CommonExprData {
-                              _lifetime: PhantomData<&()>,
-                              id: ExprId(..),
-                              span: SpanId(..),
-                          },
-                          left: BoolLit(
-                              BoolLitExpr {
-                                  data: CommonExprData {
-                                      _lifetime: PhantomData<&()>,
-                                      id: ExprId(..),
-                                      span: SpanId(..),
-                                  },
-                                  value: true,
-                              },
-                          ),
-                          right: BoolLit(
-                              BoolLitExpr {
-                                  data: CommonExprData {
-                                      _lifetime: PhantomData<&()>,
-                                      id: ExprId(..),
-                                      span: SpanId(..),
-                                  },
-                                  value: false,
-                              },
-                          ),
-                          kind: And,
-                      },
-                  ),
-                  right: UnaryOp(
-                      UnaryOpExpr {
-                          data: CommonExprData {
-                              _lifetime: PhantomData<&()>,
-                              id: ExprId(..),
-                              span: SpanId(..),
-                          },
-                          expr: BoolLit(
-                              BoolLitExpr {
-                                  data: CommonExprData {
-                                      _lifetime: PhantomData<&()>,
-                                      id: ExprId(..),
-                                      span: SpanId(..),
-                                  },
-                                  value: true,
-                              },
-                          ),
-                          kind: Not,
-                      },
-                  ),
-                  kind: Or,
-              },
-          )
+  --> $DIR/print_op.rs:10:5
+   |
+10 |     let _print_bool_ops = true && false || !true;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: BinaryOp(
+               BinaryOpExpr {
+                   data: CommonExprData {
+                       _lifetime: PhantomData<&()>,
+                       id: ExprId(..),
+                       span: SpanId(..),
+                   },
+                   left: BinaryOp(
+                       BinaryOpExpr {
+                           data: CommonExprData {
+                               _lifetime: PhantomData<&()>,
+                               id: ExprId(..),
+                               span: SpanId(..),
+                           },
+                           left: BoolLit(
+                               BoolLitExpr {
+                                   data: CommonExprData {
+                                       _lifetime: PhantomData<&()>,
+                                       id: ExprId(..),
+                                       span: SpanId(..),
+                                   },
+                                   value: true,
+                               },
+                           ),
+                           right: BoolLit(
+                               BoolLitExpr {
+                                   data: CommonExprData {
+                                       _lifetime: PhantomData<&()>,
+                                       id: ExprId(..),
+                                       span: SpanId(..),
+                                   },
+                                   value: false,
+                               },
+                           ),
+                           kind: And,
+                       },
+                   ),
+                   right: UnaryOp(
+                       UnaryOpExpr {
+                           data: CommonExprData {
+                               _lifetime: PhantomData<&()>,
+                               id: ExprId(..),
+                               span: SpanId(..),
+                           },
+                           expr: BoolLit(
+                               BoolLitExpr {
+                                   data: CommonExprData {
+                                       _lifetime: PhantomData<&()>,
+                                       id: ExprId(..),
+                                       span: SpanId(..),
+                                   },
+                                   value: true,
+                               },
+                           ),
+                           kind: Not,
+                       },
+                   ),
+                   kind: Or,
+               },
+           )
 
 warning: print test
- --> $DIR/print_op.rs:7:5
-  |
-7 |     let _print_ref = &mut value;
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: Ref(
-              RefExpr {
-                  data: CommonExprData {
-                      _lifetime: PhantomData<&()>,
-                      id: ExprId(..),
-                      span: SpanId(..),
-                  },
-                  expr: Path(
-                      PathExpr {
-                          data: CommonExprData {
-                              _lifetime: PhantomData<&()>,
-                              id: ExprId(..),
-                              span: SpanId(..),
-                          },
-                          path: AstQPath {
-                              self_ty: None,
-                              path_ty: None,
-                              path: AstPath {
-                                  segments: [
-                                      AstPathSegment {
-                                          ident: Ident {
-                                              name: "value",
-                                              span: Span {
-                                                  source: File(
-                                                      "$DIR/print_op.rs",
-                                                  ),
-                                                  start: 203,
-                                                  end: 208,
-                                              },
-                                          },
-                                          generics: GenericArgs {
-                                              args: [],
-                                          },
-                                      },
-                                  ],
-                              },
-                              target: Var(
-                                  VarId(..),
-                              ),
-                          },
-                      },
-                  ),
-                  is_mut: true,
-              },
-          )
+  --> $DIR/print_op.rs:11:5
+   |
+11 |     let _print_ref = &mut value;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: Ref(
+               RefExpr {
+                   data: CommonExprData {
+                       _lifetime: PhantomData<&()>,
+                       id: ExprId(..),
+                       span: SpanId(..),
+                   },
+                   expr: Path(
+                       PathExpr {
+                           data: CommonExprData {
+                               _lifetime: PhantomData<&()>,
+                               id: ExprId(..),
+                               span: SpanId(..),
+                           },
+                           path: AstQPath {
+                               self_ty: None,
+                               path_ty: None,
+                               path: AstPath {
+                                   segments: [
+                                       AstPathSegment {
+                                           ident: Ident {
+                                               name: "value",
+                                               span: Span {
+                                                   source: File(
+                                                       "$DIR/print_op.rs",
+                                                   ),
+                                                   start: 255,
+                                                   end: 260,
+                                               },
+                                           },
+                                           generics: GenericArgs {
+                                               args: [],
+                                           },
+                                       },
+                                   ],
+                               },
+                               target: Var(
+                                   VarId(..),
+                               ),
+                           },
+                       },
+                   ),
+                   is_mut: true,
+               },
+           )
 
-warning: 3 warnings emitted
+warning: 4 warnings emitted
 

--- a/marker_lints/tests/ui/print_ty.rs
+++ b/marker_lints/tests/ui/print_ty.rs
@@ -9,14 +9,14 @@ static PRINT_TYPE_PRIMITIVE_3: Option<(char, bool, f32, f64)> = None;
 static PRINT_TYPE_SEQUENCE: Option<AllowSync<(&[i32], [i32; 8])>> = None;
 static PRINT_TYPE_POINTER: Option<AllowSync<(&'static str, *const i32, *mut i32)>> = None;
 static PRINT_TYPE_COMPLEX: Option<
-AllowSync<(
-    AliasTy,
-    String,
-    Option<String>,
-    Vec<UnionItem>,
-    Box<dyn Debug>,
-    Box<dyn Iterator<Item = i32> + 'static>,
-)>,
+    AllowSync<(
+        AliasTy,
+        String,
+        Option<String>,
+        Vec<UnionItem>,
+        Box<dyn Debug>,
+        Box<dyn Iterator<Item = i32> + 'static>,
+    )>,
 > = None;
 
 type AliasTy = (u8, u16);

--- a/marker_lints/tests/ui/print_ty.stderr
+++ b/marker_lints/tests/ui/print_ty.stderr
@@ -482,11 +482,11 @@ warning: Printing type for
    |
 11 |   static PRINT_TYPE_COMPLEX: Option<
    |  ____________________________^
-12 | | AllowSync<(
-13 | |     AliasTy,
-14 | |     String,
+12 | |     AllowSync<(
+13 | |         AliasTy,
+14 | |         String,
 ...  |
-19 | | )>,
+19 | |     )>,
 20 | | > = None;
    | |_^
 
@@ -539,8 +539,8 @@ Path(
                                                                     source: File(
                                                                         "$DIR/print_ty.rs",
                                                                     ),
-                                                                    start: 538,
-                                                                    end: 547,
+                                                                    start: 542,
+                                                                    end: 551,
                                                                 },
                                                             },
                                                             generics: GenericArgs {
@@ -569,8 +569,8 @@ Path(
                                                                                                                 source: File(
                                                                                                                     "$DIR/print_ty.rs",
                                                                                                                 ),
-                                                                                                                start: 554,
-                                                                                                                end: 561,
+                                                                                                                start: 562,
+                                                                                                                end: 569,
                                                                                                             },
                                                                                                         },
                                                                                                         generics: GenericArgs {
@@ -606,8 +606,8 @@ Path(
                                                                                                                 source: File(
                                                                                                                     "$DIR/print_ty.rs",
                                                                                                                 ),
-                                                                                                                start: 567,
-                                                                                                                end: 573,
+                                                                                                                start: 579,
+                                                                                                                end: 585,
                                                                                                             },
                                                                                                         },
                                                                                                         generics: GenericArgs {
@@ -643,8 +643,8 @@ Path(
                                                                                                                 source: File(
                                                                                                                     "$DIR/print_ty.rs",
                                                                                                                 ),
-                                                                                                                start: 579,
-                                                                                                                end: 585,
+                                                                                                                start: 595,
+                                                                                                                end: 601,
                                                                                                             },
                                                                                                         },
                                                                                                         generics: GenericArgs {
@@ -671,8 +671,8 @@ Path(
                                                                                                                                                     source: File(
                                                                                                                                                         "$DIR/print_ty.rs",
                                                                                                                                                     ),
-                                                                                                                                                    start: 586,
-                                                                                                                                                    end: 592,
+                                                                                                                                                    start: 602,
+                                                                                                                                                    end: 608,
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             generics: GenericArgs {
@@ -720,8 +720,8 @@ Path(
                                                                                                                 source: File(
                                                                                                                     "$DIR/print_ty.rs",
                                                                                                                 ),
-                                                                                                                start: 599,
-                                                                                                                end: 602,
+                                                                                                                start: 619,
+                                                                                                                end: 622,
                                                                                                             },
                                                                                                         },
                                                                                                         generics: GenericArgs {
@@ -748,8 +748,8 @@ Path(
                                                                                                                                                     source: File(
                                                                                                                                                         "$DIR/print_ty.rs",
                                                                                                                                                     ),
-                                                                                                                                                    start: 603,
-                                                                                                                                                    end: 612,
+                                                                                                                                                    start: 623,
+                                                                                                                                                    end: 632,
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             generics: GenericArgs {
@@ -797,8 +797,8 @@ Path(
                                                                                                                 source: File(
                                                                                                                     "$DIR/print_ty.rs",
                                                                                                                 ),
-                                                                                                                start: 619,
-                                                                                                                end: 622,
+                                                                                                                start: 643,
+                                                                                                                end: 646,
                                                                                                             },
                                                                                                         },
                                                                                                         generics: GenericArgs {
@@ -862,8 +862,8 @@ Path(
                                                                                                                 source: File(
                                                                                                                     "$DIR/print_ty.rs",
                                                                                                                 ),
-                                                                                                                start: 639,
-                                                                                                                end: 642,
+                                                                                                                start: 667,
+                                                                                                                end: 670,
                                                                                                             },
                                                                                                         },
                                                                                                         generics: GenericArgs {


### PR DESCRIPTION
This PR fixes all the nits and adds all the expressions needed to make `cargo dogfood` pass. This almost finishes the work from #52, besides the `.await` expression.

There is not too much more to say. I thought about adding `cargo dogfood` to the CI, but I think it's better to wait with that, until we have the first custom lints. For now, this is a nice step into the right direction.

---

cc: https://github.com/rust-marker/marker/issues/52