### PR TITLE
Refactoring: Migrating away from `lint_pass_fns` macro code gen

### DIFF
--- a/cargo-marker/src/config.rs
+++ b/cargo-marker/src/config.rs
@@ -53,7 +53,7 @@ impl From<GitRef> for GitReference {
 #[derive(Deserialize, Debug)]
 #[serde(untagged)]
 pub enum Source {
-    // TODO: Registries are not supported yet, see https://github.com/rust-marker/marker/issues/87
+    // FIXME: Registries are not supported yet, see https://github.com/rust-marker/marker/issues/87
     Registry {
         version: String,
         registry: Option<String>,
@@ -73,7 +73,7 @@ pub struct LintDependencyEntry {
     #[serde(flatten)]
     source: Source,
     package: Option<String>,
-    // TODO: Features are not supported yet, see https://github.com/rust-marker/marker/issues/81
+    // FIXME: Features are not supported yet, see https://github.com/rust-marker/marker/issues/81
     #[serde(rename = "default-features")]
     default_features: Option<bool>,
     features: Option<Vec<String>>,

--- a/marker_adapter/src/lib.rs
+++ b/marker_adapter/src/lib.rs
@@ -17,11 +17,11 @@ use marker_api::{
 
 /// This struct is the interface used by lint drivers to pass transformed objects to
 /// external lint passes.
-pub struct Adapter<'ast> {
-    external_lint_crates: LintCrateRegistry<'ast>,
+pub struct Adapter {
+    external_lint_crates: LintCrateRegistry,
 }
 
-impl<'ast> Adapter<'ast> {
+impl Adapter {
     #[must_use]
     pub fn new_from_env() -> Self {
         let external_lint_crates = LintCrateRegistry::new_from_env();
@@ -33,16 +33,16 @@ impl<'ast> Adapter<'ast> {
         self.external_lint_crates.registered_lints()
     }
 
-    pub fn process_krate(&mut self, cx: &'ast AstContext<'ast>, krate: &Crate<'ast>) {
+    pub fn process_krate<'ast>(&mut self, cx: &'ast AstContext<'ast>, krate: &Crate<'ast>) {
         self.external_lint_crates.set_ast_context(cx);
 
         for item in krate.items() {
-            self.external_lint_crates.check_item(cx, *item);
             self.process_item(cx, item);
         }
     }
 
-    fn process_item(&mut self, cx: &'ast AstContext<'ast>, item: &ItemKind<'ast>) {
+    fn process_item<'ast>(&mut self, cx: &'ast AstContext<'ast>, item: &ItemKind<'ast>) {
+        self.external_lint_crates.check_item(cx, *item);
         match item {
             ItemKind::Mod(data) => {
                 for item in data.items() {
@@ -72,14 +72,14 @@ impl<'ast> Adapter<'ast> {
         }
     }
 
-    fn process_body(&mut self, cx: &'ast AstContext<'ast>, id: BodyId) {
+    fn process_body<'ast>(&mut self, cx: &'ast AstContext<'ast>, id: BodyId) {
         let body = cx.body(id);
         self.external_lint_crates.check_body(cx, body);
         let expr = body.expr();
         self.process_expr(cx, expr);
     }
 
-    fn process_expr(&mut self, cx: &'ast AstContext<'ast>, expr: ExprKind<'ast>) {
+    fn process_expr<'ast>(&mut self, cx: &'ast AstContext<'ast>, expr: ExprKind<'ast>) {
         self.external_lint_crates.check_expr(cx, expr);
         #[expect(clippy::single_match)]
         match expr {

--- a/marker_adapter/src/lib.rs
+++ b/marker_adapter/src/lib.rs
@@ -45,30 +45,22 @@ impl<'ast> Adapter<'ast> {
     fn process_item(&mut self, cx: &'ast AstContext<'ast>, item: &ItemKind<'ast>) {
         match item {
             ItemKind::Mod(data) => {
-                self.external_lint_crates.check_mod(cx, data);
                 for item in data.items() {
                     self.process_item(cx, item);
                 }
             },
-            ItemKind::ExternCrate(data) => self.external_lint_crates.check_extern_crate(cx, data),
-            ItemKind::Use(data) => self.external_lint_crates.check_use_decl(cx, data),
-            ItemKind::Static(data) => self.external_lint_crates.check_static_item(cx, data),
-            ItemKind::Const(data) => self.external_lint_crates.check_const_item(cx, data),
             // FIXME: Function-local items are not yet processed
             ItemKind::Fn(data) => {
-                self.external_lint_crates.check_fn(cx, data);
                 if let Some(id) = data.body() {
                     self.process_body(cx, id);
                 }
             },
             ItemKind::Struct(data) => {
-                self.external_lint_crates.check_struct(cx, data);
                 for field in data.fields() {
                     self.external_lint_crates.check_field(cx, field);
                 }
             },
             ItemKind::Enum(data) => {
-                self.external_lint_crates.check_enum(cx, data);
                 for variant in data.variants() {
                     self.external_lint_crates.check_variant(cx, variant);
                     for field in variant.fields() {

--- a/marker_adapter/src/lib.rs
+++ b/marker_adapter/src/lib.rs
@@ -11,8 +11,7 @@ use loader::LintCrateRegistry;
 use marker_api::{
     ast::{expr::ExprKind, item::ItemKind, BodyId, Crate},
     context::AstContext,
-    lint::Lint,
-    LintPass,
+    LintPass, LintPassInfo,
 };
 
 /// This struct is the interface used by lint drivers to pass transformed objects to
@@ -29,8 +28,8 @@ impl Adapter {
     }
 
     #[must_use]
-    pub fn registered_lints(&self) -> Box<[&'static Lint]> {
-        self.external_lint_crates.registered_lints()
+    pub fn registered_lints(&self) -> Vec<LintPassInfo> {
+        self.external_lint_crates.collect_lint_pass_info()
     }
 
     pub fn process_krate<'ast>(&mut self, cx: &'ast AstContext<'ast>, krate: &Crate<'ast>) {

--- a/marker_adapter/src/loader.rs
+++ b/marker_adapter/src/loader.rs
@@ -1,9 +1,9 @@
 use cfg_if::cfg_if;
 use libloading::Library;
 
-use marker_api::{context::AstContext, interface::LintCrateBindings};
 use marker_api::lint::Lint;
 use marker_api::LintPass;
+use marker_api::{interface::LintCrateBindings, AstContext};
 
 use std::ffi::{OsStr, OsString};
 
@@ -44,15 +44,15 @@ fn windows_split_os_str(s: &OsStr, c: u8) -> Vec<OsString> {
 /// This struct loads external lint crates into memory and provides a safe API
 /// to call the respective methods on all of them.
 #[derive(Default)]
-pub struct LintCrateRegistry<'lib> {
-    passes: Vec<LoadedLintCrate<'lib>>,
+pub struct LintCrateRegistry {
+    passes: Vec<LoadedLintCrate>,
 }
 
-impl<'lib> LintCrateRegistry<'lib> {
+impl LintCrateRegistry {
     /// # Errors
     /// This can return errors if the library couldn't be found or if the
     /// required symbols weren't provided.
-    fn load_external_lib(lib_path: &OsStr) -> Result<LoadedLintCrate<'lib>, LoadingError> {
+    fn load_external_lib(lib_path: &OsStr) -> Result<LoadedLintCrate, LoadingError> {
         let lib: &'static Library = Box::leak(Box::new(
             unsafe { Library::new(lib_path) }.map_err(|_| LoadingError::FileNotFound)?,
         ));
@@ -92,45 +92,71 @@ impl<'lib> LintCrateRegistry<'lib> {
 
     pub(super) fn set_ast_context<'ast>(&self, cx: &'ast AstContext<'ast>) {
         for lint_pass in &self.passes {
-            lint_pass.set_ast_context(cx);
+            (lint_pass.bindings.set_ast_context)(cx);
         }
     }
 }
 
-impl<'a> LintPass for LintCrateRegistry<'a> {
+#[warn(clippy::missing_trait_methods)]
+impl LintPass for LintCrateRegistry {
     fn registered_lints(&self) -> Box<[&'static Lint]> {
-        let mut lints = vec![];
-        for lint_pass in &self.passes {
-            lints.extend_from_slice(&lint_pass.registered_lints());
-        }
-        lints.into_boxed_slice()
+        // let mut lints = vec![];
+        // for lint_pass in &self.passes {
+        //     lints.extend_from_slice(&lint_pass.registered_lints());
+        // }
+        // lints.into_boxed_slice()
+        panic!("`registered_lints` should not be called on `LintCrateRegistry`");
     }
 
-    marker_api::for_each_lint_pass_fn!(crate::gen_lint_crate_reg_lint_pass_fn);
-}
-
-#[macro_export]
-macro_rules! gen_lint_crate_reg_lint_pass_fn {
-    (fn $fn_name:ident<'ast>(&self $(, $arg_name:ident: $arg_ty:ty)*) -> $ret_ty:ty) => {
-        // Nothing these will be implemented manually
-    };
-    (fn $fn_name:ident<'ast>(&(mut) self $(, $arg_name:ident: $arg_ty:ty)*) -> ()) => {
-        fn $fn_name<'ast>(&mut self $(, $arg_name: $arg_ty)*) {
-            for lint_pass in self.passes.iter_mut() {
-                lint_pass.$fn_name($($arg_name, )*);
-            }
+    fn check_item<'ast>(&mut self, cx: &'ast AstContext<'ast>, item: marker_api::ast::item::ItemKind<'ast>) {
+        for lp in &self.passes {
+            (lp.bindings.check_item)(cx, item);
         }
-    };
+    }
+
+    fn check_field<'ast>(&mut self, cx: &'ast AstContext<'ast>, field: &'ast marker_api::ast::item::Field<'ast>) {
+        for lp in &self.passes {
+            (lp.bindings.check_field)(cx, field);
+        }
+    }
+
+    fn check_variant<'ast>(
+        &mut self,
+        cx: &'ast AstContext<'ast>,
+        variant: &'ast marker_api::ast::item::EnumVariant<'ast>,
+    ) {
+        for lp in &self.passes {
+            (lp.bindings.check_variant)(cx, variant);
+        }
+    }
+
+    fn check_body<'ast>(&mut self, cx: &'ast AstContext<'ast>, body: &'ast marker_api::ast::item::Body<'ast>) {
+        for lp in &self.passes {
+            (lp.bindings.check_body)(cx, body);
+        }
+    }
+
+    fn check_stmt<'ast>(&mut self, cx: &'ast AstContext<'ast>, stmt: marker_api::ast::stmt::StmtKind<'ast>) {
+        for lp in &self.passes {
+            (lp.bindings.check_stmt)(cx, stmt);
+        }
+    }
+
+    fn check_expr<'ast>(&mut self, cx: &'ast AstContext<'ast>, expr: marker_api::ast::expr::ExprKind<'ast>) {
+        for lp in &self.passes {
+            (lp.bindings.check_expr)(cx, expr);
+        }
+    }
 }
 
-struct LoadedLintKrate {
+struct LoadedLintCrate {
     _lib: &'static Library,
     bindings: LintCrateBindings,
 }
 
-impl LoadedLintKrate {
+impl LoadedLintCrate {
     fn try_from_lib(lib: &'static Library) -> Result<Self, LoadingError> {
-        // 
+        // Check API version for verification
         let get_api_version = {
             unsafe {
                 lib.get::<unsafe extern "C" fn() -> &'static str>(b"marker_get_api_version\0")
@@ -141,98 +167,16 @@ impl LoadedLintKrate {
             return Err(LoadingError::IncompatibleVersion);
         }
 
+        // Load bindings
         let get_lint_crate_bindings = unsafe {
             lib.get::<extern "C" fn() -> LintCrateBindings>(b"marker_get_lint_crate_bindings\0")
                 .map_err(|_| LoadingError::MissingLintDeclaration)?
         };
-
         let bindings = get_lint_crate_bindings();
 
-        Ok(Self {
-            _lib: lib,
-            bindings
-        })
+        Ok(Self { _lib: lib, bindings })
     }
 }
-
-/// This macro generates the `LoadedLintCrate` struct, and functions for
-/// calling the [`LintPass`] functions. It's the counter part to
-/// [`marker_api::export_lint_pass`]
-#[macro_export]
-macro_rules! gen_LoadedLintCrate {
-    (
-        ($dollar:tt)
-        $(fn $fn_name:ident<'ast>(& $(($mut_:tt))? self $(, $arg_name:ident: $arg_ty:ty)*) -> $ret_ty:ty;)+
-    ) => {
-        /// This struct holds function pointers to api functions in the loaded lint crate
-        /// It owns the library instance. It sadly has to be stored as a `'static`
-        /// reference due to lifetime restrictions.
-        struct LoadedLintCrate<'a> {
-            _lib: &'static Library,
-            set_ast_context: libloading::Symbol<'a, for<'ast> unsafe extern "C" fn(&'ast AstContext<'ast>) -> ()>,
-            $(
-                $fn_name: libloading::Symbol<'a, for<'ast> unsafe extern "C" fn($($arg_ty,)*) -> $ret_ty>,
-            )*
-        }
-
-        impl<'a> LoadedLintCrate<'a> {
-            /// This function tries to resolve all api functions in the given library.
-            fn try_from_lib(lib: &'static Library) -> Result<Self, LoadingError> {
-                // get function pointers
-                let get_marker_api_version = {
-                    unsafe {
-                        lib.get::<unsafe extern "C" fn() -> &'static str>(b"get_marker_api_version\0")
-                            .map_err(|_| LoadingError::MissingLintDeclaration)?
-                    }
-                };
-                if unsafe { get_marker_api_version() } != marker_api::MARKER_API_VERSION {
-                    return Err(LoadingError::IncompatibleVersion);
-                }
-
-                let set_ast_context = unsafe {
-                    lib.get::<for<'ast> unsafe extern "C" fn(&'ast AstContext<'ast>)>(b"set_ast_context\0")
-                        .map_err(|_| LoadingError::MissingLintDeclaration)?
-                };
-
-                $(
-                    let $fn_name = {
-                        let name: Vec<u8> = stringify!($fn_name).bytes().chain(std::iter::once(b'\0')).collect();
-                        unsafe {
-                            lib.get::<for<'ast> unsafe extern "C" fn($($arg_ty,)*) -> $ret_ty>(&name)
-                                .map_err(|_| LoadingError::MissingLintDeclaration)?
-                        }
-                    };
-                )*
-                // create Self
-                Ok(Self {
-                    _lib: lib,
-                    set_ast_context,
-                    $(
-                        $fn_name,
-                    )*
-                })
-            }
-
-            fn set_ast_context<'ast>(&self, cx: &'ast AstContext<'ast>) -> () {
-                unsafe {
-                    (self.set_ast_context)(cx)
-                }
-            }
-
-            // safe wrapper to external functions
-            $(
-                #[allow(clippy::extra_unused_lifetimes)]
-                fn $fn_name<'ast>(&self $(, $arg_name: $arg_ty)*) -> $ret_ty {
-                    unsafe {
-                        (self.$fn_name)($($arg_name,)*)
-                    }
-                }
-            )*
-        }
-
-    };
-}
-marker_api::lint_pass_fns!(crate::gen_LoadedLintCrate);
 
 #[derive(Debug)]
 pub enum LoadingError {

--- a/marker_adapter/src/loader.rs
+++ b/marker_adapter/src/loader.rs
@@ -1,9 +1,8 @@
 use cfg_if::cfg_if;
 use libloading::Library;
 
-use marker_api::lint::Lint;
-use marker_api::LintPass;
 use marker_api::{interface::LintCrateBindings, AstContext};
+use marker_api::{LintPass, LintPassInfo};
 
 use std::ffi::{OsStr, OsString};
 
@@ -95,16 +94,19 @@ impl LintCrateRegistry {
             (lint_pass.bindings.set_ast_context)(cx);
         }
     }
+
+    pub(crate) fn collect_lint_pass_info(&self) -> Vec<LintPassInfo> {
+        let mut info = vec![];
+        for pass in &self.passes {
+            info.push((pass.bindings.info)());
+        }
+        info
+    }
 }
 
 #[warn(clippy::missing_trait_methods)]
 impl LintPass for LintCrateRegistry {
-    fn registered_lints(&self) -> Box<[&'static Lint]> {
-        // let mut lints = vec![];
-        // for lint_pass in &self.passes {
-        //     lints.extend_from_slice(&lint_pass.registered_lints());
-        // }
-        // lints.into_boxed_slice()
+    fn info(&self) -> LintPassInfo {
         panic!("`registered_lints` should not be called on `LintCrateRegistry`");
     }
 

--- a/marker_api/Cargo.toml
+++ b/marker_api/Cargo.toml
@@ -3,6 +3,7 @@ name = "marker_api"
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
+readme = "./README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/marker_api/README.md
+++ b/marker_api/README.md
@@ -27,12 +27,12 @@ use marker_api::{lint::Lint, LintPass};
 
 // With the [`declare_lint!`] macro we define a new lint. The macro accepts a
 // name, default lint level and description.
-marker_api::lint::declare_lint!(YOUR_LINT_NAME, Allow, "the lint descritpion");
+marker_api::declare_lint!(YOUR_LINT_NAME, Allow, "the lint descritpion");
 
 // Here we create an object that'll implement `LintPass`. This struct can
 // hold data used for linting. A mutable reference of this struct is passed to
 // each check in `LintPass`
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct TestLintPass;
 
 // Here we implement the `LintPass` for our struct. It only requires the
@@ -51,5 +51,5 @@ impl LintPass for TestLintPass {
 // Each lint crate requires exactly one marker. All lints have to be implemented
 // in one lint pass. For multiple lints it can be helpful to extract the individual
 // linting logic called by the `check_*` functions into separate modules.
-marker_api::interface::export_lint_pass!(TestLintPass);
+marker_api::export_lint_pass!(TestLintPass);
 ```

--- a/marker_api/src/context.rs
+++ b/marker_api/src/context.rs
@@ -1,3 +1,7 @@
+//! This module is responsible for the [`AstContext`] struct and related plumbing.
+//! Items in this module are generally unstable, with the exception of the
+//! exposed interface of [`AstContext`].
+
 use std::{cell::RefCell, mem::transmute};
 
 use crate::{

--- a/marker_api/src/diagnostic.rs
+++ b/marker_api/src/diagnostic.rs
@@ -1,3 +1,6 @@
+//! This module is responsible for the construction of diagnostic messages. The
+//! [`DiagnosticBuilder`] is the public stable interface, to construct messages.
+
 use crate::{
     ast::{ExprId, FieldId, ItemId, Span, StmtId, VariantId},
     context::AstContext,

--- a/marker_api/src/ffi.rs
+++ b/marker_api/src/ffi.rs
@@ -16,6 +16,7 @@ use std::{marker::PhantomData, slice};
 #[derive(Clone, Copy)]
 pub struct FfiStr<'a> {
     _lifetime: PhantomData<&'a ()>,
+    /// Not really *const, but it should have the lifetime of at least `'a`
     data: *const u8,
     len: usize,
 }
@@ -119,6 +120,7 @@ impl<T> From<Option<T>> for FfiOption<T> {
 #[derive(PartialEq, Eq, Hash, Clone, Copy)]
 pub struct FfiSlice<'a, T> {
     _lifetime: PhantomData<&'a ()>,
+    /// Not really *const, but it should have the lifetime of at least `'a`
     data: *const T,
     len: usize,
 }

--- a/marker_api/src/interface.rs
+++ b/marker_api/src/interface.rs
@@ -71,25 +71,44 @@ macro_rules! export_lint_pass {
                     $crate::context::set_ast_cx(cx);
                 }
                 extern "C" fn registered_lints() -> &'static [&'static $crate::lint::Lint] {
-                    let _lints: Box<[&'static $crate::lint::Lint]> = super::__MARKER_STATE.with(|state| state.borrow_mut().registered_lints());
+                    let _lints: Box<[&'static $crate::lint::Lint]> =
+                        super::__MARKER_STATE.with(|state| state.borrow_mut().registered_lints());
                     todo!()
                 }
-                extern "C" fn check_item<'ast>(cx: &'ast $crate::AstContext<'ast>, item: $crate::ast::item::ItemKind<'ast>) {
+                extern "C" fn check_item<'ast>(
+                    cx: &'ast $crate::AstContext<'ast>,
+                    item: $crate::ast::item::ItemKind<'ast>,
+                ) {
                     super::__MARKER_STATE.with(|state| state.borrow_mut().check_item(cx, item));
                 }
-                extern "C" fn check_field<'ast>(cx: &'ast $crate::AstContext<'ast>, field: &'ast $crate::ast::item::Field<'ast>) {
+                extern "C" fn check_field<'ast>(
+                    cx: &'ast $crate::AstContext<'ast>,
+                    field: &'ast $crate::ast::item::Field<'ast>,
+                ) {
                     super::__MARKER_STATE.with(|state| state.borrow_mut().check_field(cx, field));
                 }
-                extern "C" fn check_variant<'ast>(cx: &'ast $crate::AstContext<'ast>, variant: &'ast $crate::ast::item::EnumVariant<'ast>) {
+                extern "C" fn check_variant<'ast>(
+                    cx: &'ast $crate::AstContext<'ast>,
+                    variant: &'ast $crate::ast::item::EnumVariant<'ast>,
+                ) {
                     super::__MARKER_STATE.with(|state| state.borrow_mut().check_variant(cx, variant));
                 }
-                extern "C" fn check_body<'ast>(cx: &'ast $crate::AstContext<'ast>, body: &'ast $crate::ast::item::Body<'ast>) {
+                extern "C" fn check_body<'ast>(
+                    cx: &'ast $crate::AstContext<'ast>,
+                    body: &'ast $crate::ast::item::Body<'ast>,
+                ) {
                     super::__MARKER_STATE.with(|state| state.borrow_mut().check_body(cx, body));
                 }
-                extern "C" fn check_stmt<'ast>(cx: &'ast $crate::AstContext<'ast>, stmt: $crate::ast::stmt::StmtKind<'ast>) {
+                extern "C" fn check_stmt<'ast>(
+                    cx: &'ast $crate::AstContext<'ast>,
+                    stmt: $crate::ast::stmt::StmtKind<'ast>,
+                ) {
                     super::__MARKER_STATE.with(|state| state.borrow_mut().check_stmt(cx, stmt));
                 }
-                extern "C" fn check_expr<'ast>(cx: &'ast $crate::AstContext<'ast>, expr: $crate::ast::expr::ExprKind<'ast>) {
+                extern "C" fn check_expr<'ast>(
+                    cx: &'ast $crate::AstContext<'ast>,
+                    expr: $crate::ast::expr::ExprKind<'ast>,
+                ) {
                     super::__MARKER_STATE.with(|state| state.borrow_mut().check_expr(cx, expr));
                 }
 

--- a/marker_api/src/interface.rs
+++ b/marker_api/src/interface.rs
@@ -1,3 +1,6 @@
+//! A module responsible for generating and exposing an interface from lint crates.
+//! [`export_lint_pass`](crate::export_lint_pass) is the main macro, from this module.
+
 use crate::context::AstContext;
 
 /// **!Unstable!**

--- a/marker_api/src/lib.rs
+++ b/marker_api/src/lib.rs
@@ -21,13 +21,14 @@ pub mod lint;
 pub mod ffi;
 
 pub use context::AstContext;
+pub use interface::{LintPassInfo, LintPassInfoBuilder};
 
 /// A [`LintPass`] visits every node like a `Visitor`. The difference is that a
 /// [`LintPass`] provides some additional information about the implemented lints.
 /// The adapter will walk through the entire AST once and give each node to the
 /// registered [`LintPass`]es.
 pub trait LintPass {
-    fn registered_lints(&self) -> Box<[&'static lint::Lint]>;
+    fn info(&self) -> LintPassInfo;
 
     fn check_item<'ast>(&mut self, _cx: &'ast AstContext<'ast>, _item: ast::item::ItemKind<'ast>) {}
     fn check_field<'ast>(&mut self, _cx: &'ast AstContext<'ast>, _field: &'ast ast::item::Field<'ast>) {}

--- a/marker_api/src/lib.rs
+++ b/marker_api/src/lib.rs
@@ -20,6 +20,8 @@ pub mod lint;
 #[doc(hidden)]
 pub mod ffi;
 
+pub use context::AstContext;
+
 /// **!Unstable!**
 ///
 /// This macro returns a list of all functions declared for the [`LintPass`] trait.
@@ -49,38 +51,6 @@ macro_rules! lint_pass_fns {
                 &(mut) self,
                 _cx: &'ast $crate::context::AstContext<'ast>,
                 _item: $crate::ast::item::ItemKind<'ast>) -> ();
-            fn check_mod<'ast>(
-                &(mut) self,
-                _cx: &'ast $crate::context::AstContext<'ast>,
-                _item: &'ast $crate::ast::item::ModItem<'ast>) -> ();
-            fn check_extern_crate<'ast>(
-                &(mut) self,
-                _cx: &'ast $crate::context::AstContext<'ast>,
-                _item: &'ast $crate::ast::item::ExternCrateItem<'ast>) -> ();
-            fn check_use_decl<'ast>(
-                &(mut) self,
-                _cx: &'ast $crate::context::AstContext<'ast>,
-                _item: &'ast $crate::ast::item::UseItem<'ast>) -> ();
-            fn check_static_item<'ast>(
-                &(mut) self,
-                _cx: &'ast $crate::context::AstContext<'ast>,
-                _item: &'ast $crate::ast::item::StaticItem<'ast>) -> ();
-            fn check_const_item<'ast>(
-                &(mut) self,
-                _cx: &'ast $crate::context::AstContext<'ast>,
-                _item: &'ast $crate::ast::item::ConstItem<'ast>) -> ();
-            fn check_fn<'ast>(
-                &(mut) self,
-                _cx: &'ast $crate::context::AstContext<'ast>,
-                _item: &'ast $crate::ast::item::FnItem<'ast>) -> ();
-            fn check_struct<'ast>(
-                &(mut) self,
-                _cx: &'ast $crate::context::AstContext<'ast>,
-                _item: &'ast $crate::ast::item::StructItem<'ast>) -> ();
-            fn check_enum<'ast>(
-                &(mut) self,
-                _cx: &'ast $crate::context::AstContext<'ast>,
-                _item: &'ast $crate::ast::item::EnumItem<'ast>) -> ();
             fn check_field<'ast>(
                 &(mut) self,
                 _cx: &'ast $crate::context::AstContext<'ast>,

--- a/marker_api/src/lint.rs
+++ b/marker_api/src/lint.rs
@@ -34,11 +34,13 @@ pub struct Lint {
     ///
     /// See [`MacroReport`] for the possible levels.
     pub report_in_macro: MacroReport,
-    // TODO: do we want these
-    // pub edition_lint_opts: Option<(Edition, Level)>,
-    // pub future_incompatible: Option<FutureIncompatibleInfo>,
-    // pub feature_gate: Option<&'static str>,
-    // pub crate_level_only: bool,
+    // FIXME: We might want to add more fields. This should be possible as this
+    // struct is always constructed by a macro controlled by marker. These are some
+    // additional fields used  in rustc:
+    // * pub edition_lint_opts: Option<(Edition, Level)>,
+    // * pub future_incompatible: Option<FutureIncompatibleInfo>,
+    // * pub feature_gate: Option<&'static str>,
+    // * pub crate_level_only: bool,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]

--- a/marker_api/src/lint.rs
+++ b/marker_api/src/lint.rs
@@ -1,3 +1,4 @@
+#[repr(C)]
 #[derive(Debug, PartialEq, Eq, Hash)]
 // This sadly cannot be marked as #[non_exhaustive] as the struct construction
 // has to be possible in a static context.
@@ -43,8 +44,12 @@ pub struct Lint {
     // * pub crate_level_only: bool,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+/// FIXME(xFrednet): These settings currently don't work.
+///
+/// See rust-marker#149
+#[repr(C)]
 #[non_exhaustive]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum MacroReport {
     /// No reporting in local or external macros.
     No,
@@ -87,7 +92,7 @@ pub enum Level {
 #[macro_export]
 macro_rules! declare_lint {
     ($(#[$attr:meta])* $NAME: ident, $LEVEL: ident, $EXPLANATION: literal $(,)?) => {
-        $crate::lint::declare_lint!{$(#[$attr])* $NAME, $LEVEL, $EXPLANATION, $crate::lint::MacroReport::No }
+        $crate::declare_lint!{$(#[$attr])* $NAME, $LEVEL, $EXPLANATION, $crate::lint::MacroReport::No }
     };
     ($(#[$attr:meta])* $NAME: ident, $LEVEL: ident,
         $EXPLANATION: literal, $REPORT_IN_MACRO: expr $(,)?
@@ -101,5 +106,3 @@ macro_rules! declare_lint {
         };
     };
 }
-
-pub use declare_lint;

--- a/marker_uitest/src/lib.rs
+++ b/marker_uitest/src/lib.rs
@@ -15,7 +15,11 @@ use marker_api::{
     LintPass,
 };
 
-marker_api::interface::export_lint_pass!(TestLintPass);
+
+#[derive(Default)]
+struct TestLintPass {}
+
+marker_api::export_lint_pass!(TestLintPass);
 
 marker_api::lint::declare_lint!(TEST_LINT, Warn, "test lint warning");
 
@@ -37,9 +41,6 @@ fn emit_item_with_test_name_lint<'ast>(
     cx.emit_lint(ITEM_WITH_TEST_NAME, node, msg, span, |_| {});
 }
 
-#[derive(Default)]
-struct TestLintPass {}
-
 impl LintPass for TestLintPass {
     fn registered_lints(&self) -> Box<[&'static Lint]> {
         Box::new([TEST_LINT])
@@ -54,11 +55,11 @@ impl LintPass for TestLintPass {
             }
         }
 
-        match item {
-            ItemKind::Static(item) => check_static_item(cx, item),
-            _ => {},
+        if let ItemKind::Static(item) = item {
+            check_static_item(cx, item);
         }
-        if matches!(item.ident().map(|x| x.name()), Some(name) if name.starts_with("FindMe") || name.starts_with("FIND_ME") || name.starts_with("find_me"))
+
+        if matches!(item.ident().map(marker_api::ast::Ident::name), Some(name) if name.starts_with("FindMe") || name.starts_with("FIND_ME") || name.starts_with("find_me"))
         {
             let msg = match item {
                 ItemKind::Mod(_) => Some("module"),

--- a/marker_uitest/src/lib.rs
+++ b/marker_uitest/src/lib.rs
@@ -20,9 +20,9 @@ struct TestLintPass {}
 
 marker_api::export_lint_pass!(TestLintPass);
 
-marker_api::lint::declare_lint!(TEST_LINT, Warn, "test lint warning");
+marker_api::declare_lint!(TEST_LINT, Warn, "test lint warning");
 
-marker_api::lint::declare_lint!(
+marker_api::declare_lint!(
     ITEM_WITH_TEST_NAME,
     Warn,
     r#"A lint used for markers uitests.
@@ -58,8 +58,10 @@ impl LintPass for TestLintPass {
             check_static_item(cx, item);
         }
 
-        if matches!(item.ident().map(marker_api::ast::Ident::name), Some(name) if name.starts_with("FindMe") || name.starts_with("FIND_ME") || name.starts_with("find_me"))
-        {
+        if matches!(
+            item.ident().map(marker_api::ast::Ident::name),
+            Some(name) if name.starts_with("FindMe") || name.starts_with("FIND_ME") || name.starts_with("find_me")
+        ) {
             let msg = match item {
                 ItemKind::Mod(_) => Some("module"),
                 ItemKind::Use(_) => Some("use"),

--- a/marker_uitest/src/lib.rs
+++ b/marker_uitest/src/lib.rs
@@ -11,8 +11,7 @@ use marker_api::{
     },
     context::AstContext,
     diagnostic::{Applicability, EmissionNode},
-    lint::Lint,
-    LintPass,
+    LintPass, LintPassInfo, LintPassInfoBuilder,
 };
 
 #[derive(Default)]
@@ -41,8 +40,8 @@ fn emit_item_with_test_name_lint<'ast>(
 }
 
 impl LintPass for TestLintPass {
-    fn registered_lints(&self) -> Box<[&'static Lint]> {
-        Box::new([TEST_LINT])
+    fn info(&self) -> LintPassInfo {
+        LintPassInfoBuilder::new(Box::new([TEST_LINT, ITEM_WITH_TEST_NAME])).build()
     }
 
     fn check_item<'ast>(&mut self, cx: &'ast AstContext<'ast>, item: ItemKind<'ast>) {

--- a/marker_uitest/src/lib.rs
+++ b/marker_uitest/src/lib.rs
@@ -15,7 +15,6 @@ use marker_api::{
     LintPass,
 };
 
-
 #[derive(Default)]
 struct TestLintPass {}
 

--- a/marker_uitest/tests/ui/foo_items.rs
+++ b/marker_uitest/tests/ui/foo_items.rs
@@ -1,21 +1,23 @@
-mod good {
-    fn foo() {}
+mod find_me {
+    const FIND_ME_CONST: i32 = 0;
 
-    static FOO: i32 = 0;
+    static FIND_ME_STATIC: i32 = 0;
 
-    struct Foo {
-        foo: i32,
+    pub fn find_me_fn() {}
+
+    struct FindMeStruct {
+        find_me_field: i32,
     }
+    enum FindMeEnum {
+        FindMe,
+    }
+    union FindMeUnion {
+        a: i32,
+        b: u32,
+    }
+    trait FindMeTrait {}
 }
 
-mod foo {
-    use crate::good as foo;
-
-    const FOO: i32 = 0;
-
-    enum Foo {
-        Foo,
-    }
-}
+use find_me::find_me_fn as find_me;
 
 fn main() {}

--- a/marker_uitest/tests/ui/foo_items.stderr
+++ b/marker_uitest/tests/ui/foo_items.stderr
@@ -1,68 +1,34 @@
-warning: a function named `foo`, consider using a more meaningful name
- --> $DIR/foo_items.rs:2:5
-  |
-2 |     fn foo() {}
-  |     ^^^^^^^^^^^
-  |
-  = note: `#[warn(marker::foo_items)]` on by default
-
-warning: a static item named `foo`, consider using a more meaningful name
- --> $DIR/foo_items.rs:4:5
-  |
-4 |     static FOO: i32 = 0;
-  |     ^^^^^^^^^^^^^^^^^^^^
-
-warning: a struct named `foo`, consider using a more meaningful name
- --> $DIR/foo_items.rs:6:5
-  |
-6 | /     struct Foo {
-7 | |         foo: i32,
-8 | |     }
-  | |_____^
-
-warning: a field named `foo`, consider using a more meaningful name
- --> $DIR/foo_items.rs:7:9
-  |
-7 |         foo: i32,
-  |         ^^^^^^^^
-
-warning: a module named `foo`, consider using a more meaningful name
-  --> $DIR/foo_items.rs:11:1
+warning: found a `module` item with a test name
+  --> $DIR/foo_items.rs:1:1
    |
-11 | / mod foo {
-12 | |     use crate::good as foo;
-13 | |
-14 | |     const FOO: i32 = 0;
+1  | / mod find_me {
+2  | |     const FIND_ME_CONST: i32 = 0;
+3  | |
+4  | |     static FIND_ME_STATIC: i32 = 0;
 ...  |
-18 | |     }
+18 | |     trait FindMeTrait {}
 19 | | }
    | |_^
-
-warning: a `use` binding named `foo`, consider using a more meaningful name
-  --> $DIR/foo_items.rs:12:5
    |
-12 |     use crate::good as foo;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `#[warn(marker::item_with_test_name)]` on by default
 
-warning: a constant item named `foo`, consider using a more meaningful name
-  --> $DIR/foo_items.rs:14:5
+warning: found a field with a test name
+ --> $DIR/foo_items.rs:9:9
+  |
+9 |         find_me_field: i32,
+  |         ^^^^^^^^^^^^^^^^^^
+
+warning: found an enum variant with a test name
+  --> $DIR/foo_items.rs:12:9
    |
-14 |     const FOO: i32 = 0;
-   |     ^^^^^^^^^^^^^^^^^^^
+12 |         FindMe,
+   |         ^^^^^^
 
-warning: an enum named `foo`, consider using a more meaningful name
-  --> $DIR/foo_items.rs:16:5
+warning: found a `use` item with a test name
+  --> $DIR/foo_items.rs:21:1
    |
-16 | /     enum Foo {
-17 | |         Foo,
-18 | |     }
-   | |_____^
+21 | use find_me::find_me_fn as find_me;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: an enum variant named `foo`, consider using a more meaningful name
-  --> $DIR/foo_items.rs:17:9
-   |
-17 |         Foo,
-   |         ^^^
-
-warning: 9 warnings emitted
+warning: 4 warnings emitted
 

--- a/marker_uitest/tests/ui/foo_items.stderr
+++ b/marker_uitest/tests/ui/foo_items.stderr
@@ -12,11 +12,45 @@ warning: found a `module` item with a test name
    |
    = note: `#[warn(marker::item_with_test_name)]` on by default
 
+warning: found a `const` item with a test name
+ --> $DIR/foo_items.rs:2:5
+  |
+2 |     const FIND_ME_CONST: i32 = 0;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: found a `static` item with a test name
+ --> $DIR/foo_items.rs:4:5
+  |
+4 |     static FIND_ME_STATIC: i32 = 0;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: found a `fn` item with a test name
+ --> $DIR/foo_items.rs:6:5
+  |
+6 |     pub fn find_me_fn() {}
+  |     ^^^^^^^^^^^^^^^^^^^^^^
+
+warning: found a `struct` item with a test name
+  --> $DIR/foo_items.rs:8:5
+   |
+8  | /     struct FindMeStruct {
+9  | |         find_me_field: i32,
+10 | |     }
+   | |_____^
+
 warning: found a field with a test name
  --> $DIR/foo_items.rs:9:9
   |
 9 |         find_me_field: i32,
   |         ^^^^^^^^^^^^^^^^^^
+
+warning: found a `enum` item with a test name
+  --> $DIR/foo_items.rs:11:5
+   |
+11 | /     enum FindMeEnum {
+12 | |         FindMe,
+13 | |     }
+   | |_____^
 
 warning: found an enum variant with a test name
   --> $DIR/foo_items.rs:12:9
@@ -24,11 +58,26 @@ warning: found an enum variant with a test name
 12 |         FindMe,
    |         ^^^^^^
 
+warning: found a `union` item with a test name
+  --> $DIR/foo_items.rs:14:5
+   |
+14 | /     union FindMeUnion {
+15 | |         a: i32,
+16 | |         b: u32,
+17 | |     }
+   | |_____^
+
+warning: found a `trait` item with a test name
+  --> $DIR/foo_items.rs:18:5
+   |
+18 |     trait FindMeTrait {}
+   |     ^^^^^^^^^^^^^^^^^^^^
+
 warning: found a `use` item with a test name
   --> $DIR/foo_items.rs:21:1
    |
 21 | use find_me::find_me_fn as find_me;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: 4 warnings emitted
+warning: 11 warnings emitted
 

--- a/marker_uitest/tests/ui/print_ty.stderr
+++ b/marker_uitest/tests/ui/print_ty.stderr
@@ -1,4 +1,4 @@
-warning: Printing type for
+warning: printing type for
  --> $DIR/print_ty.rs:4:32
   |
 4 | static PRINT_TYPE_PRIMITIVE_1: Option<(u8, u16, u32, u64, u128, usize)> = None;
@@ -109,7 +109,7 @@ Path(
 )
 
 
-warning: Printing type for
+warning: printing type for
  --> $DIR/print_ty.rs:5:32
   |
 5 | static PRINT_TYPE_PRIMITIVE_2: Option<(i8, i16, i32, i64, i128, isize)> = None;
@@ -218,7 +218,7 @@ Path(
 )
 
 
-warning: Printing type for
+warning: printing type for
  --> $DIR/print_ty.rs:6:32
   |
 6 | static PRINT_TYPE_PRIMITIVE_3: Option<(char, bool, f32, f64)> = None;
@@ -308,7 +308,7 @@ Path(
 )
 
 
-warning: Printing type for
+warning: printing type for
  --> $DIR/print_ty.rs:7:29
   |
 7 | static PRINT_TYPE_SEQUENCE: Option<AllowSync<(&[i32], [i32; 8])>> = None;
@@ -452,7 +452,7 @@ Path(
 )
 
 
-warning: Printing type for
+warning: printing type for
  --> $DIR/print_ty.rs:8:28
   |
 8 | static PRINT_TYPE_POINTER: Option<AllowSync<(&'static str, *const i32, *mut i32)>> = None;
@@ -607,7 +607,7 @@ Path(
 )
 
 
-warning: Printing type for
+warning: printing type for
   --> $DIR/print_ty.rs:9:28
    |
 9  |   static PRINT_TYPE_COMPLEX: Option<


### PR DESCRIPTION
The motivation behind this change is explained in https://github.com/rust-marker/marker/issues/147. The `lint_pass_fns` macro is basically removed in favor of manually writing some boilerplate. This PR is also a preparation for following PRs.

The last commit also addresses https://github.com/rust-marker/marker/issues/146.

---

Closes https://github.com/rust-marker/marker/issues/147 
Closes https://github.com/rust-marker/marker/issues/146

Any reviews are welcome :)