### PR TITLE
Add several more checks to CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,8 @@
 [alias]
+bless   = "test --test uitest -- -- --bless"
 dogfood = "run --features dev-build --bin cargo-marker -- --forward-rust-flags"
-uitest = "test --test uitest"
-bless = "test --test uitest -- -- --bless"
 uilints = "test -p marker_uilints --test uitest"
+uitest  = "test --test uitest"
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,9 +59,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rm rust-toolchain
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: stable
+    - uses: dtolnay/rust-toolchain@stable
 
     - run: rustc -vV
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,19 +36,20 @@ jobs:
     # Setup
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: nightly-2023-07-13
-        components: cargo, clippy, rustfmt
+        components: rustfmt, clippy
+
     - run: rustc -vV
-  
+
     # Tests
     - run: cargo test
     - run: cargo clippy
     - run: cargo fmt --check
-    - run: cargo doc
+    - run: cargo doc --no-deps
 
-  # This task ensures, required packages can be build with a stable toolchain
+  # This task ensures, required packages can be built with a stable toolchain
   # the only package requiring nightly should be `marker_rustc_driver` and
   # optionally `marker_adapter`
   rust-crates-build-stable:
@@ -58,10 +59,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rm rust-toolchain
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
-        components: cargo
+
     - run: rustc -vV
 
     # Test
@@ -70,3 +71,28 @@ jobs:
     - run: cargo build --package marker_utils
     - run: cargo build --package marker_uitest
     - run: cargo build --package marker_uilints
+
+  # Check the formatting of TOML files in the repository
+  toml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: ./scripts/download/taplo.sh
+      - run: ./taplo fmt --check
+
+  # Check for typos in the repository based on a static dictionary
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: ./scripts/download/typos.sh
+      - run: ./typos
+
+  # Check for unused dependencies that uses simple regex search,
+  # meaning it's ⚡️ blazingly ⚡️ fast
+  rust-unused-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: ./scripts/download/cargo-machete.sh
+      - run: ./cargo-machete

--- a/.github/workflows/rust_bors.yml
+++ b/.github/workflows/rust_bors.yml
@@ -44,9 +44,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rm rust-toolchain
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: stable
+    - uses: dtolnay/rust-toolchain@stable
 
     - run: rustc -vV
 

--- a/.github/workflows/rust_bors.yml
+++ b/.github/workflows/rust_bors.yml
@@ -16,29 +16,25 @@ env:
 
 jobs:
   rust:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     # Setup
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
-          toolchain: nightly-2023-07-13
-          components: cargo, clippy, rustfmt
+        toolchain: nightly-2023-07-13
+        components: rustfmt, clippy
+
     - run: rustc -vV
-    - run: cargo build
-  
+
     # Tests
     - run: cargo test
     - run: cargo clippy
     - run: cargo fmt --check
-    - run: cargo doc
+    - run: cargo doc --no-deps
 
-  # This task ensures, required packages can be build with a stable toolchain
+  # This task ensures, required packages can be built with a stable toolchain
   # the only package requiring nightly should be `marker_rustc_driver` and
   # optionally `marker_adapter`
   rust-crates-build-stable:
@@ -48,10 +44,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rm rust-toolchain
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
-        components: cargo
+
     - run: rustc -vV
 
     # Test
@@ -60,3 +56,28 @@ jobs:
     - run: cargo build --package marker_utils
     - run: cargo build --package marker_uitest
     - run: cargo build --package marker_uilints
+
+  # Check the formatting of TOML files in the repository
+  toml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: ./scripts/download/taplo.sh
+      - run: ./taplo fmt --check
+
+  # Check for typos in the repository based on a static dictionary
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: ./scripts/download/typos.sh
+      - run: ./typos
+
+  # Check for unused dependencies that uses simple regex search,
+  # meaning it's ⚡️ blazingly ⚡️ fast
+  rust-unused-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: ./scripts/download/cargo-machete.sh
+      - run: ./cargo-machete

