### PR TITLE
API: Add interface to resolve `TyDefId` by a path string

### DIFF
--- a/marker_api/src/context.rs
+++ b/marker_api/src/context.rs
@@ -147,6 +147,27 @@ impl<'ast> AstContext<'ast> {
         self.driver.call_body(id)
     }
 
+    /// This function tries to resolve the given path to the corresponding [`TyDefId`].
+    ///
+    /// The slice might be empty if the path could not be resolved. This could be
+    /// due to an error in the path or because the linted crate doesn't have the
+    /// required dependency. The function can also return multiple [`TyDefId`]s,
+    /// if there are multiple crates with different versions in the dependency tree.
+    ///
+    /// The returned ids are unordered and, depending on the driver, can also
+    /// change during different calls. The slice should not be stored across
+    /// `check_*` calls.
+    ///
+    /// Here is a simple example, how the method could be used:
+    /// ```ignore
+    /// // Get the type of an expression and check that it's an ADT
+    /// if let SemTyKind::Adt(ty) = expr.ty() {
+    ///     // Check if the id belongs to the path
+    ///     if cx.resolve_ty_ids("example::path::Item").contains(&ty.ty_id()) {
+    ///         // ...
+    ///     }
+    /// }
+    /// ```
     pub fn resolve_ty_ids(&self, path: &str) -> &[TyDefId] {
         (self.driver.resolve_ty_ids)(self.driver.driver_context, path.into()).get()
     }

