### PR TITLE
Utils: Setup `marker_utils` project and add a `Visitor` (First clean dogfood)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,4 +68,5 @@ jobs:
     # Test
     - run: cargo build --package cargo_marker
     - run: cargo build --package marker_api
+    - run: cargo build --package marker_utils
     - run: cargo build --package marker_uitest

--- a/.github/workflows/rust_bors.yml
+++ b/.github/workflows/rust_bors.yml
@@ -57,4 +57,5 @@ jobs:
     # Test
     - run: cargo build --package cargo_marker
     - run: cargo build --package marker_api
+    - run: cargo build --package marker_utils
     - run: cargo build --package marker_uitest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,6 +1020,7 @@ dependencies = [
  "cfg-if",
  "libloading",
  "marker_api",
+ "marker_utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,6 +1049,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "marker_utils"
+version = "0.1.0"
+dependencies = [
+ "marker_api",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "marker_adapter",
     "marker_api",
     "marker_rustc_driver",
+    "marker_utils",
     # This is needed for rust-analyzer, uitests and other tools
     "marker_uitest",
 ]

--- a/marker_adapter/Cargo.toml
+++ b/marker_adapter/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 marker_api = { path = "../marker_api" }
+marker_utils = { path = "../marker_utils" }
 
 libloading = "0.8.0"
 cfg-if = "1.0.0"

--- a/marker_adapter/src/lib.rs
+++ b/marker_adapter/src/lib.rs
@@ -7,12 +7,20 @@
 pub mod context;
 mod loader;
 
+use std::ops::ControlFlow;
+
 use loader::LintCrateRegistry;
 use marker_api::{
-    ast::{expr::ExprKind, item::ItemKind, BodyId, Crate},
+    ast::{
+        expr::ExprKind,
+        item::{Body, EnumVariant, Field, ItemKind},
+        stmt::StmtKind,
+        Crate,
+    },
     context::AstContext,
     LintPass, LintPassInfo,
 };
+use marker_utils::visitor::{self, Visitor};
 
 /// This struct is the interface used by lint drivers to pass transformed objects to
 /// external lint passes.
@@ -36,61 +44,39 @@ impl Adapter {
         self.external_lint_crates.set_ast_context(cx);
 
         for item in krate.items() {
-            self.process_item(cx, item);
+            visitor::traverse_item::<()>(cx, self, *item);
         }
     }
+}
 
-    fn process_item<'ast>(&mut self, cx: &'ast AstContext<'ast>, item: &ItemKind<'ast>) {
-        self.external_lint_crates.check_item(cx, *item);
-        match item {
-            ItemKind::Mod(data) => {
-                for item in data.items() {
-                    self.process_item(cx, item);
-                }
-            },
-            // FIXME: Function-local items are not yet processed
-            ItemKind::Fn(data) => {
-                if let Some(id) = data.body_id() {
-                    self.process_body(cx, id);
-                }
-            },
-            ItemKind::Struct(data) => {
-                for field in data.fields() {
-                    self.external_lint_crates.check_field(cx, field);
-                }
-            },
-            ItemKind::Enum(data) => {
-                for variant in data.variants() {
-                    self.external_lint_crates.check_variant(cx, variant);
-                    for field in variant.fields() {
-                        self.external_lint_crates.check_field(cx, field);
-                    }
-                }
-            },
-            _ => {},
-        }
+impl Visitor<()> for Adapter {
+    fn visit_item<'ast>(&mut self, cx: &'ast AstContext<'ast>, item: ItemKind<'ast>) -> ControlFlow<()> {
+        self.external_lint_crates.check_item(cx, item);
+        ControlFlow::Continue(())
     }
 
-    fn process_body<'ast>(&mut self, cx: &'ast AstContext<'ast>, id: BodyId) {
-        let body = cx.body(id);
+    fn visit_field<'ast>(&mut self, cx: &'ast AstContext<'ast>, field: &'ast Field<'ast>) -> ControlFlow<()> {
+        self.external_lint_crates.check_field(cx, field);
+        ControlFlow::Continue(())
+    }
+
+    fn visit_variant<'ast>(&mut self, cx: &'ast AstContext<'ast>, variant: &'ast EnumVariant<'ast>) -> ControlFlow<()> {
+        self.external_lint_crates.check_variant(cx, variant);
+        ControlFlow::Continue(())
+    }
+
+    fn visit_body<'ast>(&mut self, cx: &'ast AstContext<'ast>, body: &'ast Body<'ast>) -> ControlFlow<()> {
         self.external_lint_crates.check_body(cx, body);
-        let expr = body.expr();
-        self.process_expr(cx, expr);
+        ControlFlow::Continue(())
     }
 
-    fn process_expr<'ast>(&mut self, cx: &'ast AstContext<'ast>, expr: ExprKind<'ast>) {
+    fn visit_stmt<'ast>(&mut self, cx: &'ast AstContext<'ast>, stmt: StmtKind<'ast>) -> ControlFlow<()> {
+        self.external_lint_crates.check_stmt(cx, stmt);
+        ControlFlow::Continue(())
+    }
+
+    fn visit_expr<'ast>(&mut self, cx: &'ast AstContext<'ast>, expr: ExprKind<'ast>) -> ControlFlow<()> {
         self.external_lint_crates.check_expr(cx, expr);
-        #[expect(clippy::single_match)]
-        match expr {
-            ExprKind::Block(block) => {
-                for stmt in block.stmts() {
-                    self.external_lint_crates.check_stmt(cx, *stmt);
-                }
-                if let Some(expr) = block.expr() {
-                    self.process_expr(cx, expr);
-                }
-            },
-            _ => {},
-        }
+        ControlFlow::Continue(())
     }
 }