--- a/.github/workflows/rust_bors.yml
+++ b/.github/workflows/rust_bors.yml
@@ -16,7 +16,11 @@ env:
 
 jobs:
   rust:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
 
     # Setup
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [workspace]
 members = [
-    "cargo-marker",
-    "marker_adapter",
-    "marker_api",
-    "marker_rustc_driver",
-    "marker_utils",
-    "marker_lints",
-    "marker_uitest",
-    "marker_uilints",
+  "cargo-marker",
+  "marker_adapter",
+  "marker_api",
+  "marker_rustc_driver",
+  "marker_utils",
+  "marker_lints",
+  "marker_uitest",
+  "marker_uilints",
 ]
 resolver = "2"
 

--- a/bors.toml
+++ b/bors.toml
@@ -4,5 +4,8 @@ status = [
   "rust (windows-latest)",
   "rust (macos-latest)",
   "rust-crates-build-stable",
+  "toml",
+  "typos",
+  "rust-unused-dependencies",
 ]
 timeout_sec = 1200 # 20 min

--- a/bors.toml
+++ b/bors.toml
@@ -1,8 +1,8 @@
-status = [
-    "rust (ubuntu-latest)",
-    "rust (windows-latest)",
-    "rust (macos-latest)",
-    "rust-crates-build-stable",
-]
 delete_merged_branches = true
+status = [
+  "rust (ubuntu-latest)",
+  "rust (windows-latest)",
+  "rust (macos-latest)",
+  "rust-crates-build-stable",
+]
 timeout_sec = 1200 # 20 min

--- a/cargo-marker/Cargo.toml
+++ b/cargo-marker/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "cargo_marker"
-version = "0.1.1"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-keywords = ["marker", "linting", "cli", "cargo", "cargo-subcommand"]
-categories = ["development-tools::cargo-plugins"]
-repository = "https://github.com/rust-marker/marker"
+categories  = ["development-tools::cargo-plugins"]
 description = "Marker's CLI interface to automatically compile and run lint crates"
+edition     = "2021"
+keywords    = ["marker", "linting", "cli", "cargo", "cargo-subcommand"]
+license     = "MIT OR Apache-2.0"
+name        = "cargo_marker"
+repository  = "https://github.com/rust-marker/marker"
+version     = "0.1.1"
 
 # Crate names in Rust are fun. I reserved `cargo_marker` as a crate name. However,
 # Cargo requires it's subcommands to use a dash like `cargo-marker`. Unable to rename
@@ -16,11 +16,11 @@ name = "cargo-marker"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.0", features = ["string"] }
-serde = { version = "1.0", features = ["derive"] }
-toml = { version = "0.7" }
-once_cell = "1.17.0"
 cargo_metadata = "0.15.4"
+clap           = { version = "4.0", features = ["string"] }
+once_cell      = "1.17.0"
+serde          = { version = "1.0", features = ["derive"] }
+toml           = { version = "0.7" }
 
 [features]
 default = []

--- a/cargo-marker/Cargo.toml
+++ b/cargo-marker/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
+name    = "cargo_marker"
+version = "0.1.1"
+
 categories  = ["development-tools::cargo-plugins"]
 description = "Marker's CLI interface to automatically compile and run lint crates"
 edition     = "2021"
 keywords    = ["marker", "linting", "cli", "cargo", "cargo-subcommand"]
 license     = "MIT OR Apache-2.0"
-name        = "cargo_marker"
 repository  = "https://github.com/rust-marker/marker"
-version     = "0.1.1"
 
 # Crate names in Rust are fun. I reserved `cargo_marker` as a crate name. However,
 # Cargo requires it's subcommands to use a dash like `cargo-marker`. Unable to rename

--- a/marker_adapter/Cargo.toml
+++ b/marker_adapter/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
+name    = "marker_adapter"
+version = "0.1.1"
+
 description = "Marker's adapter for common functions shared among lint drivers"
 edition     = "2021"
 keywords    = ["marker"]
 license     = "MIT OR Apache-2.0"
-name        = "marker_adapter"
 repository  = "https://github.com/rust-marker/marker"
