### PR TITLE
Rustc: Fix spans, sound and ICEs

### DIFF
--- a/marker_adapter/src/context.rs
+++ b/marker_adapter/src/context.rs
@@ -93,7 +93,7 @@ extern "C" fn span<'ast>(data: &(), owner: &SpanOwner) -> &'ast Span<'ast> {
     wrapper.driver_cx.span(owner)
 }
 
-extern "C" fn span_snippet<'ast>(data: &(), span: &Span) -> ffi::FfiOption<ffi::FfiStr<'ast>> {
+extern "C" fn span_snippet<'ast>(data: &(), span: &Span<'ast>) -> ffi::FfiOption<ffi::FfiStr<'ast>> {
     let wrapper = unsafe { &*(data as *const ()).cast::<DriverContextWrapper>() };
     wrapper.driver_cx.span_snippet(span).map(Into::into).into()
 }
@@ -119,7 +119,7 @@ pub trait DriverContext<'ast> {
 
     fn expr_ty(&'ast self, expr: ExprId) -> SemTyKind<'ast>;
     fn span(&'ast self, owner: &SpanOwner) -> &'ast Span<'ast>;
-    fn span_snippet(&'ast self, span: &Span) -> Option<&'ast str>;
+    fn span_snippet(&'ast self, span: &Span<'ast>) -> Option<&'ast str>;
     fn symbol_str(&'ast self, api_id: SymbolId) -> &'ast str;
     fn resolve_method_target(&'ast self, id: ExprId) -> ItemId;
 }

--- a/marker_api/src/ast/common/id.rs
+++ b/marker_api/src/ast/common/id.rs
@@ -111,6 +111,15 @@ new_id! {
 new_id! {
     /// **Unstable**
     ///
+    /// This id is used to identify the source of a `Span`. This type is only intended for internal
+    /// use. For now it's only intended for drivers to map spans back
+    #[cfg_attr(feature = "driver-api", visibility::make(pub))]
+    pub(crate) SpanSrcId: u32
+}
+
+new_id! {
+    /// **Unstable**
+    ///
     /// This id is used to identify symbols. This type is only intended for internal
     /// use. Lint crates should always get [`String`] or `&str`.
     #[cfg_attr(feature = "driver-api", visibility::make(pub))]

--- a/marker_api/src/ast/common/span.rs
+++ b/marker_api/src/ast/common/span.rs
@@ -35,7 +35,7 @@ pub struct Span<'ast> {
 
 impl<'ast> Span<'ast> {
     pub fn is_from_file(&self) -> bool {
-        matches!(self.source, SpanSource::File(..))
+        matches!(self.source, SpanSource::File(..) | SpanSource::Sugar(..))
     }
 
     pub fn is_from_macro(&self) -> bool {

--- a/marker_api/src/ast/expr/op_exprs.rs
+++ b/marker_api/src/ast/expr/op_exprs.rs
@@ -203,7 +203,7 @@ impl<'ast> UnaryOpExpr<'ast> {
 
 #[repr(C)]
 #[non_exhaustive]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum UnaryOpKind {
     /// The arithmetic negation `-` operator, like `-2`
     Neg,

--- a/marker_api/src/context.rs
+++ b/marker_api/src/context.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     diagnostic::{Diagnostic, DiagnosticBuilder, EmissionNode},
     ffi,
-    lint::{Level, Lint},
+    lint::{Level, Lint, MacroReport},
 };
 
 thread_local! {
@@ -126,6 +126,9 @@ impl<'ast> AstContext<'ast> {
     ) where
         F: FnOnce(&mut DiagnosticBuilder<'ast>),
     {
+        if matches!(lint.report_in_macro, MacroReport::No) && span.is_from_macro() {
+            return;
+        }
         let node = node.into();
         if self.lint_level_at(lint, node) != Level::Allow {
             let mut builder = DiagnosticBuilder::new(lint, node, msg.to_string(), span.clone());

--- a/marker_api/src/context.rs
+++ b/marker_api/src/context.rs
@@ -182,7 +182,9 @@ impl<'ast> AstContext<'ast> {
         self.driver.call_expr_ty(expr)
     }
 
-    pub(crate) fn span_snipped(&self, span: &Span) -> Option<String> {
+    // FIXME: This function should probably be removed in favor of a better
+    // system to deal with spans. See rust-marker/marker#175
+    pub(crate) fn span_snipped(&self, span: &Span<'ast>) -> Option<String> {
         self.driver.call_span_snippet(span)
     }
 
@@ -237,7 +239,7 @@ struct DriverCallbacks<'ast> {
     // Internal utility
     pub expr_ty: extern "C" fn(&'ast (), ExprId) -> SemTyKind<'ast>,
     pub span: extern "C" fn(&'ast (), &SpanOwner) -> &'ast Span<'ast>,
-    pub span_snippet: extern "C" fn(&'ast (), &Span) -> ffi::FfiOption<ffi::FfiStr<'ast>>,
+    pub span_snippet: extern "C" fn(&'ast (), &Span<'ast>) -> ffi::FfiOption<ffi::FfiStr<'ast>>,
     pub symbol_str: extern "C" fn(&'ast (), SymbolId) -> ffi::FfiStr<'ast>,
     pub resolve_method_target: extern "C" fn(&'ast (), ExprId) -> ItemId,
 }
@@ -264,7 +266,7 @@ impl<'ast> DriverCallbacks<'ast> {
     fn call_span(&self, span_owner: &SpanOwner) -> &'ast Span<'ast> {
         (self.span)(self.driver_context, span_owner)
     }
-    fn call_span_snippet(&self, span: &Span) -> Option<String> {
+    fn call_span_snippet(&self, span: &Span<'ast>) -> Option<String> {
         let result: Option<ffi::FfiStr> = (self.span_snippet)(self.driver_context, span).into();
         result.map(|x| x.to_string())
     }

--- a/marker_api/src/ffi.rs
+++ b/marker_api/src/ffi.rs
@@ -13,12 +13,18 @@
 use std::{marker::PhantomData, slice};
 
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Eq)]
 pub struct FfiStr<'a> {
     _lifetime: PhantomData<&'a ()>,
     /// Not really *const, but it should have the lifetime of at least `'a`
     data: *const u8,
     len: usize,
+}
+
+impl<'a> PartialEq for FfiStr<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        self.get().eq(other.get())
+    }
 }
 
 impl<'a> From<&'a str> for FfiStr<'a> {
@@ -66,6 +72,12 @@ impl<'a> ToString for FfiStr<'a> {
 impl std::fmt::Debug for FfiStr<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.get())
+    }
+}
+
+impl std::hash::Hash for FfiStr<'_> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.get().hash(state);
     }
 }
 

--- a/marker_api/src/lint.rs
+++ b/marker_api/src/lint.rs
@@ -44,17 +44,19 @@ pub struct Lint {
     // * pub crate_level_only: bool,
 }
 
-/// FIXME(xFrednet): These settings currently don't work.
+/// FIXME(xFrednet): These settings should be working now, but are still limited
+/// due to the limited [`Span`](crate::ast::Span) implementation. Ideally, I would
+/// also like more options, like a `Local` variant that only lints in local marcos.
+/// For libraries it might also be cool to have a `Crate` variant, that only lints
+/// in user code and code from macros from the specified crate.
 ///
-/// See rust-marker#149
+/// See: rust-marker/marker#149
 #[repr(C)]
 #[non_exhaustive]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum MacroReport {
     /// No reporting in local or external macros.
     No,
-    /// Only report in local macros.
-    Local,
     /// Report in local and external macros.
     All,
 }

--- a/marker_rustc_driver/src/context.rs
+++ b/marker_rustc_driver/src/context.rs
@@ -222,8 +222,10 @@ impl<'ast, 'tcx: 'ast> DriverContext<'ast> for RustcContext<'ast, 'tcx> {
         self.storage.alloc(self.marker_converter.to_span(rustc_span))
     }
 
-    fn span_snippet(&self, _span: &Span) -> Option<&'ast str> {
-        todo!()
+    fn span_snippet(&self, api_span: &Span<'ast>) -> Option<&'ast str> {
+        let rust_span = self.rustc_converter.to_span(api_span);
+        let snippet = self.rustc_cx.sess.source_map().span_to_snippet(rust_span).ok()?;
+        Some(self.storage.alloc_str(&snippet))
     }
 
     fn symbol_str(&'ast self, api_id: SymbolId) -> &'ast str {

--- a/marker_rustc_driver/src/context/storage.rs
+++ b/marker_rustc_driver/src/context/storage.rs
@@ -8,16 +8,14 @@ use crate::conversion::common::SpanSourceInfo;
 
 pub struct Storage<'ast> {
     buffer: Bump,
-    span_src_map: RefCell<FxHashMap<rustc_span::FileName, SpanSource<'ast>>>,
-    span_infos: RefCell<FxHashMap<SpanSource<'ast>, SpanSourceInfo>>,
+    span_src_info: RefCell<FxHashMap<&'ast SpanSource<'ast>, (&'ast SpanSource<'ast>, SpanSourceInfo)>>,
 }
 
 impl<'ast> Default for Storage<'ast> {
     fn default() -> Self {
         Self {
             buffer: Bump::new(),
-            span_src_map: RefCell::default(),
-            span_infos: RefCell::default(),
+            span_src_info: RefCell::default(),
         }
     }
 }
@@ -44,27 +42,33 @@ impl<'ast> Storage<'ast> {
 }
 
 impl<'ast> Storage<'ast> {
-    pub fn span_src(&self, rustc_src: &rustc_span::FileName) -> Option<SpanSource<'ast>> {
-        self.span_src_map.borrow().get(rustc_src).copied()
+    pub fn get_span_src_info<'a>(
+        &'ast self,
+        api_src: &'a SpanSource<'a>,
+    ) -> Option<(&'ast SpanSource<'ast>, SpanSourceInfo)> {
+        self.span_src_info.borrow().get(api_src).copied()
     }
 
-    pub fn add_span_src(&self, rustc_src: rustc_span::FileName, api_src: SpanSource<'ast>) {
-        let prev_item = self.span_src_map.borrow_mut().insert(rustc_src, api_src);
-        debug_assert!(
-            prev_item.is_none(),
-            "`SpanSource`s should never be mapped and inserted twice"
-        );
-    }
+    pub fn insert_span_src_info(
+        &'ast self,
+        api_src: &SpanSource<'_>,
+        src_info: SpanSourceInfo,
+    ) -> (&'ast SpanSource<'ast>, SpanSourceInfo) {
+        let alloc_api_src = self.alloc(match api_src {
+            SpanSource::File(name) => SpanSource::File(self.alloc_str(name.get()).into()),
+            SpanSource::Macro(id) => SpanSource::Macro(*id),
+            SpanSource::Sugar(name, id) => SpanSource::Sugar(self.alloc_str(name.get()).into(), *id),
+        });
 
-    pub fn span_src_info(&self, api_src: SpanSource<'ast>) -> Option<SpanSourceInfo> {
-        self.span_infos.borrow().get(&api_src).copied()
-    }
-
-    pub fn add_span_src_info(&self, api_src: SpanSource<'ast>, src_info: SpanSourceInfo) {
-        let prev_item = self.span_infos.borrow_mut().insert(api_src, src_info);
+        let prev_item = self
+            .span_src_info
+            .borrow_mut()
+            .insert(alloc_api_src, (alloc_api_src, src_info));
         debug_assert!(
             prev_item.is_none(),
             "`SpanSourceInfo`s should never be mapped and inserted twice"
         );
+
+        (alloc_api_src, src_info)
     }
 }

--- a/marker_rustc_driver/src/conversion/marker.rs
+++ b/marker_rustc_driver/src/conversion/marker.rs
@@ -171,6 +171,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
             (hir::LangItem::FormatAlignment, self.to_symbol_id(Symbol::intern("rustc_ast::format::FormatAlignment"))),
             (hir::LangItem::FormatCount, self.to_symbol_id(Symbol::intern("rustc_ast::format::FormatCount"))),
             (hir::LangItem::FormatUnsafeArg, self.to_symbol_id(Symbol::intern("core::fmt::rt::UnsafeArg"))),
+            (hir::LangItem::ResumeTy, self.to_symbol_id(Symbol::intern("lang_item::ResumeTy"))),
         ];
 
         self.lang_item_map.borrow_mut().extend(list);
@@ -218,5 +219,3 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
         ))
     }
 }
-
-pub fn create_lang_item_map() {}

--- a/marker_rustc_driver/src/conversion/marker/common.rs
+++ b/marker_rustc_driver/src/conversion/marker/common.rs
@@ -347,7 +347,14 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
             hir::def::Res::SelfTyParam { trait_: def_id, .. } | hir::def::Res::SelfTyAlias { alias_to: def_id, .. } => {
                 AstPathTarget::SelfTy(self.to_item_id(*def_id))
             },
-            hir::def::Res::SelfCtor(_) => todo!("{res:#?}"),
+            hir::def::Res::SelfCtor(self_src) => {
+                // This should only be able to show up while a `CtorExpr` is
+                // constructed. Marker's `CtorExpr` don't include a `DefId` to
+                // the actual constructor, but a path indicating which type will
+                // be constructed. This means it should be safe to just return a
+                // `SelfTy` here.
+                AstPathTarget::SelfTy(self.to_item_id(*self_src))
+            },
             hir::def::Res::Local(id) => AstPathTarget::Var(self.to_var_id(*id)),
             hir::def::Res::ToolMod => todo!("{res:#?}"),
             hir::def::Res::NonMacroAttr(_) => todo!("{res:#?}"),

--- a/marker_rustc_driver/src/conversion/marker/common.rs
+++ b/marker_rustc_driver/src/conversion/marker/common.rs
@@ -4,8 +4,8 @@ use marker_api::ast::generic::GenericArgs;
 use marker_api::ast::ty::SynTyKind;
 use marker_api::ast::{
     Abi, AstPath, AstPathSegment, AstPathTarget, AstQPath, BodyId, Constness, CrateId, ExprId, FieldId, GenericId,
-    Ident, ItemId, LetStmtId, Mutability, Safety, Span, SpanId, SpanSource, SymbolId, Syncness, TraitRef, TyDefId,
-    VarId, VariantId,
+    Ident, ItemId, LetStmtId, Mutability, Safety, Span, SpanId, SpanSource, SpanSrcId, SymbolId, Syncness, TraitRef,
+    TyDefId, VarId, VariantId,
 };
 use marker_api::lint::Level;
 use rustc_hir as hir;
@@ -106,6 +106,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     pub fn to_field_id(&self, id: impl Into<HirIdLayout>) -> FieldId {
         transmute_id!(HirIdLayout as FieldId = id.into())
     }
+
     #[must_use]
     pub fn to_body_id(&self, rustc_id: hir::BodyId) -> BodyId {
         transmute_id!(
@@ -129,6 +130,11 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     #[must_use]
     pub fn to_let_stmt_id(&self, id: impl Into<HirIdLayout>) -> LetStmtId {
         transmute_id!(HirIdLayout as LetStmtId = id.into())
+    }
+
+    #[must_use]
+    pub fn to_span_src_id(&self, id: rustc_span::SyntaxContext) -> SpanSrcId {
+        transmute_id!(rustc_span::SyntaxContext as SpanSrcId = id)
     }
 }
 
@@ -383,50 +389,78 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     }
 
     pub fn to_span(&self, rustc_span: rustc_span::Span) -> Span<'ast> {
-        let (src, src_info) = self.to_span_info(rustc_span);
-        let start = (rustc_span.lo().0 as usize) - src_info.rustc_start_offset;
-        let end = (rustc_span.hi().0 as usize) - src_info.rustc_start_offset;
+        let ((src, src_info), span) = self.to_span_info(rustc_span);
+        let start = (span.lo().0 as usize) - src_info.rustc_start_offset;
+        let end = (span.hi().0 as usize) - src_info.rustc_start_offset;
         Span::new(src, start, end)
     }
 
-    fn to_span_info(&self, rustc_span: rustc_span::Span) -> (SpanSource<'ast>, SpanSourceInfo) {
-        let map = self.rustc_cx.sess.source_map();
-        let rustc_src = map.lookup_source_file(rustc_span.lo());
+    fn to_span_info(
+        &self,
+        rustc_span: rustc_span::Span,
+    ) -> ((&'ast SpanSource<'ast>, SpanSourceInfo), rustc_span::Span) {
+        fn file_info(rustc_cx: rustc_middle::ty::TyCtxt<'_>, span: rustc_span::Span) -> (String, usize) {
+            let map = rustc_cx.sess.source_map();
+            let rustc_src = map.lookup_source_file(span.lo());
+            let name = if let rustc_span::FileName::Real(
+                rustc_span::RealFileName::LocalPath(path)
+                | rustc_span::RealFileName::Remapped { virtual_name: path, .. },
+            ) = &rustc_src.name
+            {
+                path.to_string_lossy().to_string()
+            } else {
+                unreachable!("spans which don't come from from expansion always belong to a file")
+            };
 
-        if let Some(api_src) = self.storage.span_src(&rustc_src.name) {
-            if let Some(src_info) = self.storage.span_src_info(api_src) {
-                return (api_src, src_info);
-            }
-            unreachable!("each `SpanSource` object should also have a `SpanSourceInfo` object")
+            let offset = rustc_src.start_pos.0 as usize;
+            (name, offset)
         }
 
-        let api_src = match &rustc_src.name {
-            rustc_span::FileName::Real(real_name) => match real_name {
-                rustc_span::RealFileName::LocalPath(path)
-                | rustc_span::RealFileName::Remapped { virtual_name: path, .. } => {
-                    SpanSource::File(self.alloc(path.clone()))
-                },
-            },
-            rustc_span::FileName::MacroExpansion(_) => todo!(),
-            rustc_span::FileName::ProcMacroSourceCode(_) => todo!(),
-            rustc_span::FileName::QuoteExpansion(_)
-            | rustc_span::FileName::Anon(_)
-            | rustc_span::FileName::CfgSpec(_)
-            | rustc_span::FileName::CliCrateAttr(_)
-            | rustc_span::FileName::Custom(_)
-            | rustc_span::FileName::DocTest(_, _)
-            | rustc_span::FileName::InlineAsm(_) => {
-                unimplemented!("the api should only receive and request spans from files and macros")
-            },
-        };
-        let api_info = SpanSourceInfo {
-            rustc_span_cx: rustc_span.data().ctxt,
-            rustc_start_offset: rustc_src.start_pos.0 as usize,
-        };
+        let syn_cx = rustc_span.ctxt();
+        if !rustc_span.from_expansion() {
+            // This is a normal source file
+            let (name, offset) = file_info(self.rustc_cx, rustc_span);
 
-        self.storage.add_span_src_info(api_src, api_info);
-        self.storage.add_span_src(rustc_src.name.clone(), api_src);
+            // Check Marker's cache
+            let api_hash_source = SpanSource::File((&name).into());
+            if let Some(span_info) = self.storage.get_span_src_info(&api_hash_source) {
+                return (span_info, rustc_span);
+            }
 
-        (api_src, api_info)
+            // Create and insert data
+            let api_info = SpanSourceInfo {
+                rustc_span_cx: syn_cx,
+                rustc_start_offset: offset,
+            };
+
+            (
+                self.storage.insert_span_src_info(&api_hash_source, api_info),
+                rustc_span,
+            )
+        } else if let Some(expansion_data) = rustc_span.source_callee() {
+            // This span comes from a macro or other desugared magic.
+            let sugar_file_name: String;
+            let api_hash_source = if matches!(expansion_data.kind, rustc_span::ExpnKind::Macro(..)) {
+                SpanSource::Macro(self.to_span_src_id(syn_cx))
+            } else {
+                (sugar_file_name, _) = file_info(self.rustc_cx, rustc_span);
+                SpanSource::Sugar((&sugar_file_name).into(), self.to_span_src_id(syn_cx))
+            };
+            if let Some(span_info) = self.storage.get_span_src_info(&api_hash_source) {
+                return (span_info, expansion_data.call_site);
+            }
+
+            let api_info = SpanSourceInfo {
+                rustc_span_cx: syn_cx,
+                rustc_start_offset: expansion_data.call_site.lo().0 as usize,
+            };
+
+            (
+                self.storage.insert_span_src_info(&api_hash_source, api_info),
+                expansion_data.call_site,
+            )
+        } else {
+            unreachable!("the api should only receive and request spans from files and macros")
+        }
     }
 }

--- a/marker_rustc_driver/src/conversion/marker/item.rs
+++ b/marker_rustc_driver/src/conversion/marker/item.rs
@@ -1,4 +1,5 @@
 use marker_api::ast::{
+    expr,
     item::{
         AdtKind, AssocItemKind, Body, CommonItemData, ConstItem, EnumItem, EnumVariant, ExternBlockItem,
         ExternCrateItem, ExternItemKind, Field, FnItem, ImplItem, ItemKind, ModItem, StaticItem, StructItem, TraitItem,
@@ -353,6 +354,31 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
         let id = self.to_body_id(body.id());
         if let Some(&body) = self.bodies.borrow().get(&id) {
             return body;
+        }
+
+        // Check for an async body
+        if let Some(src) = body.generator_kind {
+            match src {
+                hir::GeneratorKind::Async(_) => self
+                    .rustc_cx
+                    .sess
+                    .struct_span_warn(
+                        body.value.span,
+                        "async blocks and await expressions are currently not supported",
+                    )
+                    .note("see rust-marker/marker#174")
+                    .emit(),
+                hir::GeneratorKind::Gen => {
+                    // Yield expressions are currently unstable anyways, so no need for a message
+                },
+            }
+            return self.alloc(Body::new(
+                self.to_item_id(self.rustc_cx.hir().body_owner_def_id(body.id())),
+                expr::ExprKind::Unstable(self.alloc(expr::UnstableExpr::new(
+                    expr::CommonExprData::new(self.to_expr_id(body.value.hir_id), self.to_span_id(body.value.span)),
+                    expr::ExprPrecedence::Unstable(0),
+                ))),
+            ));
         }
 
         // Body-Translation-Stack push

--- a/marker_rustc_driver/src/conversion/marker/pat.rs
+++ b/marker_rustc_driver/src/conversion/marker/pat.rs
@@ -121,7 +121,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
             },
             hir::PatKind::Lit(lit) => {
                 let expr = self.to_expr(lit);
-                let lit_expr = expr.try_into().expect("this should be a literal expression");
+                let lit_expr = expr.try_into().unwrap_or_else(|_| panic!("this should be a literal expression {lit:#?}"));
                 PatKind::Lit(lit_expr)
             },
             hir::PatKind::Range(start, end, kind) => PatKind::Range(self.alloc(RangePat::new(

--- a/marker_rustc_driver/src/conversion/marker/pat.rs
+++ b/marker_rustc_driver/src/conversion/marker/pat.rs
@@ -121,7 +121,9 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
             },
             hir::PatKind::Lit(lit) => {
                 let expr = self.to_expr(lit);
-                let lit_expr = expr.try_into().unwrap_or_else(|_| panic!("this should be a literal expression {lit:#?}"));
+                let lit_expr = expr
+                    .try_into()
+                    .unwrap_or_else(|_| panic!("this should be a literal expression {lit:#?}"));
                 PatKind::Lit(lit_expr)
             },
             hir::PatKind::Range(start, end, kind) => PatKind::Range(self.alloc(RangePat::new(

--- a/marker_rustc_driver/src/conversion/marker/ty.rs
+++ b/marker_rustc_driver/src/conversion/marker/ty.rs
@@ -122,10 +122,9 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
             | mid::ty::TyKind::GeneratorWitness(_)
             | mid::ty::TyKind::GeneratorWitnessMIR(_, _) => SemTyKind::Unstable(self.alloc(SemUnstableTy::new())),
             mid::ty::TyKind::Never => SemTyKind::Never(self.alloc(SemNeverTy::new())),
-            mid::ty::TyKind::Alias(mid::ty::AliasKind::Inherent | mid::ty::AliasKind::Projection, info) => {
+            mid::ty::TyKind::Alias(_, info) => {
                 SemTyKind::Alias(self.alloc(SemAliasTy::new(self.to_item_id(info.def_id))))
             },
-            mid::ty::TyKind::Alias(kind, info) => todo!("{kind:#?}\n\n{info:#?}"),
             mid::ty::TyKind::Param(param) => {
                 let body_id = self
                     .rustc_body

--- a/marker_rustc_driver/src/conversion/rustc/common.rs
+++ b/marker_rustc_driver/src/conversion/rustc/common.rs
@@ -184,9 +184,9 @@ impl<'ast, 'tcx> RustcConverter<'ast, 'tcx> {
     }
 
     pub fn to_span(&self, api_span: &Span<'ast>) -> rustc_span::Span {
-        let src_info = self
+        let (_, src_info) = self
             .storage
-            .span_src_info(api_span.source())
+            .get_span_src_info(api_span.source())
             .expect("all driver created `SpanSources` have a matching info");
 
         #[expect(clippy::cast_possible_truncation, reason = "`u32` is set by rustc and will be fine")]

--- a/marker_rustc_driver/src/conversion/rustc/unstable.rs
+++ b/marker_rustc_driver/src/conversion/rustc/unstable.rs
@@ -7,7 +7,7 @@ impl<'ast, 'tcx> RustcConverter<'ast, 'tcx> {
         self.lints.borrow_mut().entry(api_lint).or_insert_with(|| {
             // Not extracted to an extra function, as it's very specific
             let report_in_external_macro = match api_lint.report_in_macro {
-                MacroReport::No | MacroReport::Local => false,
+                MacroReport::No => false,
                 MacroReport::All => true,
                 _ => unreachable!(),
             };

--- a/marker_uilints/src/lib.rs
+++ b/marker_uilints/src/lib.rs
@@ -30,6 +30,16 @@ marker_api::declare_lint! {
 
 marker_api::declare_lint! {
     /// # What it does
+    /// A lint used for marker's uitests.
+    ///
+    /// It's used to print spans and is allowed to emit code in macros
+    PRINT_SPAN_LINT,
+    Warn,
+    marker_api::lint::MacroReport::All,
+}
+
+marker_api::declare_lint! {
+    /// # What it does
     /// A lint used for markers uitests.
     ///
     /// It warns about about item names starting with `FindMe`, `find_me` or `FIND_ME`.
@@ -111,7 +121,7 @@ impl LintPass for TestLintPass {
                     diag.note(format!("{expr:#?}"));
                 });
             } else if ident.name().starts_with("_span") {
-                cx.emit_lint(TEST_LINT, stmt.id(), "print span", stmt.span(), |diag| {
+                cx.emit_lint(PRINT_SPAN_LINT, stmt.id(), "print span", stmt.span(), |diag| {
                     let span = expr.span();
                     diag.note(format!("Debug: {:#?}", span));
                     diag.note(format!("Snippet: {}", span.snippet_or("..")));

--- a/marker_uilints/src/lib.rs
+++ b/marker_uilints/src/lib.rs
@@ -110,6 +110,12 @@ impl LintPass for TestLintPass {
                 cx.emit_lint(TEST_LINT, stmt.id(), "print test", stmt.span(), |diag| {
                     diag.note(format!("{expr:#?}"));
                 });
+            } else if ident.name().starts_with("_span") {
+                cx.emit_lint(TEST_LINT, stmt.id(), "print span", stmt.span(), |diag| {
+                    let span = expr.span();
+                    diag.note(format!("Debug: {:#?}", span));
+                    diag.note(format!("Snippet: {}", span.snippet_or("..")));
+                });
             } else if ident.name().starts_with("_ty") {
                 cx.emit_lint(TEST_LINT, stmt.id(), "print type test", stmt.span(), |diag| {
                     diag.note(format!("{:#?}", expr.ty()));

--- a/marker_uilints/tests/ui/find_item.rs
+++ b/marker_uilints/tests/ui/find_item.rs
@@ -1,3 +1,15 @@
-static FIND_ITEM: u32 = 4;
+macro_rules! ignore_macro_magic {
+    () => {
+        static FIND_ITEM: u32 = 4;
+    };
+}
+
+mod find_real_item {
+    static FIND_ITEM: u32 = 4;
+}
+
+mod ignore_macro_item {
+    ignore_macro_magic!();
+}
 
 fn main() {}

--- a/marker_uilints/tests/ui/find_item.stderr
+++ b/marker_uilints/tests/ui/find_item.stderr
@@ -1,21 +1,21 @@
 warning: hey there is a static item here
- --> $DIR/find_item.rs:1:1
+ --> $DIR/find_item.rs:8:5
   |
-1 | static FIND_ITEM: u32 = 4;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `duck`
+8 |     static FIND_ITEM: u32 = 4;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `duck`
   |
   = note: a note
   = help: a help
 note: a spanned note
- --> $DIR/find_item.rs:1:1
+ --> $DIR/find_item.rs:8:5
   |
-1 | static FIND_ITEM: u32 = 4;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+8 |     static FIND_ITEM: u32 = 4;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a spanned help
- --> $DIR/find_item.rs:1:1
+ --> $DIR/find_item.rs:8:5
   |
-1 | static FIND_ITEM: u32 = 4;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+8 |     static FIND_ITEM: u32 = 4;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
   = note: `#[warn(marker::test_lint)]` on by default
 
 warning: 1 warning emitted

--- a/marker_uilints/tests/ui/print_cond_expr.rs
+++ b/marker_uilints/tests/ui/print_cond_expr.rs
@@ -51,7 +51,7 @@ mod question_mark {
 
     fn kanske_result() -> Result<i32, i32> {
         let x: Result<i32, i32> = Ok(1);
-        let _print_option_match = x?;
+        let _print_result_match = x?;
         Err(4)
     }
 }

--- a/marker_uilints/tests/ui/print_cond_expr.rs
+++ b/marker_uilints/tests/ui/print_cond_expr.rs
@@ -35,6 +35,7 @@ fn matches(scrutinee: &[i32]) {
 
     let opt = Some(1);
     let _print_match_with_path = match opt {
+        Some(-1) => (),
         Some(1) => (),
         Some(x) => (),
         None => (),

--- a/marker_uilints/tests/ui/print_cond_expr.stderr
+++ b/marker_uilints/tests/ui/print_cond_expr.stderr
@@ -1110,11 +1110,12 @@ warning: print test
                                                    ident: Ident {
                                                        name: "Try::branch",
                                                        span: Span {
-                                                           source: File(
+                                                           source: Sugar(
                                                                "$DIR/print_cond_expr.rs",
+                                                               SpanSrcId(..),
                                                            ),
-                                                           start: 994,
-                                                           end: 996,
+                                                           start: 0,
+                                                           end: 2,
                                                        },
                                                    },
                                                    generics: GenericArgs {
@@ -1174,7 +1175,7 @@ warning: print test
 warning: print test
   --> $DIR/print_cond_expr.rs:54:9
    |
-54 |         let _print_option_match = x?;
+54 |         let _print_result_match = x?;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: QuestionMark(
@@ -1207,11 +1208,12 @@ warning: print test
                                                    ident: Ident {
                                                        name: "Try::branch",
                                                        span: Span {
-                                                           source: File(
+                                                           source: Sugar(
                                                                "$DIR/print_cond_expr.rs",
+                                                               SpanSrcId(..),
                                                            ),
-                                                           start: 1138,
-                                                           end: 1140,
+                                                           start: 0,
+                                                           end: 2,
                                                        },
                                                    },
                                                    generics: GenericArgs {

--- a/marker_uilints/tests/ui/print_cond_expr.stderr
+++ b/marker_uilints/tests/ui/print_cond_expr.stderr
@@ -758,10 +758,11 @@ warning: print test
   --> $DIR/print_cond_expr.rs:37:5
    |
 37 | /     let _print_match_with_path = match opt {
-38 | |         Some(1) => (),
-39 | |         Some(x) => (),
-40 | |         None => (),
-41 | |     };
+38 | |         Some(-1) => (),
+39 | |         Some(1) => (),
+40 | |         Some(x) => (),
+41 | |         None => (),
+42 | |     };
    | |______^
    |
    = note: Match(
@@ -846,6 +847,84 @@ warning: print test
                                            span: SpanId(..),
                                            ident: SymbolId(..),
                                            pat: Lit(
+                                               UnaryOp(
+                                                   UnaryOpExpr {
+                                                       data: CommonExprData {
+                                                           _lifetime: PhantomData<&()>,
+                                                           id: ExprId(..),
+                                                           span: SpanId(..),
+                                                       },
+                                                       expr: IntLit(
+                                                           IntLitExpr {
+                                                               data: CommonExprData {
+                                                                   _lifetime: PhantomData<&()>,
+                                                                   id: ExprId(..),
+                                                                   span: SpanId(..),
+                                                               },
+                                                               value: 1,
+                                                               suffix: None,
+                                                           },
+                                                       ),
+                                                       kind: Neg,
+                                                   },
+                                               ),
+                                           ),
+                                       },
+                                   ],
+                                   is_non_exhaustive: false,
+                               },
+                           ),
+                           guard: None,
+                           expr: Tuple(
+                               TupleExpr {
+                                   data: CommonExprData {
+                                       _lifetime: PhantomData<&()>,
+                                       id: ExprId(..),
+                                       span: SpanId(..),
+                                   },
+                                   elements: [],
+                               },
+                           ),
+                       },
+                       MatchArm {
+                           span: SpanId(..),
+                           pat: Struct(
+                               StructPat {
+                                   data: CommonPatData {
+                                       _lifetime: PhantomData<&()>,
+                                       span: SpanId(..),
+                                   },
+                                   path: AstQPath {
+                                       self_ty: None,
+                                       path_ty: None,
+                                       path: AstPath {
+                                           segments: [
+                                               AstPathSegment {
+                                                   ident: Ident {
+                                                       name: "Some",
+                                                       span: Span {
+                                                           source: File(
+                                                               "$DIR/print_cond_expr.rs",
+                                                           ),
+                                                           start: 807,
+                                                           end: 811,
+                                                       },
+                                                   },
+                                                   generics: GenericArgs {
+                                                       args: [],
+                                                   },
+                                               },
+                                           ],
+                                       },
+                                       target: Variant(
+                                           VariantId(..),
+                                       ),
+                                   },
+                                   fields: [
+                                       StructFieldPat {
+                                           span: SpanId(..),
+                                           ident: SymbolId(..),
+                                           pat: Lit(
                                                Int(
                                                    IntLitExpr {
                                                        data: CommonExprData {
@@ -895,8 +974,8 @@ warning: print test
                                                            source: File(
                                                                "$DIR/print_cond_expr.rs",
                                                            ),
-                                                           start: 806,
-                                                           end: 810,
+                                                           start: 830,
+                                                           end: 834,
                                                        },
                                                    },
                                                    generics: GenericArgs {
@@ -963,8 +1042,8 @@ warning: print test
                                                            source: File(
                                                                "$DIR/print_cond_expr.rs",
                                                            ),
-                                                           start: 829,
-                                                           end: 833,
+                                                           start: 853,
+                                                           end: 857,
                                                        },
                                                    },
                                                    generics: GenericArgs {
@@ -996,9 +1075,9 @@ warning: print test
            )
 
 warning: print test
-  --> $DIR/print_cond_expr.rs:47:9
+  --> $DIR/print_cond_expr.rs:48:9
    |
-47 |         let _print_option_match = x?;
+48 |         let _print_option_match = x?;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: QuestionMark(
@@ -1034,8 +1113,8 @@ warning: print test
                                                            source: File(
                                                                "$DIR/print_cond_expr.rs",
                                                            ),
-                                                           start: 970,
-                                                           end: 972,
+                                                           start: 994,
+                                                           end: 996,
                                                        },
                                                    },
                                                    generics: GenericArgs {
@@ -1070,8 +1149,8 @@ warning: print test
                                                                source: File(
                                                                    "$DIR/print_cond_expr.rs",
                                                                ),
-                                                               start: 970,
-                                                               end: 971,
+                                                               start: 994,
+                                                               end: 995,
                                                            },
                                                        },
                                                        generics: GenericArgs {
@@ -1093,9 +1172,9 @@ warning: print test
            )
 
 warning: print test
-  --> $DIR/print_cond_expr.rs:53:9
+  --> $DIR/print_cond_expr.rs:54:9
    |
-53 |         let _print_option_match = x?;
+54 |         let _print_option_match = x?;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: QuestionMark(
@@ -1131,8 +1210,8 @@ warning: print test
                                                            source: File(
                                                                "$DIR/print_cond_expr.rs",
                                                            ),
-                                                           start: 1114,
-                                                           end: 1116,
+                                                           start: 1138,
+                                                           end: 1140,
                                                        },
                                                    },
                                                    generics: GenericArgs {
@@ -1167,8 +1246,8 @@ warning: print test
                                                                source: File(
                                                                    "$DIR/print_cond_expr.rs",
                                                                ),
-                                                               start: 1114,
-                                                               end: 1115,
+                                                               start: 1138,
+                                                               end: 1139,
                                                            },
                                                        },
                                                        generics: GenericArgs {

--- a/marker_uilints/tests/ui/print_span.rs
+++ b/marker_uilints/tests/ui/print_span.rs
@@ -6,7 +6,7 @@ macro_rules! magic_macro {
 use magic_macro;
 
 fn main() {
-    let _span_macro = magic_macro!();
-    
     let _span_normal = 178;
+
+    let _span_macro = magic_macro!();
 }

--- a/marker_uilints/tests/ui/print_span.rs
+++ b/marker_uilints/tests/ui/print_span.rs
@@ -1,0 +1,12 @@
+macro_rules! magic_macro {
+    () => {
+        "*magic penguin noises*"
+    };
+}
+use magic_macro;
+
+fn main() {
+    let _span_macro = magic_macro!();
+    
+    let _span_normal = 178;
+}

--- a/marker_uilints/tests/ui/print_span.stderr
+++ b/marker_uilints/tests/ui/print_span.stderr
@@ -1,33 +1,33 @@
 warning: print span
  --> $DIR/print_span.rs:9:5
   |
-9 |     let _span_macro = magic_macro!();
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+9 |     let _span_normal = 178;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: Debug: Span {
-              source: Macro(
-                  SpanSrcId(..),
+              source: File(
+                  "$DIR/print_span.rs",
               ),
-              start: 0,
-              end: 14,
+              start: 134,
+              end: 137,
           }
-  = note: Snippet: magic_macro!()
-  = note: `#[warn(marker::test_lint)]` on by default
+  = note: Snippet: 178
+  = note: `#[warn(marker::print_span_lint)]` on by default
 
 warning: print span
   --> $DIR/print_span.rs:11:5
    |
-11 |     let _span_normal = 178;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+11 |     let _span_macro = magic_macro!();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: Debug: Span {
-               source: File(
-                   "$DIR/print_span.rs",
+               source: Macro(
+                   SpanSrcId(..),
                ),
-               start: 177,
-               end: 180,
+               start: 0,
+               end: 14,
            }
-   = note: Snippet: 178
+   = note: Snippet: magic_macro!()
 
 warning: 2 warnings emitted
 

--- a/marker_uilints/tests/ui/print_span.stderr
+++ b/marker_uilints/tests/ui/print_span.stderr
@@ -1,0 +1,33 @@
+warning: print span
+ --> $DIR/print_span.rs:9:5
+  |
+9 |     let _span_macro = magic_macro!();
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: Debug: Span {
+              source: Macro(
+                  SpanSrcId(..),
+              ),
+              start: 0,
+              end: 14,
+          }
+  = note: Snippet: magic_macro!()
+  = note: `#[warn(marker::test_lint)]` on by default
+
+warning: print span
+  --> $DIR/print_span.rs:11:5
+   |
+11 |     let _span_normal = 178;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: Debug: Span {
+               source: File(
+                   "$DIR/print_span.rs",
+               ),
+               start: 177,
+               end: 180,
+           }
+   = note: Snippet: 178
+
+warning: 2 warnings emitted
+

--- a/marker_uilints/tests/ui/test-lang-items.rs
+++ b/marker_uilints/tests/ui/test-lang-items.rs
@@ -1,4 +1,0 @@
-fn main() {
-    let x = 0;
-    println!("Test {0}\n", x);
-}

--- a/marker_uilints/tests/ui/test_no_async_ice.rs
+++ b/marker_uilints/tests/ui/test_no_async_ice.rs
@@ -1,0 +1,9 @@
+use std::path::Path;
+use std::path::PathBuf;
+
+pub async fn canonicalize(path: impl AsRef<Path>) -> std::io::Result<PathBuf> {
+    let _path = path.as_ref().to_owned();
+    Ok(PathBuf::from("./duck"))
+}
+
+fn main() {}

--- a/marker_uilints/tests/ui/test_no_async_ice.stderr
+++ b/marker_uilints/tests/ui/test_no_async_ice.stderr
@@ -1,0 +1,14 @@
+warning: async blocks and await expressions are currently not supported
+ --> $DIR/test_no_async_ice.rs:4:79
+  |
+4 |   pub async fn canonicalize(path: impl AsRef<Path>) -> std::io::Result<PathBuf> {
+  |  _______________________________________________________________________________^
+5 | |     let _path = path.as_ref().to_owned();
+6 | |     Ok(PathBuf::from("./duck"))
+7 | | }
+  | |_^
+  |
+  = note: see rust-marker/marker#174
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
I ran Marker on several crates and fixed ICEs as they came up. I also found a soundness issue in the previous `SpanSource` implementation. Totally fixing spans is a task for another darker day, but this should work well enough for v0.1.0.

I tested Marker on the following crates:
* `clap`
* `parking_lot`
* `rand`
* `regex`
* `serde`
* `time`
* `tokio`
* `unicode-xid`

I want to test more crates, also as part of the CI, but this PR has grown too much already. 