--- a/marker_adapter/src/lib.rs
+++ b/marker_adapter/src/lib.rs
@@ -50,7 +50,7 @@ impl Adapter {
             },
             // FIXME: Function-local items are not yet processed
             ItemKind::Fn(data) => {
-                if let Some(id) = data.body() {
+                if let Some(id) = data.body_id() {
                     self.process_body(cx, id);
                 }
             },

--- a/marker_api/src/ast/expr/block_expr.rs
+++ b/marker_api/src/ast/expr/block_expr.rs
@@ -111,7 +111,7 @@ impl<'ast> ClosureExpr<'ast> {
         self.capture_kind
     }
 
-    pub fn body(&self) -> BodyId {
+    pub fn body_id(&self) -> BodyId {
         self.body
     }
 }

--- a/marker_api/src/ast/expr/control_flow_expr.rs
+++ b/marker_api/src/ast/expr/control_flow_expr.rs
@@ -415,7 +415,7 @@ impl<'ast> ContinueExpr<'ast> {
 pub struct LoopExpr<'ast> {
     data: CommonExprData<'ast>,
     label: FfiOption<Ident<'ast>>,
-    body: ExprKind<'ast>,
+    block: ExprKind<'ast>,
 }
 
 impl<'ast> LoopExpr<'ast> {
@@ -423,8 +423,8 @@ impl<'ast> LoopExpr<'ast> {
         self.label.get()
     }
 
-    pub fn body(&self) -> ExprKind<'ast> {
-        self.body
+    pub fn block(&self) -> ExprKind<'ast> {
+        self.block
     }
 }
 
@@ -432,11 +432,11 @@ super::impl_expr_data!(LoopExpr<'ast>, Loop);
 
 #[cfg(feature = "driver-api")]
 impl<'ast> LoopExpr<'ast> {
-    pub fn new(data: CommonExprData<'ast>, label: Option<Ident<'ast>>, body: ExprKind<'ast>) -> Self {
+    pub fn new(data: CommonExprData<'ast>, label: Option<Ident<'ast>>, block: ExprKind<'ast>) -> Self {
         Self {
             data,
             label: label.into(),
-            body,
+            block,
         }
     }
 }
@@ -462,7 +462,7 @@ pub struct WhileExpr<'ast> {
     data: CommonExprData<'ast>,
     label: FfiOption<Ident<'ast>>,
     condition: ExprKind<'ast>,
-    body: ExprKind<'ast>,
+    block: ExprKind<'ast>,
 }
 
 impl<'ast> WhileExpr<'ast> {
@@ -474,8 +474,8 @@ impl<'ast> WhileExpr<'ast> {
         self.condition
     }
 
-    pub fn body(&self) -> ExprKind<'ast> {
-        self.body
+    pub fn block(&self) -> ExprKind<'ast> {
+        self.block
     }
 }
 
@@ -487,13 +487,13 @@ impl<'ast> WhileExpr<'ast> {
         data: CommonExprData<'ast>,
         label: Option<Ident<'ast>>,
         condition: ExprKind<'ast>,
-        body: ExprKind<'ast>,
+        block: ExprKind<'ast>,
     ) -> Self {
         Self {
             data,
             condition,
             label: label.into(),
-            body,
+            block,
         }
     }
 }
@@ -519,7 +519,7 @@ pub struct ForExpr<'ast> {
     label: FfiOption<Ident<'ast>>,
     pat: PatKind<'ast>,
     iterable: ExprKind<'ast>,
-    body: ExprKind<'ast>,
+    block: ExprKind<'ast>,
 }
 
 impl<'ast> ForExpr<'ast> {
@@ -535,8 +535,8 @@ impl<'ast> ForExpr<'ast> {
         self.iterable
     }
 
-    pub fn body(&self) -> ExprKind<'ast> {
-        self.body
+    pub fn block(&self) -> ExprKind<'ast> {
+        self.block
     }
 }
 
@@ -549,14 +549,14 @@ impl<'ast> ForExpr<'ast> {
         label: Option<Ident<'ast>>,
         pat: PatKind<'ast>,
         iterable: ExprKind<'ast>,
-        body: ExprKind<'ast>,
+        block: ExprKind<'ast>,
     ) -> Self {
         Self {
             data,
             label: label.into(),
             pat,
             iterable,
-            body,
+            block,
         }
     }
 }

--- a/marker_api/src/ast/expr/ctor_expr.rs
+++ b/marker_api/src/ast/expr/ctor_expr.rs
@@ -29,7 +29,7 @@ impl<'ast> ArrayExpr<'ast> {
         self.elements.get()
     }
 
-    pub fn len_expr(&self) -> Option<ExprKind<'ast>> {
+    pub fn len(&self) -> Option<ExprKind<'ast>> {
         self.len_expr.copy()
     }
 }

--- a/marker_api/src/ast/item/fn_item.rs
+++ b/marker_api/src/ast/item/fn_item.rs
@@ -26,7 +26,7 @@ pub struct FnItem<'ast> {
     data: CommonItemData<'ast>,
     generics: GenericParams<'ast>,
     callable_data: CommonCallableData<'ast>,
-    body: FfiOption<BodyId>,
+    body_id: FfiOption<BodyId>,
 }
 
 super::impl_item_data!(FnItem, Fn);
@@ -36,8 +36,8 @@ impl<'ast> FnItem<'ast> {
         &self.generics
     }
 
-    pub fn body(&self) -> Option<BodyId> {
-        self.body.copy()
+    pub fn body_id(&self) -> Option<BodyId> {
+        self.body_id.copy()
     }
 }
 
@@ -55,7 +55,7 @@ impl<'ast> FnItem<'ast> {
             data,
             generics,
             callable_data,
-            body: body.into(),
+            body_id: body.into(),
         }
     }
 }

--- a/marker_api/src/ast/pat/struct_pat.rs
+++ b/marker_api/src/ast/pat/struct_pat.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ast::{AstPath, Span, SpanId, SymbolId},
+    ast::{AstQPath, Span, SpanId, SymbolId},
     context::with_cx,
     ffi::FfiSlice,
 };
@@ -10,13 +10,13 @@ use super::{CommonPatData, PatKind};
 #[derive(Debug)]
 pub struct StructPat<'ast> {
     data: CommonPatData<'ast>,
-    path: AstPath<'ast>,
+    path: AstQPath<'ast>,
     fields: FfiSlice<'ast, StructFieldPat<'ast>>,
     is_non_exhaustive: bool,
 }
 
 impl<'ast> StructPat<'ast> {
-    pub fn path(&self) -> &AstPath<'ast> {
+    pub fn path(&self) -> &AstQPath<'ast> {
         &self.path
     }
 
