### PR TITLE
API: The README of marker_api rebirth and a new `marker_api::prelude` module

### DIFF
--- a/marker_api/README.md
+++ b/marker_api/README.md
@@ -1,12 +1,41 @@
 # Marker API
 
-This crate provides the stable API for lint crates.
-Here you can find representations for a simple variable name up to the AST of an entire crate.
-This is the only dependency needed to get start with a new *linting crate*.
+[![Crates.io](https://img.shields.io/crates/v/marker_api.svg)](https://crates.io/crates/marker_api)
+<!--
+FIXME(xFrednet): Add license shield, once crates.io also says:
+[![License: MIT OR Apache-2.0](https://img.shields.io/crates/l/marker_api.svg)](#license)
+-->
 
-:warning: This crate also contains some unstable items, which are required by the current infrastructure. These items are clearly marked and hidden from the documentation. :warning:
+*marker_api* provides a representation of the AST and all connected types needed to create custom *lint crates* for [Marker], an experimental linting interface for Rust.
 
-## Getting started
+> **Note**
+>
+> The project is in the early stages of development, some things are still missing and the API is not stable yet.
+>
+> A list of limitations and planned features can be found in [Marker's Readme].
+
+[Marker]: https://github.com/rust-marker/marker
+[Marker's Readme]: https://github.com/rust-marker/marker/blob/master/README.md
+
+## Key Features
+
+* **Stability**: Marker's API design focuses on stability and extendability. The goal is to archive backwards compatibility, so that any lint, written after version 1.0.0, will compile and continue to work for years to come.
+* **Usability**: Marker's API focuses on usability, where possible under the constraints of Marker's stability guarantees. Types follow common design patterns and naming conventions, allowing you to focus on the lint logic directly.
+* **Driver Independent**: Every code analysis requires a driver that parses the code and provides further information. Marker's API is designed to be driver-independent, allowing it to support future compilers and potentially IDEs. (Currently, [rustc] is the only available driver)
+
+## Usage
+
+This section will cover how you can setup your own *lint crate*. If you only want to run custom lints, checkout Marker's CLI interface [cargo_marker]. The rest of the section assumes that you have [`cargo_marker`] installed.
+
+[cargo_marker]: https://crates.io/crates/cargo_marker
+
+### Template
+
+The simplest way to get started, is to use Marker's [lint crate template], which already includes all dependencies, example code, and a working test setup.
+
+[lint crate template]: https://github.com/rust-marker/lint-crate-template
+
+### Manual Setup
 
 To get started, create a new cargo project that compiles to a library (`cargo init --lib`).
 Afterwards, the `Cargo.toml` has to be edited to compile the crate to a dynamic library.
@@ -18,42 +47,17 @@ crate-type = ["cdylib"]
 
 [dependencies]
 marker_api = "<version>"
+marker_utils = "<version>"
 ```
 
-Now that everything is setup, we jump into `src/lib.rs` where we add everything needed for marker to load the crate:
+## Contributing
 
-```rust,ignore
-use marker_api::{lint::Lint, LintPass};
+Contributions are highly appreciated! If you encounter any issues or have suggestions for improvements, please don't hesitate to open an issue or submit a pull request on [Marker's GitHub repository](https://github.com/rust-marker/marker).
 
-// With the [`declare_lint!`] macro we define a new lint. The macro accepts a
-// name, default lint level and description.
-marker_api::declare_lint!{
-    /// The lint description
-    YOUR_LINT_NAME,
-    Allow,
-}
+## License
 
-// Here we create an object that'll implement `LintPass`. This struct can
-// hold data used for linting. A mutable reference of this struct is passed to
-// each check in `LintPass`
-#[derive(Debug, Default)]
-struct TestLintPass;
+Copyright (c) 2022-2023 Rust-Marker
 
-// Here we implement the `LintPass` for our struct. It only requires the
-// implementation of one function, that returns all lints which are implemented
-// by this crate.
-impl LintPass for TestLintPass {
-    fn registered_lints(&self) -> Box<[&'static Lint]> {
-        Box::new([YOUR_LINT_NAME])
-    }
+Rust-Marker is distributed under the terms of the MIT license or the Apache License (Version 2.0).
 
-    // Here we can finally start linting, by implementing `check_*` functions.
-    // See `LintPass` for a complete list of provided callbacks.
-}
-
-// Last but not least, we have to mark our object that implements `LintPass`.
-// Each lint crate requires exactly one marker. All lints have to be implemented
-// in one lint pass. For multiple lints it can be helpful to extract the individual
-// linting logic called by the `check_*` functions into separate modules.
-marker_api::export_lint_pass!(TestLintPass);
-```
+See [LICENSE-APACHE](https://github.com/rust-marker/marker/blob/master/LICENSE-APACHE), [LICENSE-MIT](https://github.com/rust-marker/marker/blob/master/LICENSE-MIT).

--- a/marker_api/README.md
+++ b/marker_api/README.md
@@ -17,15 +17,17 @@ FIXME(xFrednet): Add license shield, once crates.io also says:
 [Marker]: https://github.com/rust-marker/marker
 [Marker's Readme]: https://github.com/rust-marker/marker/blob/master/README.md
 
-## Key Features
+## Goals
 
-* **Stability**: Marker's API design focuses on stability and extendability. The goal is to archive backwards compatibility, so that any lint, written after version 1.0.0, will compile and continue to work for years to come.
+* **Stability**: Marker's API design focuses on stability and expendability. The goal is to archive backwards compatibility, so that any lint, written after version 1.0.0, will compile and continue to work for years to come.
 * **Usability**: Marker's API focuses on usability, where possible under the constraints of Marker's stability guarantees. Types follow common design patterns and naming conventions, allowing you to focus on the lint logic directly.
 * **Driver Independent**: Every code analysis requires a driver that parses the code and provides further information. Marker's API is designed to be driver-independent, allowing it to support future compilers and potentially IDEs. (Currently, [rustc] is the only available driver)
 
+[rustc]: https://github.com/rust-lang/rust/
+
 ## Usage
 
-This section will cover how you can setup your own *lint crate*. If you only want to run custom lints, checkout Marker's CLI interface [cargo_marker]. The rest of the section assumes that you have [`cargo_marker`] installed.
+This section will cover how you can set up your own *lint crate*. If you only want to run custom lints, checkout Marker's CLI interface [cargo_marker]. The rest of the section assumes that you have [cargo_marker] installed.
 
 [cargo_marker]: https://crates.io/crates/cargo_marker
 
@@ -37,9 +39,9 @@ The simplest way to get started, is to use Marker's [lint crate template], which
 
 ### Manual Setup
 
-To get started, create a new cargo project that compiles to a library (`cargo init --lib`).
-Afterwards, the `Cargo.toml` has to be edited to compile the crate to a dynamic library.
-You can simply add the following after the `[package]` values:
+#### Cargo.toml
+
+To get started, create a new Rust crate that compiles to a library (`cargo init --lib`). Afterwards, edit the `Cargo.toml` to compile the crate to a dynamic library and include `marker_api` as a dependency. You can simply add the following to your `Cargo.toml` file:
 
 ```toml
 [lib]
@@ -49,6 +51,58 @@ crate-type = ["cdylib"]
 marker_api = "<version>"
 marker_utils = "<version>"
 ```
+
+#### src/lib.rs
+
+The lint crate needs to provide an implementation of the `LintPass` trait and call the `marker_api::export_lint_pass` macro with the implementing type. Here is the minimal template:
+
+```rust,ignore
+use marker_api::{LintPass, LintPassInfo, LintPassInfoBuilder};
+
+// This is the struct that will implement the `LintPass` trait.
+#[derive(Default)]
+struct MyLintPass;
+
+// This macro allow Marker to load the lint crate. Only one lint pass can be
+// exported per lint crate.
+marker_api::export_lint_pass!(MyLintPass);
+
+// This macro declares a new lint, that can later be emitted
+marker_api::declare_lint! {
+    /// # What it does
+    /// Here you can explain what your lint does. The description supports normal
+    /// markdown.
+    ///
+    /// # Example
+    /// ```rs
+    /// // Bad example
+    /// ```
+    ///
+    /// Use instead:
+    /// ```rs
+    /// // Good example
+    /// ```
+    MY_LINT,
+    Warn,
+}
+
+// This is the actual `LintPass` implementation, which will be called by Marker.
+impl LintPass for MyLintPass {
+    fn info(&self) -> LintPassInfo {
+        LintPassInfoBuilder::new(Box::new([MY_LINT])).build()
+    }
+}
+```
+
+Now you can implement different `check_*` function in the `LintPass` trait.
+
+#### UI-Tests
+
+To automatically test your lints, you might want to check out the [marker_uitest] crate.
+
+And that's it. Happy linting!
+
+[marker_uitest]: https://crates.io/crates/marker_uitest
 
 ## Contributing
 

--- a/marker_api/README.md
+++ b/marker_api/README.md
@@ -57,6 +57,7 @@ marker_utils = "<version>"
 The lint crate needs to provide an implementation of the `LintPass` trait and call the `marker_api::export_lint_pass` macro with the implementing type. Here is the minimal template:
 
 ```rust,ignore
+use marker_api::prelude::*;
 use marker_api::{LintPass, LintPassInfo, LintPassInfoBuilder};
 
 // This is the struct that will implement the `LintPass` trait.

--- a/marker_api/src/context.rs
+++ b/marker_api/src/context.rs
@@ -80,7 +80,7 @@ where
 }
 
 /// This context will be passed to each [`LintPass`](`super::LintPass`) call to enable the user
-/// to emit lints and to retieve nodes by the given ids.
+/// to emit lints and to retrieve nodes by the given ids.
 #[repr(C)]
 pub struct AstContext<'ast> {
     driver: &'ast DriverCallbacks<'ast>,

--- a/marker_api/src/lib.rs
+++ b/marker_api/src/lib.rs
@@ -16,6 +16,7 @@ pub mod context;
 pub mod diagnostic;
 pub mod interface;
 pub mod lint;
+pub mod prelude;
 
 #[doc(hidden)]
 pub mod ffi;

--- a/marker_api/src/prelude.rs
+++ b/marker_api/src/prelude.rs
@@ -1,0 +1,16 @@
+//! This prelude is a collection of traits and types which are commonly used
+//! when working with Marker. Simply add `use marker_api::prelude::*;` to your
+//! file, to import them all.
+
+// AST Traits:
+pub use crate::ast::expr::ExprData;
+pub use crate::ast::item::ItemData;
+pub use crate::ast::pat::PatData;
+pub use crate::ast::ty::SynTyData;
+
+// Common types
+pub use crate::ast::expr::ExprKind;
+pub use crate::ast::item::ItemKind;
+pub use crate::ast::Ident;
+pub use crate::ast::Span;
+pub use crate::AstContext;


### PR DESCRIPTION
This PR basically rewrites the entire readme of the `marker_api` crate. It also adds the `marker_api::prelude` module for convenience. What a beautiful PR :D

[:framed_picture: Rendered `README.md` :framed_picture:](https://github.com/xFrednet/marker/blob/151-who-reads-api-docs-anyways/marker_api/README.md)

---

cc: https://github.com/rust-marker/marker/issues/151