-version     = "0.1.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/marker_adapter/Cargo.toml
+++ b/marker_adapter/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-name = "marker_adapter"
-version = "0.1.1"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-keywords = ["marker"]
-repository = "https://github.com/rust-marker/marker"
 description = "Marker's adapter for common functions shared among lint drivers"
+edition     = "2021"
+keywords    = ["marker"]
+license     = "MIT OR Apache-2.0"
+name        = "marker_adapter"
+repository  = "https://github.com/rust-marker/marker"
+version     = "0.1.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-marker_api = { path = "../marker_api", version = "0.1.1", features = ["driver-api"] }
+marker_api   = { path = "../marker_api", version = "0.1.1", features = ["driver-api"] }
 marker_utils = { path = "../marker_utils", version = "0.1.1" }
 
+cfg-if     = "1.0.0"
 libloading = "0.8.0"
-cfg-if = "1.0.0"

--- a/marker_adapter/src/loader.rs
+++ b/marker_adapter/src/loader.rs
@@ -58,7 +58,7 @@ impl LintCrateRegistry {
 
         let pass = LoadedLintCrate::try_from_lib(lib)?;
 
-        // FIXME: Create issue for lifetimes and fix droping and pointer decl stuff
+        // FIXME: Create issue for lifetimes and fix dropping and pointer decl stuff
 
         Ok(pass)
     }

--- a/marker_api/Cargo.toml
+++ b/marker_api/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "marker_api"
-version = "0.1.1"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-keywords = ["marker", "linting"]
-categories = ["development-tools"]
-repository = "https://github.com/rust-marker/marker"
+categories  = ["development-tools"]
 description = "Marker's API, designed for stability and usability"
+edition     = "2021"
+keywords    = ["marker", "linting"]
+license     = "MIT OR Apache-2.0"
+name        = "marker_api"
+repository  = "https://github.com/rust-marker/marker"
+version     = "0.1.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/marker_api/Cargo.toml
+++ b/marker_api/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
+name    = "marker_api"
+version = "0.1.1"
+
 categories  = ["development-tools"]
 description = "Marker's API, designed for stability and usability"
 edition     = "2021"
 keywords    = ["marker", "linting"]
 license     = "MIT OR Apache-2.0"
-name        = "marker_api"
 repository  = "https://github.com/rust-marker/marker"