--- a/marker_api/src/context.rs
+++ b/marker_api/src/context.rs
@@ -4,7 +4,7 @@ use crate::{
     ast::{
         item::{Body, ItemKind},
         ty::SemTyKind,
-        BodyId, ExprId, ItemId, Span, SpanOwner, SymbolId,
+        BodyId, ExprId, ItemId, Span, SpanOwner, SymbolId, TyDefId,
     },
     diagnostic::{Diagnostic, DiagnosticBuilder, EmissionNode},
     ffi,
@@ -146,6 +146,10 @@ impl<'ast> AstContext<'ast> {
     pub fn body(&self, id: BodyId) -> &Body<'ast> {
         self.driver.call_body(id)
     }
+
+    pub fn resolve_ty_ids(&self, path: &str) -> &[TyDefId] {
+        (self.driver.resolve_ty_ids)(self.driver.driver_context, path.into()).get()
+    }
 }
 
 impl<'ast> AstContext<'ast> {
@@ -203,6 +207,8 @@ struct DriverCallbacks<'ast> {
     pub item: extern "C" fn(&'ast (), id: ItemId) -> ffi::FfiOption<ItemKind<'ast>>,
     pub body: extern "C" fn(&'ast (), id: BodyId) -> &'ast Body<'ast>,
 
+    pub resolve_ty_ids: extern "C" fn(&'ast (), path: ffi::FfiStr<'_>) -> ffi::FfiSlice<'ast, TyDefId>,
+
     // Internal utility
     pub expr_ty: extern "C" fn(&'ast (), ExprId) -> SemTyKind<'ast>,
     pub get_span: extern "C" fn(&'ast (), &SpanOwner) -> &'ast Span<'ast>,
@@ -223,6 +229,10 @@ impl<'ast> DriverCallbacks<'ast> {
     fn call_item(&self, id: ItemId) -> Option<ItemKind<'ast>> {
         (self.item)(self.driver_context, id).copy()
     }
+    fn call_body(&self, id: BodyId) -> &'ast Body<'ast> {
+        (self.body)(self.driver_context, id)
+    }
+
     fn call_expr_ty(&self, expr: ExprId) -> SemTyKind<'ast> {
         (self.expr_ty)(self.driver_context, expr)
     }
@@ -235,9 +245,6 @@ impl<'ast> DriverCallbacks<'ast> {
     }
     fn call_symbol_str(&self, sym: SymbolId) -> &'ast str {
         (self.symbol_str)(self.driver_context, sym).get()
-    }
-    pub fn call_body(&self, id: BodyId) -> &'ast Body<'ast> {
-        (self.body)(self.driver_context, id)
     }
     pub fn resolve_method_target(&self, expr: ExprId) -> ItemId {
         (self.resolve_method_target)(self.driver_context, expr)

--- a/marker_driver_rustc/src/context.rs
+++ b/marker_driver_rustc/src/context.rs
@@ -131,6 +131,10 @@ impl<'ast, 'tcx: 'ast> DriverContext<'ast> for RustcContext<'ast, 'tcx> {
         self.marker_converter.to_body(rustc_body)
     }
 
+    fn resolve_ty_ids(&'ast self, _path: &str) -> &'ast [marker_api::ast::TyDefId] {
+        todo!()
+    }
+
     fn expr_ty(&'ast self, expr: ExprId) -> marker_api::ast::ty::SemTyKind<'ast> {
         let hir_id = self.rustc_converter.to_hir_id(expr);
         self.marker_converter.expr_ty(hir_id)

--- a/marker_driver_rustc/src/context/storage.rs
+++ b/marker_driver_rustc/src/context/storage.rs
@@ -36,6 +36,11 @@ impl<'ast> Storage<'ast> {
     {
         self.buffer.alloc_slice_fill_iter(iter)
     }
+
+    #[must_use]
+    pub fn alloc_str(&'ast self, value: &str) -> &'ast str {
+        self.buffer.alloc_str(value)
+    }
 }
 
 impl<'ast> Storage<'ast> {

--- a/marker_driver_rustc/src/conversion/marker.rs
+++ b/marker_driver_rustc/src/conversion/marker.rs
@@ -19,7 +19,7 @@ use marker_api::{
         expr::ExprKind,
         item::{Body, ItemKind},
         ty::SemTyKind,
-        BodyId, Crate, ExprId, ItemId, Span, SymbolId,
+        BodyId, Crate, ExprId, ItemId, Span, SymbolId, TyDefId,
     },
     lint::Level,
 };
@@ -74,6 +74,7 @@ impl<'ast, 'tcx> MarkerConverter<'ast, 'tcx> {
     forward_to_inner!(pub fn to_lint_level(&self, level: rustc_lint::Level) -> Level);
     forward_to_inner!(pub fn to_item(&self, rustc_item: &'tcx hir::Item<'tcx>) -> Option<ItemKind<'ast>>);
     forward_to_inner!(pub fn to_body(&self, body: &hir::Body<'tcx>) -> &'ast Body<'ast>);
+    forward_to_inner!(pub fn to_ty_def_id(&self, id: hir::def_id::DefId) -> TyDefId);
     forward_to_inner!(pub fn to_span(&self, rustc_span: rustc_span::Span) -> Span<'ast>);
     forward_to_inner!(pub fn to_crate(
         &self,

--- a/marker_lints/src/lib.rs
+++ b/marker_lints/src/lib.rs
@@ -4,11 +4,12 @@
 use marker_api::{
     ast::{
         item::{
-            ConstItem, EnumItem, EnumVariant, ExternCrateItem, Field, FnItem, ItemData, ModItem, StaticItem,
+            ConstItem, EnumItem, EnumVariant, ExternCrateItem, Field, FnItem, ItemData, ItemKind, ModItem, StaticItem,
             StructItem, UseItem,
         },
         pat::PatKind,
         stmt::StmtKind,
+        ty::SemTyKind,
         Span,
     },
     context::AstContext,
@@ -140,6 +141,66 @@ impl LintPass for TestLintPass {
                 cx.emit_lint(TEST_LINT, stmt.id(), "print type test", stmt.span(), |diag| {
                     diag.note(format!("{:#?}", expr.ty()));
                 });
+            } else if ident.name().starts_with("_check_path") {
+                cx.emit_lint(TEST_LINT, stmt.id(), "check type resolution", stmt.span(), |diag| {
+                    let SemTyKind::Adt(adt) = expr.ty().kind() else {
+                        unreachable!("how? Everything should be an ADT")
+                    };
+                    let path = "std::vec::Vec";
+                    let ids = cx.resolve_ty_ids(path);
+                    diag.note(format!("Is this a {:#?} -> {}", path, ids.contains(&adt.def_id())));
+
+                    let path = "std::string::String";
+                    let ids = cx.resolve_ty_ids(path);
+                    diag.note(format!("Is this a {:#?} -> {}", path, ids.contains(&adt.def_id())));
+
+                    let path = "std::option::Option";
+                    let ids = cx.resolve_ty_ids(path);
+                    diag.note(format!("Is this a {:#?} -> {}", path, ids.contains(&adt.def_id())));
+                });
+            }
+        }
+    }
+
+    fn check_item<'ast>(&mut self, cx: &'ast AstContext<'ast>, item: ItemKind<'ast>) {
+        fn try_resolve_path(cx: &AstContext<'_>, path: &str) {
+            let ids = cx.resolve_ty_ids(path);
+            eprintln!("Resolving {path:?} yielded {ids:#?}");
+        }
+
+        if let ItemKind::Fn(item) = item {
+            if let Some(ident) = item.ident() {
+                if ident.name() == "test_ty_id_resolution" {
+                    eprintln!("# Invalid paths");
+                    try_resolve_path(cx, "");
+                    try_resolve_path(cx, "something");
+                    try_resolve_path(cx, "bool");
+                    try_resolve_path(cx, "u32");
+                    try_resolve_path(cx, "crate::super");
+                    try_resolve_path(cx, "crate::self::super");
+
+                    eprintln!("");
+                    eprintln!("# Unresolvable");
+                    try_resolve_path(cx, "something::weird");
+                    try_resolve_path(cx, "something::weird::very::very::very::very::very::long");
+
+                    eprintln!("");
+                    eprintln!("# Not a type");
+                    try_resolve_path(cx, "std::env");
+                    try_resolve_path(cx, "std::i32");
+                    try_resolve_path(cx, "std::primitive::i32");
+                    try_resolve_path(cx, "std::option::Option::None");
+
+                    eprintln!("");
+                    eprintln!("# Valid");
+                    try_resolve_path(cx, "std::option::Option");
+                    try_resolve_path(cx, "std::vec::Vec");
+                    try_resolve_path(cx, "std::string::String");
+
+                    eprintln!("");
+                    eprintln!("=====================================================================");
+                    eprintln!("");
+                }
             }
         }
     }

--- a/marker_lints/src/lib.rs
+++ b/marker_lints/src/lib.rs
@@ -143,7 +143,7 @@ impl LintPass for TestLintPass {
                 });
             } else if ident.name().starts_with("_check_path") {
                 cx.emit_lint(TEST_LINT, stmt.id(), "check type resolution", stmt.span(), |diag| {
-                    let SemTyKind::Adt(adt) = expr.ty().kind() else {
+                    let SemTyKind::Adt(adt) = expr.ty() else {
                         unreachable!("how? Everything should be an ADT")
                     };
                     let path = "std::vec::Vec";
@@ -155,6 +155,10 @@ impl LintPass for TestLintPass {
                     diag.note(format!("Is this a {:#?} -> {}", path, ids.contains(&adt.def_id())));
 
                     let path = "std::option::Option";
+                    let ids = cx.resolve_ty_ids(path);
+                    diag.note(format!("Is this a {:#?} -> {}", path, ids.contains(&adt.def_id())));
+
+                    let path = "crate::TestType";
                     let ids = cx.resolve_ty_ids(path);
                     diag.note(format!("Is this a {:#?} -> {}", path, ids.contains(&adt.def_id())));
                 });
@@ -179,27 +183,36 @@ impl LintPass for TestLintPass {
                     try_resolve_path(cx, "crate::super");
                     try_resolve_path(cx, "crate::self::super");
 
-                    eprintln!("");
+                    eprintln!();
                     eprintln!("# Unresolvable");
                     try_resolve_path(cx, "something::weird");
                     try_resolve_path(cx, "something::weird::very::very::very::very::very::long");
 
-                    eprintln!("");
+                    eprintln!();
                     eprintln!("# Not a type");
                     try_resolve_path(cx, "std::env");
                     try_resolve_path(cx, "std::i32");
                     try_resolve_path(cx, "std::primitive::i32");
                     try_resolve_path(cx, "std::option::Option::None");
 
-                    eprintln!("");
+                    eprintln!();
                     eprintln!("# Valid");
                     try_resolve_path(cx, "std::option::Option");
                     try_resolve_path(cx, "std::vec::Vec");
                     try_resolve_path(cx, "std::string::String");
 
-                    eprintln!("");
+                    eprintln!();
+                    eprintln!("# Valid local items");
+                    try_resolve_path(cx, "item_id_resolution::TestType");
+                    try_resolve_path(cx, "crate::TestType");
+                    eprintln!(
+                        "Check equal: {}",
+                        cx.resolve_ty_ids("item_id_resolution::TestType") == cx.resolve_ty_ids("crate::TestType")
+                    );
+
+                    eprintln!();
                     eprintln!("=====================================================================");
-                    eprintln!("");
+                    eprintln!();
                 }
             }
         }

--- a/marker_lints/tests/ui/item_id_resolution.rs
+++ b/marker_lints/tests/ui/item_id_resolution.rs
@@ -1,10 +1,13 @@
 // normalize-stderr-windows: "tests/ui/" -> "$$DIR/"
 
+struct TestType(u32);
+
 // Please don't change the function name, it's used by the lint
 fn test_ty_id_resolution() {
     let _check_path_vec = vec!["hey"];
     let _check_path_string = String::from("marker");
     let _check_path_option = Option::Some("<3");
+    let _check_path_test_type = TestType(3);
 }
 
 fn main() {}

--- a/marker_lints/tests/ui/item_id_resolution.rs
+++ b/marker_lints/tests/ui/item_id_resolution.rs
@@ -1,0 +1,10 @@
+// normalize-stderr-windows: "tests/ui/" -> "$$DIR/"
+
+// Please don't change the function name, it's used by the lint
+fn test_ty_id_resolution() {
+    let _check_path_vec = vec!["hey"];
+    let _check_path_string = String::from("marker");
+    let _check_path_option = Option::Some("<3");
+}
+
+fn main() {}

--- a/marker_lints/tests/ui/item_id_resolution.stderr
+++ b/marker_lints/tests/ui/item_id_resolution.stderr
@@ -1,0 +1,64 @@
+# Invalid paths
+Resolving "" yielded []
+Resolving "something" yielded []
+Resolving "bool" yielded []
+Resolving "u32" yielded []
+Resolving "crate::super" yielded []
+Resolving "crate::self::super" yielded []
+
+# Unresolvable
+Resolving "something::weird" yielded []
+Resolving "something::weird::very::very::very::very::very::long" yielded []
+
+# Not a type
+Resolving "std::env" yielded []
+Resolving "std::i32" yielded []
+Resolving "std::primitive::i32" yielded []
+Resolving "std::option::Option::None" yielded []
+
+# Valid
+Resolving "std::option::Option" yielded [
+    TyDefId(..),
+]
+Resolving "std::vec::Vec" yielded [
+    TyDefId(..),
+]
+Resolving "std::string::String" yielded [
+    TyDefId(..),
+]
+
+=====================================================================
+
+warning: check type resolution
+ --> $DIR/item_id_resolution.rs:5:5
+  |
+5 |     let _check_path_vec = vec!["hey"];
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: Is this a "std::vec::Vec" -> true
+  = note: Is this a "std::string::String" -> false
+  = note: Is this a "std::option::Option" -> false
+  = note: `#[warn(marker::test_lint)]` on by default
+
+warning: check type resolution
+ --> $DIR/item_id_resolution.rs:6:5
+  |
+6 |     let _check_path_string = String::from("marker");
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: Is this a "std::vec::Vec" -> false
+  = note: Is this a "std::string::String" -> true
+  = note: Is this a "std::option::Option" -> false
+
+warning: check type resolution
+ --> $DIR/item_id_resolution.rs:7:5
+  |
+7 |     let _check_path_option = Option::Some("<3");
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: Is this a "std::vec::Vec" -> false
+  = note: Is this a "std::string::String" -> false
+  = note: Is this a "std::option::Option" -> true
+
+warning: 3 warnings emitted
+

--- a/marker_lints/tests/ui/item_id_resolution.stderr
+++ b/marker_lints/tests/ui/item_id_resolution.stderr
@@ -27,38 +27,61 @@ Resolving "std::string::String" yielded [
     TyDefId(..),
 ]
 
+# Valid local items
+Resolving "item_id_resolution::TestType" yielded [
+    TyDefId(..),
+]
+Resolving "crate::TestType" yielded [
+    TyDefId(..),
+]
+Check equal: true
+
 =====================================================================
 
 warning: check type resolution
- --> $DIR/item_id_resolution.rs:5:5
+ --> $DIR/item_id_resolution.rs:7:5
   |
-5 |     let _check_path_vec = vec!["hey"];
+7 |     let _check_path_vec = vec!["hey"];
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: Is this a "std::vec::Vec" -> true
   = note: Is this a "std::string::String" -> false
   = note: Is this a "std::option::Option" -> false
+  = note: Is this a "crate::TestType" -> false
   = note: `#[warn(marker::test_lint)]` on by default
 
 warning: check type resolution
- --> $DIR/item_id_resolution.rs:6:5
+ --> $DIR/item_id_resolution.rs:8:5
   |
-6 |     let _check_path_string = String::from("marker");
+8 |     let _check_path_string = String::from("marker");
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: Is this a "std::vec::Vec" -> false
   = note: Is this a "std::string::String" -> true
   = note: Is this a "std::option::Option" -> false
+  = note: Is this a "crate::TestType" -> false
 
 warning: check type resolution
- --> $DIR/item_id_resolution.rs:7:5
+ --> $DIR/item_id_resolution.rs:9:5
   |
-7 |     let _check_path_option = Option::Some("<3");
+9 |     let _check_path_option = Option::Some("<3");
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: Is this a "std::vec::Vec" -> false
   = note: Is this a "std::string::String" -> false
   = note: Is this a "std::option::Option" -> true
+  = note: Is this a "crate::TestType" -> false
 
-warning: 3 warnings emitted
+warning: check type resolution
+  --> $DIR/item_id_resolution.rs:10:5
+   |
+10 |     let _check_path_test_type = TestType(3);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: Is this a "std::vec::Vec" -> false
+   = note: Is this a "std::string::String" -> false
+   = note: Is this a "std::option::Option" -> false
+   = note: Is this a "crate::TestType" -> true
+
+warning: 4 warnings emitted
 


### PR DESCRIPTION
This is not the ideal implementation, as it requires manual path resolution. Rustc sadly hides the related functions from the public interface. https://github.com/rust-marker/marker/issues/93 provides additional information.

Closes: https://github.com/rust-marker/marker/issues/93