@@ -38,7 +38,7 @@ super::impl_pat_data!(StructPat<'ast>, Struct);
 impl<'ast> StructPat<'ast> {
     pub fn new(
         data: CommonPatData<'ast>,
-        path: AstPath<'ast>,
+        path: AstQPath<'ast>,
         fields: &'ast [StructFieldPat<'ast>],
         is_non_exhaustive: bool,
     ) -> Self {

--- a/marker_rustc_driver/src/conversion/marker.rs
+++ b/marker_rustc_driver/src/conversion/marker.rs
@@ -164,10 +164,13 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
         use rustc_span::symbol::Symbol;
         #[rustfmt::skip]
         let list = [
-            (hir::LangItem::FormatArguments, self.to_symbol_id(Symbol::intern("FormatArguments"))),
-            (hir::LangItem::FormatArgument, self.to_symbol_id(Symbol::intern("FormatArgument"))),
             (hir::LangItem::TryTraitBranch, self.to_symbol_id(Symbol::intern("Try::branch"))),
-            (hir::LangItem::FormatPlaceholder, self.to_symbol_id(Symbol::intern(""))),
+            (hir::LangItem::FormatArgument, self.to_symbol_id(Symbol::intern("rustc_ast::format::FormatArgument"))),
+            (hir::LangItem::FormatArguments, self.to_symbol_id(Symbol::intern("rustc_ast::format::FormatArguments"))),
+            (hir::LangItem::FormatPlaceholder, self.to_symbol_id(Symbol::intern("rustc_ast::format::FormatPlaceholder"))),
+            (hir::LangItem::FormatAlignment, self.to_symbol_id(Symbol::intern("rustc_ast::format::FormatAlignment"))),
+            (hir::LangItem::FormatCount, self.to_symbol_id(Symbol::intern("rustc_ast::format::FormatCount"))),
+            (hir::LangItem::FormatUnsafeArg, self.to_symbol_id(Symbol::intern("core::fmt::rt::UnsafeArg"))),
         ];
 
         self.lang_item_map.borrow_mut().extend(list);

--- a/marker_rustc_driver/src/conversion/marker.rs
+++ b/marker_rustc_driver/src/conversion/marker.rs
@@ -167,6 +167,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
             (hir::LangItem::FormatArguments, self.to_symbol_id(Symbol::intern("FormatArguments"))),
             (hir::LangItem::FormatArgument, self.to_symbol_id(Symbol::intern("FormatArgument"))),
             (hir::LangItem::TryTraitBranch, self.to_symbol_id(Symbol::intern("Try::branch"))),
+            (hir::LangItem::FormatPlaceholder, self.to_symbol_id(Symbol::intern(""))),
         ];
 
         self.lang_item_map.borrow_mut().extend(list);

--- a/marker_rustc_driver/src/conversion/marker/expr.rs
+++ b/marker_rustc_driver/src/conversion/marker/expr.rs
@@ -198,7 +198,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
             hir::ExprKind::Match(_scrutinee, _arms, hir::MatchSource::ForLoopDesugar) => {
                 ExprKind::For(self.alloc(self.to_for_from_desugar(expr)))
             },
-            hir::ExprKind::Match(scrutinee, arms, hir::MatchSource::Normal) => {
+            hir::ExprKind::Match(scrutinee, arms, hir::MatchSource::Normal | hir::MatchSource::FormatArgs) => {
                 ExprKind::Match(self.alloc(MatchExpr::new(data, self.to_expr(scrutinee), self.to_match_arms(arms))))
             },
             hir::ExprKind::Match(scrutinee, [_early_return, _continue], hir::MatchSource::TryDesugar) => {

--- a/marker_rustc_driver/src/conversion/marker/pat.rs
+++ b/marker_rustc_driver/src/conversion/marker/pat.rs
@@ -62,7 +62,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                 }));
                 PatKind::Struct(self.alloc(StructPat::new(
                     data,
-                    self.to_path_from_qpath(qpath),
+                    self.to_qpath_from_pat(qpath, pat),
                     api_fields,
                     *has_rest,
                 )))
@@ -82,7 +82,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                 }));
                 PatKind::Struct(self.alloc(StructPat::new(
                     data,
-                    self.to_path_from_qpath(qpath),
+                    self.to_qpath_from_pat(qpath, pat),
                     api_fields,
                     ddpos.is_some(),
                 )))
@@ -116,7 +116,9 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                 };
                 PatKind::Slice(self.alloc(SlicePat::new(data, elements)))
             },
