### PR TITLE
Rustc: Enable `non_exhaustive_omitted_patterns_lint` feature and lint

### DIFF
--- a/marker_rustc_driver/src/context.rs
+++ b/marker_rustc_driver/src/context.rs
@@ -117,7 +117,7 @@ impl<'ast, 'tcx: 'ast> DriverContext<'ast> for RustcContext<'ast, 'tcx> {
                                 self.rustc_converter.to_applicability(*app),
                             );
                         },
-                        _ => todo!(),
+                        _ => unreachable!(),
                     }
                 }
                 builder

--- a/marker_rustc_driver/src/conversion/marker/common.rs
+++ b/marker_rustc_driver/src/conversion/marker/common.rs
@@ -137,10 +137,9 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     pub fn to_lint_level(&self, level: rustc_lint::Level) -> Level {
         match level {
             rustc_lint::Level::Allow => Level::Allow,
-            rustc_lint::Level::Warn => Level::Warn,
+            rustc_lint::Level::Warn | rustc_lint::Level::ForceWarn(_) | rustc_lint::Level::Expect(_) => Level::Warn,
             rustc_lint::Level::Deny => Level::Deny,
             rustc_lint::Level::Forbid => Level::Forbid,
-            _ => unreachable!(),
         }
     }
 

--- a/marker_rustc_driver/src/conversion/rustc/common.rs
+++ b/marker_rustc_driver/src/conversion/rustc/common.rs
@@ -141,7 +141,7 @@ impl<'ast, 'tcx> RustcConverter<'ast, 'tcx> {
             },
             EmissionNode::Field(id) => return Some(self.to_hir_id(id)),
             EmissionNode::Variant(id) => self.to_def_id(id),
-            _ => todo!(),
+            _ => unreachable!(),
         };
 
         def_id
@@ -179,7 +179,7 @@ impl<'ast, 'tcx> RustcConverter<'ast, 'tcx> {
             Applicability::MaybeIncorrect => rustc_errors::Applicability::MaybeIncorrect,
             Applicability::HasPlaceholders => rustc_errors::Applicability::HasPlaceholders,
             Applicability::Unspecified => rustc_errors::Applicability::Unspecified,
-            _ => todo!(),
+            _ => unreachable!(),
         }
     }
 

--- a/marker_rustc_driver/src/conversion/rustc/unstable.rs
+++ b/marker_rustc_driver/src/conversion/rustc/unstable.rs
@@ -9,7 +9,7 @@ impl<'ast, 'tcx> RustcConverter<'ast, 'tcx> {
             let report_in_external_macro = match api_lint.report_in_macro {
                 MacroReport::No | MacroReport::Local => false,
                 MacroReport::All => true,
-                _ => unreachable!("added variant to lint::MacroReport"),
+                _ => unreachable!(),
             };
 
             Box::leak(Box::new(rustc_lint::Lint {

--- a/marker_rustc_driver/src/main.rs
+++ b/marker_rustc_driver/src/main.rs
@@ -1,21 +1,17 @@
 #![doc = include_str!("../README.md")]
 #![feature(rustc_private)]
-#![feature(lint_reasons)]
 #![feature(let_chains)]
+#![feature(lint_reasons)]
 #![feature(iter_collect_into)]
+#![feature(non_exhaustive_omitted_patterns_lint)]
 #![warn(rustc::internal)]
 #![warn(clippy::pedantic)]
+#![warn(non_exhaustive_omitted_patterns)]
 #![allow(clippy::missing_panics_doc)]
 #![allow(clippy::module_name_repetitions)]
-#![allow(
-    clippy::needless_lifetimes,
-    reason = "some lifetimes will be required to fix ICEs, <'ast, '_> also looks weird"
-)]
-#![allow(clippy::needless_collect, reason = "it has false positives for `alloc_slice_iter`")]
-#![allow(
-    clippy::too_many_lines,
-    reason = "long functions are sometimes unavoidable for matches"
-)]
+#![allow(clippy::needless_lifetimes, reason = "lifetimes will be required to fix ICEs")]
+#![allow(clippy::needless_collect, reason = "false positives for `alloc_slice`")]
+#![allow(clippy::too_many_lines, reason = "long functions are unavoidable for matches")]
 
 extern crate rustc_ast;
 extern crate rustc_data_structures;


### PR DESCRIPTION
Closes https://github.com/rust-marker/marker/issues/25