-version     = "0.1.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/marker_api/src/lint.rs
+++ b/marker_api/src/lint.rs
@@ -79,7 +79,7 @@ pub enum Level {
     /// The `deny` level will produce an error and stop further execution after the lint
     /// pass is complete.
     Deny,
-    /// The `forbid` level will produce an error and cannot be overriden by the user.
+    /// The `forbid` level will produce an error and cannot be overridden by the user.
     ///
     /// Choosing this diagnostic level should require heavy consideration, because should a lint
     /// with this level produce a false-positive, the user won't have an option to `allow` the lint

--- a/marker_lints/Cargo.toml
+++ b/marker_lints/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "marker_lints"
-version = "0.1.1"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-keywords = ["marker", "lint"]
-repository = "https://github.com/rust-marker/marker"
 description = "Lints for the marker_api and marker_utils crate"
+edition     = "2021"
+keywords    = ["marker", "lint"]
+license     = "MIT OR Apache-2.0"
+name        = "marker_lints"
+repository  = "https://github.com/rust-marker/marker"
+version     = "0.1.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -19,5 +19,5 @@ marker_api = { path = "../marker_api", version = "0.1.1" }
 marker_uitest = { path = "../marker_uitest", features = ["dev-build"] }
 
 [[test]]
-name = "uitest"
 harness = false
+name    = "uitest"

--- a/marker_lints/Cargo.toml
+++ b/marker_lints/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
+name    = "marker_lints"
+version = "0.1.1"
+
 description = "Lints for the marker_api and marker_utils crate"
 edition     = "2021"
 keywords    = ["marker", "lint"]
 license     = "MIT OR Apache-2.0"
-name        = "marker_lints"
 repository  = "https://github.com/rust-marker/marker"
-version     = "0.1.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/marker_rustc_driver/Cargo.toml
+++ b/marker_rustc_driver/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-name = "marker_rustc_driver"
-version = "0.1.1"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-keywords = ["marker", "linting"]
-repository = "https://github.com/rust-marker/marker"
+build       = "build.rs"
 description = "Marker's lint driver for rustc"
-build = "build.rs"
+edition     = "2021"
+keywords    = ["marker", "linting"]
+license     = "MIT OR Apache-2.0"
+name        = "marker_rustc_driver"
+repository  = "https://github.com/rust-marker/marker"
+version     = "0.1.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-marker_api = { path = "../marker_api", version = "0.1.1", features = ["driver-api"] }
 marker_adapter = { path = "../marker_adapter", version = "0.1.1" }
+marker_api     = { path = "../marker_api", version = "0.1.1", features = ["driver-api"] }
 
+bumpalo          = "3.12"
 rustc_tools_util = "0.3"
-bumpalo = "3.12"
 
 [build-dependencies]
 rustc_tools_util = "0.3"

--- a/marker_rustc_driver/Cargo.toml
+++ b/marker_rustc_driver/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
+name    = "marker_rustc_driver"
+version = "0.1.1"
+
 build       = "build.rs"
 description = "Marker's lint driver for rustc"
 edition     = "2021"
 keywords    = ["marker", "linting"]
 license     = "MIT OR Apache-2.0"
-name        = "marker_rustc_driver"
 repository  = "https://github.com/rust-marker/marker"
-version     = "0.1.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/marker_uilints/Cargo.toml
+++ b/marker_uilints/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
+name    = "marker_uilints"
+version = "0.1.1"
+
 edition = "2021"
 license = "MIT OR Apache-2.0"
-name    = "marker_uilints"
 publish = false
-version = "0.1.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/marker_uilints/Cargo.toml
+++ b/marker_uilints/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "marker_uilints"
-version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
+name    = "marker_uilints"
 publish = false
+version = "0.1.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -17,5 +17,5 @@ marker_api = { path = "../marker_api", version = "0.1.1" }
 marker_uitest = { path = "../marker_uitest", features = ["dev-build"] }
 
 [[test]]
-name = "uitest"
 harness = false
+name    = "uitest"

--- a/marker_uilints/src/lib.rs
+++ b/marker_uilints/src/lib.rs
@@ -134,7 +134,7 @@ impl LintPass for TestLintPass {
             } else if ident.name().starts_with("_span") {
                 cx.emit_lint(PRINT_SPAN_LINT, stmt.id(), "print span", stmt.span(), |diag| {
                     let span = expr.span();
-                    diag.note(format!("Debug: {:#?}", span));
+                    diag.note(format!("Debug: {span:#?}"));
                     diag.note(format!("Snippet: {}", span.snippet_or("..")));
                 });
             } else if ident.name().starts_with("_ty") {

--- a/marker_uitest/Cargo.toml
+++ b/marker_uitest/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-name = "marker_uitest"
-version = "0.1.1"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-keywords = ["marker", "linting"]
-repository = "https://github.com/rust-marker/marker"
 description = "A thin wrapper around the ui_test crate for Marker"
+edition     = "2021"
+keywords    = ["marker", "linting"]
+license     = "MIT OR Apache-2.0"
+name        = "marker_uitest"
+repository  = "https://github.com/rust-marker/marker"
+version     = "0.1.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ui_test = "0.11.7"
+semver   = "1.0"
 tempfile = "3.6.0"
-semver = "1.0"
+ui_test  = "0.11.7"
 
 [features]
 default = []

--- a/marker_uitest/Cargo.toml
+++ b/marker_uitest/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
+name    = "marker_uitest"
+version = "0.1.1"
+
 description = "A thin wrapper around the ui_test crate for Marker"
 edition     = "2021"
 keywords    = ["marker", "linting"]
 license     = "MIT OR Apache-2.0"
-name        = "marker_uitest"
 repository  = "https://github.com/rust-marker/marker"
-version     = "0.1.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/marker_utils/Cargo.toml
+++ b/marker_utils/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
+name    = "marker_utils"
+version = "0.1.1"
+
 categories  = ["development-tools"]
 description = "Marker's standard library for creating lints"
 edition     = "2021"
 keywords    = ["marker", "linting"]
 license     = "MIT OR Apache-2.0"
-name        = "marker_utils"
 repository  = "https://github.com/rust-marker/marker"
-version     = "0.1.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/marker_utils/Cargo.toml
+++ b/marker_utils/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "marker_utils"
-version = "0.1.1"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-keywords = ["marker", "linting"]
-categories = ["development-tools"]
-repository = "https://github.com/rust-marker/marker"
+categories  = ["development-tools"]
 description = "Marker's standard library for creating lints"
+edition     = "2021"
+keywords    = ["marker", "linting"]
+license     = "MIT OR Apache-2.0"
+name        = "marker_utils"
+repository  = "https://github.com/rust-marker/marker"
+version     = "0.1.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,7 @@
-max_width = 120
-comment_width = 100
+comment_width              = 100
+edition                    = "2021"
+error_on_line_overflow     = true
 match_block_trailing_comma = true
-wrap_comments = true
-edition = "2021"
-error_on_line_overflow = true
-version = "Two"
+max_width                  = 120
+version                    = "Two"
+wrap_comments              = true

--- a/scripts/download/cargo-machete.sh
+++ b/scripts/download/cargo-machete.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-script_dir=$(readlink -f $(dirname $0))
+script_dir=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 
 . $script_dir/lib.sh
 

--- a/scripts/download/cargo-machete.sh
+++ b/scripts/download/cargo-machete.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(readlink -f $(dirname $0))
+
+. $script_dir/lib.sh
+
+version=v0.5.0
+
+base_url="https://github.com/bnjbvr/cargo-machete/releases/download/$version"
+
+file_stem="cargo-machete-$version-x86_64-unknown-linux-musl"
+
+curl_and_decompress $base_url/$file_stem.tar.gz --strip-components 1 $file_stem/cargo-machete

--- a/scripts/download/cargo-machete.sh
+++ b/scripts/download/cargo-machete.sh
@@ -6,10 +6,12 @@ script_dir=$(readlink -f $(dirname $0))
 
 . $script_dir/lib.sh
 
-version=v0.5.0
+version=0.5.0
 
-base_url="https://github.com/bnjbvr/cargo-machete/releases/download/$version"
+base_url=https://github.com/bnjbvr/cargo-machete/releases/download/v$version
+file_stem=cargo-machete-v$version-$arch_rust-unknown-linux-musl
 
-file_stem="cargo-machete-$version-x86_64-unknown-linux-musl"
-
-curl_and_decompress $base_url/$file_stem.tar.gz --strip-components 1 $file_stem/cargo-machete
+download_and_decompress \
+    --check-hash sha256 \
+    $base_url/$file_stem.tar.gz \
+    --strip-components 1 $file_stem/cargo-machete

--- a/scripts/download/lib.sh
+++ b/scripts/download/lib.sh
@@ -1,0 +1,67 @@
+set -euo pipefail
+
+script_dir=$(readlink -f $(dirname $0))
+
+. $script_dir/../lib.sh
+
+# Produces Rust-style arch names, e.g. x86_64, aarch64, etc.
+export arch_rust=$(uname -m)
+
+function download_and_decompress {
+    with_backoff try_download_and_decompress "$@"
+}
+
+function try_download_and_decompress {
+    local hash_algo=""
+    while [[ "$#" -gt 0 ]]; do
+        case $1 in
+        --check-hash)
+            hash_algo="$2"
+            shift 2
+            ;;
+        *)
+            break
+            ;;
+        esac
+    done
+
+    local url="$1"
+    shift
+
+    local archive=$(basename $url)
+
+    curl_with_retry $url --remote-name
+
+    # Check the hash of the downloaded file if it was requested
+    if [[ "$hash_algo" != "" ]]
+    then
+        hash=$(curl_with_retry $url.$hash_algo)
+        echo "$hash $archive" | with_log ${hash_algo}sum --check
+    fi
+
+    if [[ $url == *.tar.gz || $url == *.tgz ]]
+    then
+        with_log tar --extract --gzip --file $archive "$@"
+    elif [[ $url == *.tar.xz ]]
+    then
+        with_log tar --extract --xz --file $archive "$@"
+    elif [[ $url == *.gz ]]
+    then
+        with_log gzip --decompress $archive > $(basename $url .gz)
+    else
+        echo "Unknown file type: $url"
+        exit 1
+    fi
+
+    rm $archive
+}
+
+function curl_with_retry {
+    with_log curl \
+        --silent \
+        --location \
+        --retry 5 \
+        --retry-connrefused \
+        --retry-delay 30 \
+        "$@"
+}