-            hir::PatKind::Path(path) => PatKind::Path(self.alloc(PathPat::new(data, self.to_qpath_from_pat(path)))),
+            hir::PatKind::Path(path) => {
+                PatKind::Path(self.alloc(PathPat::new(data, self.to_qpath_from_pat(path, pat))))
+            },
             hir::PatKind::Lit(lit) => {
                 let expr = self.to_expr(lit);
                 let lit_expr = expr.try_into().expect("this should be a literal expression");

--- a/marker_rustc_driver/src/conversion/marker/ty.rs
+++ b/marker_rustc_driver/src/conversion/marker/ty.rs
@@ -122,7 +122,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
             | mid::ty::TyKind::GeneratorWitness(_)
             | mid::ty::TyKind::GeneratorWitnessMIR(_, _) => SemTyKind::Unstable(self.alloc(SemUnstableTy::new())),
             mid::ty::TyKind::Never => SemTyKind::Never(self.alloc(SemNeverTy::new())),
-            mid::ty::TyKind::Alias(mid::ty::AliasKind::Inherent, info) => {
+            mid::ty::TyKind::Alias(mid::ty::AliasKind::Inherent | mid::ty::AliasKind::Projection, info) => {
                 SemTyKind::Alias(self.alloc(SemAliasTy::new(self.to_item_id(info.def_id))))
             },
             mid::ty::TyKind::Alias(kind, info) => todo!("{kind:#?}\n\n{info:#?}"),

--- a/marker_uitest/src/lib.rs
+++ b/marker_uitest/src/lib.rs
@@ -47,7 +47,7 @@ impl LintPass for TestLintPass {
     fn check_item<'ast>(&mut self, cx: &'ast AstContext<'ast>, item: ItemKind<'ast>) {
         if let ItemKind::Fn(item) = item {
             if let Some(ident) = item.ident() {
-                if ident.name() == "test_ty_id_resolution" {
+                if ident.name() == "test_ty_id_resolution_trigger" {
                     test_ty_id_resolution(cx);
                 }
             }

--- a/marker_uitest/tests/ui/item_id_resolution.rs
+++ b/marker_uitest/tests/ui/item_id_resolution.rs
@@ -1,7 +1,7 @@
 struct TestType(u32);
 
 // Please don't change the function name, it's used by the lint
-fn test_ty_id_resolution() {
+fn test_ty_id_resolution_trigger() {
     let _check_path_vec = vec!["hey"];
     let _check_path_string = String::from("marker");
     let _check_path_option = Option::Some("<3");

--- a/marker_uitest/tests/ui/print_assign_expr.stderr
+++ b/marker_uitest/tests/ui/print_assign_expr.stderr
@@ -318,24 +318,31 @@ warning: print test
                                                _lifetime: PhantomData<&()>,
                                                span: SpanId(..),
                                            },
-                                           path: AstPath {
-                                               segments: [
-                                                   AstPathSegment {
-                                                       ident: Ident {
-                                                           name: "S",
-                                                           span: Span {
-                                                               source: File(
-                                                                   "$DIR/print_assign_expr.rs",
-                                                               ),
-                                                               start: 264,
-                                                               end: 265,
+                                           path: AstQPath {
+                                               self_ty: None,
+                                               path_ty: None,
+                                               path: AstPath {
+                                                   segments: [
+                                                       AstPathSegment {
+                                                           ident: Ident {
+                                                               name: "S",
+                                                               span: Span {
+                                                                   source: File(
+                                                                       "$DIR/print_assign_expr.rs",
+                                                                   ),
+                                                                   start: 264,
+                                                                   end: 265,
+                                                               },
+                                                           },
+                                                           generics: GenericArgs {
+                                                               args: [],
                                                            },
                                                        },
-                                                       generics: GenericArgs {
-                                                           args: [],
-                                                       },
-                                                   },
-                                               ],
+                                                   ],
+                                               },
+                                               target: Item(
+                                                   ItemId(..),
+                                               ),
                                            },
                                            fields: [
                                                StructFieldPat {

--- a/marker_uitest/tests/ui/print_cond_expr.stderr
+++ b/marker_uitest/tests/ui/print_cond_expr.stderr
@@ -195,24 +195,31 @@ warning: print test
                                        _lifetime: PhantomData<&()>,
                                        span: SpanId(..),
                                    },
-                                   path: AstPath {
-                                       segments: [
-                                           AstPathSegment {
-                                               ident: Ident {
-                                                   name: "Some",
-                                                   span: Span {
-                                                       source: File(
-                                                           "$DIR/print_cond_expr.rs",
-                                                       ),
-                                                       start: 312,
-                                                       end: 316,
+                                   path: AstQPath {
+                                       self_ty: None,
+                                       path_ty: None,
+                                       path: AstPath {
+                                           segments: [
+                                               AstPathSegment {
+                                                   ident: Ident {
+                                                       name: "Some",
+                                                       span: Span {
+                                                           source: File(
+                                                               "$DIR/print_cond_expr.rs",
+                                                           ),
+                                                           start: 312,
+                                                           end: 316,
+                                                       },
+                                                   },
+                                                   generics: GenericArgs {
+                                                       args: [],
                                                    },
                                                },
-                                               generics: GenericArgs {
-                                                   args: [],
-                                               },
-                                           },
-                                       ],
+                                           ],
+                                       },
+                                       target: Variant(
+                                           VariantId(..),
+                                       ),
                                    },
                                    fields: [
                                        StructFieldPat {
@@ -808,24 +815,31 @@ warning: print test
                                        _lifetime: PhantomData<&()>,
                                        span: SpanId(..),
                                    },
-                                   path: AstPath {
-                                       segments: [
-                                           AstPathSegment {
-                                               ident: Ident {
-                                                   name: "Some",
-                                                   span: Span {
-                                                       source: File(
-                                                           "$DIR/print_cond_expr.rs",
-                                                       ),
-                                                       start: 783,
-                                                       end: 787,
+                                   path: AstQPath {
+                                       self_ty: None,
+                                       path_ty: None,
+                                       path: AstPath {
+                                           segments: [
+                                               AstPathSegment {
+                                                   ident: Ident {
+                                                       name: "Some",
+                                                       span: Span {
+                                                           source: File(
+                                                               "$DIR/print_cond_expr.rs",
+                                                           ),
+                                                           start: 783,
+                                                           end: 787,
+                                                       },
+                                                   },
+                                                   generics: GenericArgs {
+                                                       args: [],
                                                    },
                                                },
-                                               generics: GenericArgs {
-                                                   args: [],
-                                               },
-                                           },
-                                       ],
+                                           ],
+                                       },
+                                       target: Variant(
+                                           VariantId(..),
+                                       ),
                                    },
                                    fields: [
                                        StructFieldPat {
@@ -869,24 +883,31 @@ warning: print test
                                        _lifetime: PhantomData<&()>,
                                        span: SpanId(..),
                                    },
-                                   path: AstPath {
-                                       segments: [
-                                           AstPathSegment {
-                                               ident: Ident {
-                                                   name: "Some",
-                                                   span: Span {
-                                                       source: File(
-                                                           "$DIR/print_cond_expr.rs",
-                                                       ),
-                                                       start: 806,
-                                                       end: 810,
+                                   path: AstQPath {
+                                       self_ty: None,
+                                       path_ty: None,
+                                       path: AstPath {
+                                           segments: [
+                                               AstPathSegment {
+                                                   ident: Ident {
+                                                       name: "Some",
+                                                       span: Span {
+                                                           source: File(
+                                                               "$DIR/print_cond_expr.rs",
+                                                           ),
+                                                           start: 806,
+                                                           end: 810,
+                                                       },
+                                                   },
+                                                   generics: GenericArgs {
+                                                       args: [],
                                                    },
                                                },
-                                               generics: GenericArgs {
-                                                   args: [],
-                                               },
-                                           },
-                                       ],
+                                           ],
+                                       },
+                                       target: Variant(
+                                           VariantId(..),
+                                       ),
                                    },
                                    fields: [
                                        StructFieldPat {

--- a/marker_uitest/tests/ui/print_loop_expr.stderr
+++ b/marker_uitest/tests/ui/print_loop_expr.stderr
@@ -38,7 +38,7 @@ warning: print test
                                           },
                                       },
                                   ),
-                                  body: Block(
+                                  block: Block(
                                       BlockExpr {
                                           data: CommonExprData {
                                               _lifetime: PhantomData<&()>,
@@ -90,7 +90,7 @@ warning: print test
                                   span: SpanId(..),
                               },
                               label: None,
-                              body: Block(
+                              block: Block(
                                   BlockExpr {
                                       data: CommonExprData {
                                           _lifetime: PhantomData<&()>,
@@ -176,7 +176,7 @@ warning: print test
                                            },
                                        },
                                    ),
-                                   body: Block(
+                                   block: Block(
                                        BlockExpr {
                                            data: CommonExprData {
                                                _lifetime: PhantomData<&()>,
@@ -288,7 +288,7 @@ warning: print test
                                        ),
                                    },
                                ),
-                               body: Block(
+                               block: Block(
                                    BlockExpr {
                                        data: CommonExprData {
                                            _lifetime: PhantomData<&()>,
@@ -469,7 +469,7 @@ warning: print test
                                            is_inclusive: false,
                                        },
                                    ),
-                                   body: Block(
+                                   block: Block(
                                        BlockExpr {
                                            data: CommonExprData {
                                                _lifetime: PhantomData<&()>,
@@ -566,7 +566,7 @@ warning: print test
                                        },
                                    },
                                ),
-                               body: Block(
+                               block: Block(
                                    BlockExpr {
                                        data: CommonExprData {
                                            _lifetime: PhantomData<&()>,

--- a/marker_uitest/tests/ui/print_loop_expr.stderr
+++ b/marker_uitest/tests/ui/print_loop_expr.stderr
@@ -215,24 +215,31 @@ warning: print test
                                                    _lifetime: PhantomData<&()>,
                                                    span: SpanId(..),
                                                },
-                                               path: AstPath {
-                                                   segments: [
-                                                       AstPathSegment {
-                                                           ident: Ident {
-                                                               name: "Some",
-                                                               span: Span {
-                                                                   source: File(
-                                                                       "$DIR/print_loop_expr.rs",
-                                                                   ),
-                                                                   start: 237,
-                                                                   end: 241,
+                                               path: AstQPath {
+                                                   self_ty: None,
+                                                   path_ty: None,
+                                                   path: AstPath {
+                                                       segments: [
+                                                           AstPathSegment {
+                                                               ident: Ident {
+                                                                   name: "Some",
+                                                                   span: Span {
+                                                                       source: File(
+                                                                           "$DIR/print_loop_expr.rs",
+                                                                       ),
+                                                                       start: 237,
+                                                                       end: 241,
+                                                                   },
+                                                               },
+                                                               generics: GenericArgs {
+                                                                   args: [],
                                                                },
                                                            },
-                                                           generics: GenericArgs {
-                                                               args: [],
-                                                           },
-                                                       },
-                                                   ],
+                                                       ],
+                                                   },
+                                                   target: Variant(
+                                                       VariantId(..),
+                                                   ),
                                                },
                                                fields: [
                                                    StructFieldPat {

--- a/marker_uitest/tests/ui/print_semantic_ty.rs
+++ b/marker_uitest/tests/ui/print_semantic_ty.rs
@@ -13,12 +13,31 @@ pub struct AllowSync<T> {
 }
 unsafe impl<T> Sync for AllowSync<T> {}
 
-trait InterestingTrait<T> {
+trait InterestingSuperTrait {
+    type C: Default;
+}
+
+trait InterestingTrait<T>: InterestingSuperTrait {
     type A: Default;
     fn use_alias(&self) {
-        // FIXME: This expression is currently not found by the print test code.
-        // Try to figure out why and then make sure that is is correctly represented.
-        let _ty: Self::A = Self::A::default();
+        //#[clippy::dump]
+        let _ty: Self::C = Self::C::default();
+        let _ty: <Self as InterestingTrait<T>>::A = Self::A::default();
+    }
+}
+
+struct Duck;
+
+impl InterestingSuperTrait for Duck {
+    type C = u32;
+}
+
+impl InterestingTrait<u32> for Duck {
+    type A = u32;
+    fn use_alias(&self) {
+        #[clippy::dump]
+        let _ty: Self::C = Self::C::default();
+        let _ty: <Self as InterestingTrait<u32>>::A = Self::A::default();
     }
 }
 

--- a/marker_uitest/tests/ui/print_semantic_ty.stderr
+++ b/marker_uitest/tests/ui/print_semantic_ty.stderr
@@ -1,7 +1,60 @@
 warning: print type test
-  --> $DIR/print_semantic_ty.rs:26:5
+  --> $DIR/print_semantic_ty.rs:24:9
    |
-26 |     let _ty_generic: T = t;
+24 |         let _ty: Self::C = Self::C::default();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: Alias(
+               SemAliasTy {
+                   _lifetime: PhantomData<&()>,
+                   alias_item: ItemId(..),
+               },
+           )
+   = note: `#[warn(marker::test_lint)]` on by default
+
+warning: print type test
+  --> $DIR/print_semantic_ty.rs:25:9
+   |
+25 |         let _ty: <Self as InterestingTrait<T>>::A = Self::A::default();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: Alias(
+               SemAliasTy {
+                   _lifetime: PhantomData<&()>,
+                   alias_item: ItemId(..),
+               },
+           )
+
+warning: print type test
+  --> $DIR/print_semantic_ty.rs:39:9
+   |
+39 |         let _ty: Self::C = Self::C::default();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: Num(
+               SemNumTy {
+                   _ast: PhantomData<&()>,
+                   numeric_kind: U32,
+               },
+           )
+
+warning: print type test
+  --> $DIR/print_semantic_ty.rs:40:9
+   |
+40 |         let _ty: <Self as InterestingTrait<u32>>::A = Self::A::default();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: Num(
+               SemNumTy {
+                   _ast: PhantomData<&()>,
+                   numeric_kind: U32,
+               },
+           )
+
+warning: print type test
+  --> $DIR/print_semantic_ty.rs:45:5
+   |
+45 |     let _ty_generic: T = t;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: Generic(
@@ -10,12 +63,11 @@ warning: print type test
                    generic_id: GenericId(..),
                },
            )
-   = note: `#[warn(marker::test_lint)]` on by default
 
 warning: print type test
-  --> $DIR/print_semantic_ty.rs:35:5
+  --> $DIR/print_semantic_ty.rs:54:5
    |
-35 |     let _ty: u32 = 10;
+54 |     let _ty: u32 = 10;
    |     ^^^^^^^^^^^^^^^^^^
    |
    = note: Num(
@@ -26,9 +78,9 @@ warning: print type test
            )
 
 warning: print type test
-  --> $DIR/print_semantic_ty.rs:36:5
+  --> $DIR/print_semantic_ty.rs:55:5
    |
-36 |     let _ty_primitive: Option<(u8, u16, u32, u64, u128, usize)> = None;
+55 |     let _ty_primitive: Option<(u8, u16, u32, u64, u128, usize)> = None;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: Adt(
@@ -86,9 +138,9 @@ warning: print type test
            )
 
 warning: print type test
-  --> $DIR/print_semantic_ty.rs:37:5
+  --> $DIR/print_semantic_ty.rs:56:5
    |
-37 |     let _ty_primitive: Option<(i8, i16, i32, i64, i128, isize)> = None;
+56 |     let _ty_primitive: Option<(i8, i16, i32, i64, i128, isize)> = None;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: Adt(
@@ -146,9 +198,9 @@ warning: print type test
            )
 
 warning: print type test
-  --> $DIR/print_semantic_ty.rs:38:5
+  --> $DIR/print_semantic_ty.rs:57:5
    |
-38 |     let _ty_primitive: Option<(char, bool, f32, f64)> = None;
+57 |     let _ty_primitive: Option<(char, bool, f32, f64)> = None;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: Adt(
@@ -190,9 +242,9 @@ warning: print type test
            )
 
 warning: print type test
-  --> $DIR/print_semantic_ty.rs:39:5
+  --> $DIR/print_semantic_ty.rs:58:5
    |
-39 |     let _ty_sequence: [u32; 1] = [10];
+58 |     let _ty_sequence: [u32; 1] = [10];
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: Array(
@@ -207,9 +259,9 @@ warning: print type test
            )
 
 warning: print type test
-  --> $DIR/print_semantic_ty.rs:41:5
+  --> $DIR/print_semantic_ty.rs:60:5
    |
-41 |     let _ty_sequence: &[u32] = slice;
+60 |     let _ty_sequence: &[u32] = slice;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: Ref(
@@ -229,9 +281,9 @@ warning: print type test
            )
 
 warning: print type test
-  --> $DIR/print_semantic_ty.rs:42:5
+  --> $DIR/print_semantic_ty.rs:61:5
    |
-42 |     let _ty_ptr: Option<(&'static str, *const i32, *mut i32)> = None;
+61 |     let _ty_ptr: Option<(&'static str, *const i32, *mut i32)> = None;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: Adt(
@@ -283,9 +335,9 @@ warning: print type test
            )
 
 warning: print type test
-  --> $DIR/print_semantic_ty.rs:43:5
+  --> $DIR/print_semantic_ty.rs:62:5
    |
-43 |     let _ty_fn_item: fn(u32) -> f32 = u32_to_f32;
+62 |     let _ty_fn_item: fn(u32) -> f32 = u32_to_f32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: FnTy(
@@ -298,9 +350,9 @@ warning: print type test
            )
 
 warning: print type test
-  --> $DIR/print_semantic_ty.rs:44:5
+  --> $DIR/print_semantic_ty.rs:63:5
    |
-44 |     let _ty_closure = || x = 9;
+63 |     let _ty_closure = || x = 9;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: ClosureTy(
@@ -361,9 +413,9 @@ warning: print type test
            )
 
 warning: print type test
-  --> $DIR/print_semantic_ty.rs:49:5
+  --> $DIR/print_semantic_ty.rs:68:5
    |
-49 |     let _ty_fn_ptr: fn(u32) -> f32 = fn_ptr;
+68 |     let _ty_fn_ptr: fn(u32) -> f32 = fn_ptr;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: FnPtr(
@@ -388,9 +440,9 @@ warning: print type test
            )
 
 warning: print type test
-  --> $DIR/print_semantic_ty.rs:53:5
+  --> $DIR/print_semantic_ty.rs:72:5
    |
-53 |     let _ty_simple_alias: AliasTy = AliasTy::new(12);
+72 |     let _ty_simple_alias: AliasTy = AliasTy::new(12);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: Adt(
@@ -422,9 +474,9 @@ warning: print type test
            )
 
 warning: print type test
-  --> $DIR/print_semantic_ty.rs:55:5
+  --> $DIR/print_semantic_ty.rs:74:5
    |
-55 |     let _ty_adt: String = String::new();
+74 |     let _ty_adt: String = String::new();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: Adt(
@@ -437,9 +489,9 @@ warning: print type test
            )
 
 warning: print type test
-  --> $DIR/print_semantic_ty.rs:56:5
+  --> $DIR/print_semantic_ty.rs:75:5
    |
-56 |     let _ty_dyn_simple: Option<Box<dyn Debug>> = None;
+75 |     let _ty_dyn_simple: Option<Box<dyn Debug>> = None;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: Adt(
@@ -489,9 +541,9 @@ warning: print type test
            )
 
 warning: print type test
-  --> $DIR/print_semantic_ty.rs:57:5
+  --> $DIR/print_semantic_ty.rs:76:5
    |
-57 |     let _ty_dyn_complex: Option<Box<dyn Iterator<Item = i32> + 'static>> = None;
+76 |     let _ty_dyn_complex: Option<Box<dyn Iterator<Item = i32> + 'static>> = None;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: Adt(
@@ -552,5 +604,5 @@ warning: print type test
                },
            )
 
-warning: 15 warnings emitted
+warning: 19 warnings emitted
 

--- a/marker_utils/Cargo.toml
+++ b/marker_utils/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "marker_utils"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+keywords = ["marker", "linting"]
+categories = ["development-tools"]
+repository = "https://github.com/rust-marker/marker"
+description = "Marker's ultimate toolbox for creating lints"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+marker_api = { path = "../marker_api" }

--- a/marker_utils/README.md
+++ b/marker_utils/README.md
@@ -1,0 +1,22 @@
+# Marker Utils
+
+[![Crates.io](https://img.shields.io/crates/v/marker_utils.svg)](https://crates.io/crates/marker_utils)
+
+The ultimate toolbox for [Marker], an experimental linting interface for Rust. *marker_utils* provides all the utility required to efficiently write create lint crates.
+
+> **Note**
+>
+> The project is in the early stages of development, some things are still missing and the API is not stable yet.
+>
+> A list of limitations and planned features can be found in [Marker's Readme].
+
+[Marker]: https://github.com/rust-marker/marker
+[Marker's Readme]: https://github.com/rust-marker/marker/blob/master/README.md
+
+## License
+
+Copyright (c) 2022-2023 Rust-Marker
+
+Rust-marker is distributed under the terms of the MIT license or the Apache License (Version 2.0).
+
+See [LICENSE-APACHE](https://github.com/rust-marker/marker/blob/master/LICENSE-APACHE), [LICENSE-MIT](https://github.com/rust-marker/marker/blob/master/LICENSE-MIT).

--- a/marker_utils/src/lib.rs
+++ b/marker_utils/src/lib.rs
@@ -4,3 +4,5 @@
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::unused_self)] // `self` is needed to potentualy change the behavior later
 #![allow(clippy::trivially_copy_pass_by_ref)] // Needed to potentualy change the behavior later
+
+pub mod visitor;

--- a/marker_utils/src/lib.rs
+++ b/marker_utils/src/lib.rs
@@ -1,0 +1,6 @@
+#![doc = include_str!("../README.md")]
+#![warn(clippy::pedantic)]
+#![warn(clippy::exhaustive_enums)]
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::unused_self)] // `self` is needed to potentualy change the behavior later
+#![allow(clippy::trivially_copy_pass_by_ref)] // Needed to potentualy change the behavior later

--- a/marker_utils/src/visitor.rs
+++ b/marker_utils/src/visitor.rs
@@ -1,0 +1,291 @@
+use std::ops::ControlFlow;
+
+use marker_api::{
+    ast::{
+        expr::ExprKind,
+        item::{Body, EnumVariant, Field, ItemKind},
+        stmt::StmtKind,
+    },
+    context::AstContext,
+};
+
+pub trait Visitor<B> {
+    fn visit_item<'ast>(&mut self, _cx: &'ast AstContext<'ast>, _item: ItemKind<'ast>) -> ControlFlow<B> {
+        ControlFlow::Continue(())
+    }
+
+    fn visit_field<'ast>(&mut self, _cx: &'ast AstContext<'ast>, _field: &'ast Field<'ast>) -> ControlFlow<B> {
+        ControlFlow::Continue(())
+    }
+
+    fn visit_variant<'ast>(
+        &mut self,
+        _cx: &'ast AstContext<'ast>,
+        _variant: &'ast EnumVariant<'ast>,
+    ) -> ControlFlow<B> {
+        ControlFlow::Continue(())
+    }
+
+    fn visit_body<'ast>(&mut self, _cx: &'ast AstContext<'ast>, _body: &'ast Body<'ast>) -> ControlFlow<B> {
+        ControlFlow::Continue(())
+    }
+
+    fn visit_stmt<'ast>(&mut self, _cx: &'ast AstContext<'ast>, _stmt: StmtKind<'ast>) -> ControlFlow<B> {
+        ControlFlow::Continue(())
+    }
+
+    fn visit_expr<'ast>(&mut self, _cx: &'ast AstContext<'ast>, _expr: ExprKind<'ast>) -> ControlFlow<B> {
+        ControlFlow::Continue(())
+    }
+}
+
+pub fn traverse_item<'ast, B>(
+    cx: &'ast AstContext<'ast>,
+    visitor: &mut dyn Visitor<B>,
+    kind: ItemKind<'ast>,
+) -> ControlFlow<B> {
+    visitor.visit_item(cx, kind)?;
+    match kind {
+        ItemKind::Mod(module) => {
+            for mod_item in module.items() {
+                traverse_item(cx, visitor, *mod_item)?;
+            }
+        },
+        ItemKind::Static(item) => {
+            if let Some(body_id) = item.body_id() {
+                traverse_body(cx, visitor, cx.body(body_id))?;
+            }
+        },
+        ItemKind::Const(item) => {
+            if let Some(body_id) = item.body_id() {
+                traverse_body(cx, visitor, cx.body(body_id))?;
+            }
+        },
+        ItemKind::Fn(item) => {
+            if let Some(body_id) = item.body_id() {
+                traverse_body(cx, visitor, cx.body(body_id))?;
+            }
+        },
+        ItemKind::Struct(item) => {
+            for field in item.fields() {
+                visitor.visit_field(cx, field)?;
+            }
+        },
+        ItemKind::Union(item) => {
+            for field in item.fields() {
+                visitor.visit_field(cx, field)?;
+            }
+        },
+        ItemKind::Enum(item) => {
+            for variant in item.variants() {
+                visitor.visit_variant(cx, variant)?;
+            }
+        },
+        ItemKind::Trait(item) => {
+            for assoc_item in item.items() {
+                traverse_item(cx, visitor, assoc_item.as_item())?;
+            }
+        },
+        ItemKind::Impl(item) => {
+            for assoc_item in item.items() {
+                traverse_item(cx, visitor, assoc_item.as_item())?;
+            }
+        },
+        ItemKind::ExternBlock(item) => {
+            for ext_item in item.items() {
+                traverse_item(cx, visitor, ext_item.as_item())?;
+            }
+        },
+        ItemKind::ExternCrate(_) | ItemKind::Use(_) | ItemKind::Unstable(_) | ItemKind::TyAlias(_) => {
+            // These items have no sub nodes, which are visited by this visitor
+        },
+        _ => unreachable!("all items are covered"),
+    }
+    ControlFlow::Continue(())
+}
+
+pub fn traverse_body<'ast, B>(
+    cx: &'ast AstContext<'ast>,
+    visitor: &mut dyn Visitor<B>,
+    body: &'ast Body<'ast>,
+) -> ControlFlow<B> {
+    visitor.visit_body(cx, body)?;
+
+    traverse_expr(cx, visitor, body.expr())?;
+
+    ControlFlow::Continue(())
+}
+
+pub fn traverse_stmt<'ast, B>(
+    cx: &'ast AstContext<'ast>,
+    visitor: &mut dyn Visitor<B>,
+    stmt: StmtKind<'ast>,
+) -> ControlFlow<B> {
+    visitor.visit_stmt(cx, stmt)?;
+
+    match stmt {
+        StmtKind::Item(item) => {
+            traverse_item(cx, visitor, item)?;
+        },
+        StmtKind::Let(lt) => {
+            if let Some(init) = lt.init() {
+                traverse_expr(cx, visitor, init)?;
+            }
+            if let Some(els) = lt.els() {
+                traverse_expr(cx, visitor, els)?;
+            }
+        },
+        StmtKind::Expr(expr) => {
+            traverse_expr(cx, visitor, expr)?;
+        },
+        _ => unreachable!("all statements are covered"),
+    }
+
+    ControlFlow::Continue(())
+}
+
+pub fn traverse_expr<'ast, B>(
+    cx: &'ast AstContext<'ast>,
+    visitor: &mut dyn Visitor<B>,
+    expr: ExprKind<'ast>,
+) -> ControlFlow<B> {
+    visitor.visit_expr(cx, expr)?;
+
+    match expr {
+        ExprKind::Block(e) => {
+            for stmt in e.stmts() {
+                traverse_stmt(cx, visitor, *stmt)?;
+            }
+            if let Some(block_expr) = e.expr() {
+                traverse_expr(cx, visitor, block_expr)?;
+            }
+        },
+        ExprKind::Closure(e) => {
+            traverse_body(cx, visitor, cx.body(e.body_id()))?;
+        },
+        ExprKind::UnaryOp(e) => {
+            traverse_expr(cx, visitor, e.expr())?;
+        },
+        ExprKind::Ref(e) => {
+            traverse_expr(cx, visitor, e.expr())?;
+        },
+        ExprKind::BinaryOp(e) => {
+            traverse_expr(cx, visitor, e.left())?;
+            traverse_expr(cx, visitor, e.right())?;
+        },
+        ExprKind::QuestionMark(e) => {
+            traverse_expr(cx, visitor, e.expr())?;
+        },
+        ExprKind::Assign(e) => {
+            traverse_expr(cx, visitor, e.value())?;
+        },
+        ExprKind::As(e) => {
+            traverse_expr(cx, visitor, e.expr())?;
+        },
+        ExprKind::Call(e) => {
+            traverse_expr(cx, visitor, e.operand())?;
+            for arg in e.args() {
+                traverse_expr(cx, visitor, *arg)?;
+            }
+        },
+        ExprKind::Method(e) => {
+            traverse_expr(cx, visitor, e.receiver())?;
+            for arg in e.args() {
+                traverse_expr(cx, visitor, *arg)?;
+            }
+        },
+        ExprKind::Array(e) => {
+            for el in e.elements() {
+                traverse_expr(cx, visitor, *el)?;
+            }
+            if let Some(len) = e.len() {
+                traverse_expr(cx, visitor, len)?;
+            }
+        },
+        ExprKind::Tuple(e) => {
+            for el in e.elements() {
+                traverse_expr(cx, visitor, *el)?;
+            }
+        },
+        ExprKind::Ctor(e) => {
+            for field in e.fields() {
+                traverse_expr(cx, visitor, field.expr())?;
+            }
+            if let Some(base) = e.base() {
+                traverse_expr(cx, visitor, base)?;
+            }
+        },
+        // I like the simplicity of the API, even if the dereference part of
+        // slices is a bit annoying. But typing all of this out is kind of meh.
+        // not super interesting and almost just copy pasta, but not enough for
+        // a macro... Oh well, back to work
+        ExprKind::Range(e) => {
+            if let Some(start) = e.start() {
+                traverse_expr(cx, visitor, start)?;
+            }
+            if let Some(end) = e.start() {
+                traverse_expr(cx, visitor, end)?;
+            }
+        },
+        ExprKind::Index(e) => {
+            traverse_expr(cx, visitor, e.operand())?;
+            traverse_expr(cx, visitor, e.index())?;
+        },
+        ExprKind::Field(e) => {
+            traverse_expr(cx, visitor, e.operand())?;
+        },
+        ExprKind::If(e) => {
+            traverse_expr(cx, visitor, e.condition())?;
+            traverse_expr(cx, visitor, e.then())?;
+            if let Some(els) = e.els() {
+                traverse_expr(cx, visitor, els)?;
+            }
+        },
+        ExprKind::Let(e) => {
+            traverse_expr(cx, visitor, e.scrutinee())?;
+        },
+        ExprKind::Match(e) => {
+            traverse_expr(cx, visitor, e.scrutinee())?;
+            for arm in e.arms() {
+                if let Some(guard) = arm.guard() {
+                    traverse_expr(cx, visitor, guard)?;
+                }
+                traverse_expr(cx, visitor, arm.expr())?;
+            }
+        },
+        ExprKind::Break(e) => {
+            if let Some(val) = e.expr() {
+                traverse_expr(cx, visitor, val)?;
+            }
+        },
+        ExprKind::Return(e) => {
+            if let Some(val) = e.expr() {
+                traverse_expr(cx, visitor, val)?;
+            }
+        },
+        ExprKind::For(e) => {
+            traverse_expr(cx, visitor, e.iterable())?;
+            traverse_expr(cx, visitor, e.block())?;
+        },
+        ExprKind::Loop(e) => {
+            traverse_expr(cx, visitor, e.block())?;
+        },
+        ExprKind::While(e) => {
+            traverse_expr(cx, visitor, e.condition())?;
+            traverse_expr(cx, visitor, e.block())?;
+        },
+        ExprKind::IntLit(_)
+        | ExprKind::FloatLit(_)
+        | ExprKind::StrLit(_)
+        | ExprKind::CharLit(_)
+        | ExprKind::BoolLit(_)
+        | ExprKind::Unstable(_)
+        | ExprKind::Path(_)
+        | ExprKind::Continue(_) => {
+            // These expressions have no sub nodes, which are visited by this visitor
+        },
+        _ => unreachable!("all expressions are covered"),
+    }
+
+    ControlFlow::Continue(())
+}

--- a/marker_utils/src/visitor.rs
+++ b/marker_utils/src/visitor.rs
@@ -144,6 +144,7 @@ pub fn traverse_stmt<'ast, B>(
     ControlFlow::Continue(())
 }
 
+#[allow(clippy::too_many_lines)]
 pub fn traverse_expr<'ast, B>(
     cx: &'ast AstContext<'ast>,
     visitor: &mut dyn Visitor<B>,


### PR DESCRIPTION
This PR is an important milestone. It adds the new `marker_utils` crate with a new `Visitor` trait. This trait is then directly used to traverse the entire AST in the `marker_adapter` crate. And finally, dogfood, or better say a clean dogfood. It just passes, able to translate everything. I don't quite know how to feel about this, tbh.

The number of changes sadly exploded, sorry if someone actually looks at this :sweat_smile:

---

cc: https://github.com/rust-marker/marker/issues/159 I think the design still needs some small adjustments, like being able to limit the scope of what is being visited etc. 