--- a/scripts/download/lib.sh
+++ b/scripts/download/lib.sh
@@ -1,6 +1,4 @@
-set -euo pipefail
-
-script_dir=$(readlink -f $(dirname $0))
+script_dir=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 
 . $script_dir/../lib.sh
 
@@ -47,7 +45,7 @@ function try_download_and_decompress {
         with_log tar --extract --xz --file $archive "$@"
     elif [[ $url == *.gz ]]
     then
-        with_log gzip --decompress $archive > $(basename $url .gz)
+        with_log gzip --decompress --stdout $archive > $(basename $url .gz)
     else
         echo "Unknown file type: $url"
         exit 1

--- a/scripts/download/taplo.sh
+++ b/scripts/download/taplo.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-script_dir=$(readlink -f $(dirname $0))
+script_dir=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 
 . $script_dir/lib.sh
 

--- a/scripts/download/taplo.sh
+++ b/scripts/download/taplo.sh
@@ -6,13 +6,8 @@ script_dir=$(readlink -f $(dirname $0))
 
 . $script_dir/lib.sh
 
-version=0.8.1
+version=0.7.0
 
-base_url="https://github.com/tamasfe/taplo/releases/download/$version"
+base_url=https://github.com/tamasfe/taplo/releases/download/release-taplo-cli-$version
 
-file_name=taplo-full-linux-x86_64
-
-curl_and_decompress $base_url/$file_name.gz
-
-mv $file_name ./taplo
-chmod +x ./taplo
+download_and_decompress $base_url/taplo-$arch_rust-unknown-linux-gnu.tar.gz taplo

--- a/scripts/download/taplo.sh
+++ b/scripts/download/taplo.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(readlink -f $(dirname $0))
+
+. $script_dir/lib.sh
+
+version=0.8.1
+
+base_url="https://github.com/tamasfe/taplo/releases/download/$version"
+
+file_name=taplo-full-linux-x86_64
+
+curl_and_decompress $base_url/$file_name.gz
+
+mv $file_name ./taplo
+chmod +x ./taplo

--- a/scripts/download/taplo.sh
+++ b/scripts/download/taplo.sh
@@ -6,8 +6,14 @@ script_dir=$(readlink -f $(dirname $0))
 
 . $script_dir/lib.sh
 
-version=0.7.0
+version=0.8.1
 
-base_url=https://github.com/tamasfe/taplo/releases/download/release-taplo-cli-$version
+base_url=https://github.com/tamasfe/taplo/releases/download/$version
 
-download_and_decompress $base_url/taplo-$arch_rust-unknown-linux-gnu.tar.gz taplo
+file_stem=taplo-linux-$arch_rust
+
+download_and_decompress $base_url/$file_stem.gz
+
+mv $file_stem taplo
+
+chmod +x ./taplo

--- a/scripts/download/typos.sh
+++ b/scripts/download/typos.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(readlink -f $(dirname $0))
+
+. $script_dir/lib.sh
+
+# Typos check should be pinned to the very specific version
+# to prevent sudden dictionary updates from making our CI fail
+version=v1.16.1
+
+base_url="https://github.com/crate-ci/typos/releases/download/$version"
+
+file_stem="typos-$version-x86_64-unknown-linux-musl"
+
+curl_and_decompress $base_url/$file_stem.tar.gz ./typos

--- a/scripts/download/typos.sh
+++ b/scripts/download/typos.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-script_dir=$(readlink -f $(dirname $0))
+script_dir=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 
 . $script_dir/lib.sh
 

--- a/scripts/download/typos.sh
+++ b/scripts/download/typos.sh
@@ -10,8 +10,8 @@ script_dir=$(readlink -f $(dirname $0))
 # to prevent sudden dictionary updates from making our CI fail
 version=v1.16.1
 
-base_url="https://github.com/crate-ci/typos/releases/download/$version"
+base_url=https://github.com/crate-ci/typos/releases/download/$version
 
-file_stem="typos-$version-x86_64-unknown-linux-musl"
+file_stem=typos-$version-x86_64-unknown-linux-musl
 
-curl_and_decompress $base_url/$file_stem.tar.gz ./typos
+download_and_decompress $base_url/$file_stem.tar.gz ./typos

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1,8 +1,6 @@
 # This file is meant to be sourced by other scripts, not executed directly.
 # It contains a bunch of helper functions for writing bash scripts.
 
-set -euo pipefail
-
 # This output stream is used by subshells to send their output to the
 # global build process stdout. This is needed e.g. for writing special commands
 # to the shells actual stdout instead of the command's stdout to let the github

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1,0 +1,136 @@
+# This file is meant to be sourced by other scripts, not executed directly.
+# It contains a bunch of helper functions for writing bash scripts.
+
+set -euo pipefail
+
+# This output stream is used by subshells to send their output to the
+# global build process stdout. This is needed e.g. for writing special commands
+# to the shells actual stdout instead of the command's stdout to let the github
+# actions runner read them
+global_stdout=3
+eval "exec $global_stdout>&1"
+
+# Retry a command a with backoff.
+#
+# The retry count is given by ATTEMPTS (default 5), the
+# initial backoff timeout is given by TIMEOUT in seconds
+# (default 1.)
+#
+# Successive backoffs double the timeout.
+#
+# Beware of set -e killing your whole script!
+#
+# Adapted from https://coderwall.com/p/--eiqg/exponential-backoff-in-bash
+function with_backoff {
+    local max_attempts=${ATTEMPTS-5}
+    local timeout=${TIMEOUT-1}
+    local attempt=0
+    local exit_code=0
+
+    while [[ $attempt < $max_attempts ]]
+    do
+        if [[ $attempt == 0 ]]; then
+            start_group "${@}"
+        else
+            start_group "[Try $((attempt + 1))/$max_attempts] ${@}"
+        fi
+
+        # Temporarily disable the "exit script on error" behavior
+        set +o errexit
+
+        "$@"
+        exit_code=$?
+
+        # put exit on error back up
+        set -o errexit
+
+        end_group
+
+        if [[ $exit_code == 0 ]]; then
+            break
+        fi
+
+        echo "Failure! Retrying in $timeout seconds.." 1>&2
+        sleep $timeout
+        attempt=$(( attempt + 1 ))
+        timeout=$(( timeout * 2 ))
+    done
+
+    if [[ $exit_code != 0 ]]; then
+        echo "You've failed me for the last time! (exit code $exit_code) ($@)" 1>&2
+    fi
+
+    return $exit_code
+}
+
+# Returns a command with syntax highlighting
+function colorize_command {
+    program=$1
+    shift
+
+    local args=()
+    for arg in "$@"; do
+        if [[ $arg =~ ^- ]]; then
+            args+=("\033[34;1m${arg}\033[0m")
+        else
+            args+=("\033[0;33m${arg}\033[0m")
+        fi
+    done
+
+    echo "\033[1;33m${program}\033[0m ${args[*]}"
+}
+
+# Log the command and execute it
+function with_log {
+    command=$(colorize_command "$@")
+
+    >&$global_stdout echo -e "\033[32;1m❱\033[0m $command"
+
+    "$@"
+}
+
+# Log the command and execute it, but collapse the output on CI
+function with_collapsed_log {
+    start_group "$@"
+
+    # Temporarily disable the "exit script on error" behavior
+    set +o errexit
+
+    "$@"
+    local exit_code=$?
+
+    # put exit on error back up
+    set -o errexit
+
+    end_group
+
+    return $exit_code
+}
+
+function group_header {
+    command=$(colorize_command "$@")
+
+    echo -e "\033[32;1m👉 ❱❱❱❱ $command\n"
+}
+
+# Begin a collapsible group. You'll need to click on the logs to expand them on CI
+#
+# Beware that it's not possible to nest groups. Two consecutive start_group calls are wrong.
+function start_group {
+    local group=$(group_header "${@}")
+
+    if [ "${GITHUB_ACTIONS:-false}" == "true" ]; then
+        >&$global_stdout echo -e "::group::${group}"
+    else
+        >&$global_stdout echo -e "${group}"
+    fi
+}
+
+# Finish the previously started collapsible group.
+#
+# Beware that it's not possible to nest groups, this closes all groups
+function end_group {
+    if [ "${GITHUB_ACTIONS:-false}" == "true" ]; then
+        >&$global_stdout echo "::endgroup::"
+    fi
+}

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,15 @@
+include = ["**/*.toml"]
+
+[formatting]
+allowed_blank_lines = 2
+column_width        = 80
+
+align_entries        = true
+array_auto_collapse  = true
+array_auto_expand    = true
+array_trailing_comma = true
+reorder_keys         = true
+trailing_newline     = true
+
+crlf                = false
+inline_table_expand = false


### PR DESCRIPTION
Some of this code was taken from [my public repo](https://github.com/Veetaha/snowpity/blob/master/.github/workflows/ci.yml), and some of the scripts were copied from my private repo (with the permission to do so gained as well).

## New checks to CI
- [`typos`](https://github.com/crate-ci/typos): this one has a static dictionary of known typos, and is famous for very low rate of false positives for that reason. It analyzes all text files in the repo and finds known typos in them. It's possible to autofix all typos with `typos -w`. 
- [`taplo`](https://github.com/tamasfe/taplo): formatter for TOML files just like `rustfmt`, it's possible to auto-format toml files with `taplo fmt` and configure the style as you wish in `taplo.toml`. 
- [`cargo-machete`](https://github.com/bnjbvr/cargo-machete) a heuristic check for unused dependencies. It parses the Rust files basically with a regex to figure out if the crate's name is ever mention in any paths and use statements in the sources. It is blazingly fast for that reason and nowhere near `cargo-udeps`, because it doesn't require compilation, `nightly` or anything like that. It's possible to ignore false-positive errors with the package metadata if you ever stumble into those.

## Scripts

All these checks are blazingly fast. I have them on my pre-commit hook in other repos, but I didn't add pre-commit hooks in this PR. 

I also added bash scripts for downloading the pre-compiled binaries for these dependencies, so it's possible to download them either locally or on CI with the same code. The downloading code is instrumented with good logging and exponential retries (in case github's CDN feels unwell) and good logging. This is how it looks on CI:

<img width="990" alt="image" src="https://github.com/rust-marker/marker/assets/36276403/ddb4cff2-4575-487e-a507-3bdede20ee3d">

The sections marked with the 👉 symbol are expandable, they [use github's log groups ](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines)

If you ever want to download precompiled binaries for any other tools in the future it's easy to copy some existing download script in `scripts/download` for the tool you want to add and adapt the URL and `download_and_decompress` parameters for the delivery method of that tool.

## Refactorings

Replaced the `actions-rs` github actions for installing the toolchain with [Dtolnay's actions](https://github.com/dtolnay/rust-toolchain), because the former are deprecated and unmaintained, while Dtolnay's action is the modern maintained alternative.

Added `--no-deps` to `cargo doc`, this should speed up this CI step, because I am sure you don't want to build the docs for your dependencies on CI.
