### PR TITLE
API: Remove `CallableData` from `FnItem` and use fields instead

### DIFF
--- a/marker_api/src/ast/common/callable.rs
+++ b/marker_api/src/ast/common/callable.rs
@@ -16,21 +16,17 @@ use super::{Abi, Constness, Safety, Span, SpanId, SymbolId, Syncness};
 /// This trait is only meant to be implemented inside this crate. The `Sealed`
 /// super trait prevents external implementations.
 pub trait CallableData<'ast>: Debug + Sealed {
-    /// Returns `true`, if this callable is `const`.
-    ///
-    /// Defaults to `false` if unspecified.
+    /// Returns the [`Constness`] of this callable
     fn constness(&self) -> Constness;
 
-    /// Returns `true`, if this callable is `async`.
+    /// Returns the [`Syncness`] of this callable.
     ///
-    /// Defaults to `false` if unspecified.
+    /// Use this to check if the function is async.
     fn syncness(&self) -> Syncness;
 
-    /// Returns `true`, if this callable is marked as `unsafe`.
+    /// Returns the [`Safety`] of this callable.
     ///
-    /// Defaults to `false` if unspecified. `extern` functions will
-    /// also return `false` by default, even if they require `unsafe`
-    /// by default.
+    /// Use this to check if the function is unsafe.
     fn safety(&self) -> Safety;
 
     /// Returns `true`, if this callable is marked as `extern`. Bare functions
@@ -41,7 +37,7 @@ pub trait CallableData<'ast>: Debug + Sealed {
     /// Defaults to `false` if unspecified.
     fn is_extern(&self) -> bool;
 
-    /// Returns the [`Abi`] of the callable, if specified.
+    /// Returns the [`Abi`] of the callable.
     fn abi(&self) -> Abi;
 
     /// Returns `true`, if this callable has a specified `self` argument. The
@@ -54,7 +50,7 @@ pub trait CallableData<'ast>: Debug + Sealed {
     /// [`has_self()`](`Self::has_self`) to determine if the first argument is `self`.
     fn params(&self) -> &[Parameter<'ast>];
 
-    /// Returns the return type, if specified.
+    /// The return type of this callable, if specified.
     fn return_ty(&self) -> Option<&SynTyKind<'ast>>;
 }
 

--- a/marker_api/src/ast/item/fn_item.rs
+++ b/marker_api/src/ast/item/fn_item.rs
@@ -1,21 +1,28 @@
 use crate::ast::generic::SynGenericParams;
-use crate::ast::{impl_callable_data_trait, BodyId, CommonCallableData};
-use crate::ffi::FfiOption;
+use crate::ast::pat::PatKind;
+use crate::ast::ty::SynTyKind;
+use crate::ast::{Abi, BodyId, Constness, Safety, SpanId, Syncness};
+use crate::context::with_cx;
+use crate::ffi::{FfiOption, FfiSlice};
+use crate::prelude::Span;
 
 use super::CommonItemData;
 
 /// A function item like:
 ///
 /// ```
-/// pub fn foo() {}
+/// // A function with a parameter and a body
+/// pub fn foo(bot: u32) {}
 ///
 /// # pub struct SomeItem;
 /// impl SomeItem {
+///     // A function as an associated item, with a body
 ///     pub fn bar(&self) {}
 /// }
 ///
 /// pub trait SomeTrait {
-///     fn baz(_: i32);
+///     // A function without a body
+///     pub fn baz(_: i32);
 /// }
 /// ```
 ///
@@ -25,7 +32,14 @@ use super::CommonItemData;
 pub struct FnItem<'ast> {
     data: CommonItemData<'ast>,
     generics: SynGenericParams<'ast>,
-    callable_data: CommonCallableData<'ast>,
+    constness: Constness,
+    syncness: Syncness,
+    safety: Safety,
+    is_extern: bool,
+    has_self: bool,
+    abi: Abi,
+    params: FfiSlice<'ast, FnParam<'ast>>,
+    return_ty: FfiOption<SynTyKind<'ast>>,
     body_id: FfiOption<BodyId>,
 }
 
@@ -36,26 +50,132 @@ impl<'ast> FnItem<'ast> {
         &self.generics
     }
 
+    /// The [`BodyId`] of this function. It can be `None` in trait definitions
+    /// or for extern functions.
     pub fn body_id(&self) -> Option<BodyId> {
         self.body_id.copy()
     }
-}
 
-impl_callable_data_trait!(FnItem<'ast>);
+    /// Returns the [`Constness`] of this callable
+    pub fn constness(&self) -> Constness {
+        self.constness
+    }
+
+    /// Returns the [`Syncness`] of this callable.
+    ///
+    /// Use this to check if the function is async.
+    pub fn syncness(&self) -> Syncness {
+        self.syncness
+    }
+
+    /// Returns the [`Safety`] of this callable.
+    ///
+    /// Use this to check if the function is unsafe.
+    pub fn safety(&self) -> Safety {
+        self.safety
+    }
+
+    /// Returns `true`, if this callable is marked as `extern`. Bare functions
+    /// only use the `extern` keyword to specify the ABI. These will currently
+    /// still return `false` even if the keyword is present. In those cases,
+    /// please refer to the [`abi()`](`Self::abi`) instead.
+    ///
+    /// Defaults to `false` if unspecified.
+    pub fn is_extern(&self) -> bool {
+        self.is_extern
+    }
+
+    /// Returns the [`Abi`] of the callable.
+    pub fn abi(&self) -> Abi {
+        self.abi
+    }
+
+    /// Returns `true`, if this callable has a specified `self` argument. The
+    /// type of `self` can be retrieved from the first element of
+    /// [`params()`](`Self::params`).
+    pub fn has_self(&self) -> bool {
+        self.has_self
+    }
+
+    /// Returns the parameters, that this callable accepts. The `self` argument
+    /// of methods, will be the first element of this slice. Use
+    /// [`has_self()`](`Self::has_self`) to determine if the first argument is `self`.
+    pub fn params(&self) -> &[FnParam<'ast>] {
+        self.params.get()
+    }
+
+    /// The return type of this callable, if specified.
+    pub fn return_ty(&self) -> Option<&SynTyKind<'ast>> {
+        self.return_ty.get()
+    }
+}
 
 #[cfg(feature = "driver-api")]
 impl<'ast> FnItem<'ast> {
     pub fn new(
         data: CommonItemData<'ast>,
         generics: SynGenericParams<'ast>,
-        callable_data: CommonCallableData<'ast>,
+        constness: Constness,
+        syncness: Syncness,
+        safety: Safety,
+        is_extern: bool,
+        has_self: bool,
+        abi: Abi,
+        params: &'ast [FnParam<'ast>],
+        return_ty: Option<SynTyKind<'ast>>,
         body: Option<BodyId>,
     ) -> Self {
         Self {
             data,
             generics,
-            callable_data,
+            constness,
+            syncness,
+            safety,
+            is_extern,
+            has_self,
+            abi,
+            params: params.into(),
+            return_ty: return_ty.into(),
             body_id: body.into(),
         }
+    }
+}
+
+/// A parameter for a [`FnItem`], like:
+///
+/// ```
+/// // A parameter with a name and type
+/// //                     vvvvvvvvv
+/// fn function_with_ident(name: u32) {}
+/// // A parameter with a pattern and type
+/// //                       vvvvvvvvvvvvvvvvvv
+/// fn function_with_pattern((a, b): (u32, i32)) {}
+/// ```
+#[repr(C)]
+#[derive(Debug)]
+pub struct FnParam<'ast> {
+    span: SpanId,
+    pat: PatKind<'ast>,
+    ty: SynTyKind<'ast>,
+}
+
+impl<'ast> FnParam<'ast> {
+    pub fn span(&self) -> &Span<'ast> {
+        with_cx(self, |cx| cx.span(self.span))
+    }
+
+    pub fn pat(&self) -> PatKind<'ast> {
+        self.pat
+    }
+
+    pub fn ty(&self) -> SynTyKind<'ast> {
+        self.ty
+    }
+}
+
+#[cfg(feature = "driver-api")]
+impl<'ast> FnParam<'ast> {
+    pub fn new(span: SpanId, pat: PatKind<'ast>, ty: SynTyKind<'ast>) -> Self {
+        Self { span, pat, ty }
     }
 }

--- a/marker_api/src/ast/item/fn_item.rs
+++ b/marker_api/src/ast/item/fn_item.rs
@@ -22,7 +22,7 @@ use super::CommonItemData;
 ///
 /// pub trait SomeTrait {
 ///     // A function without a body
-///     pub fn baz(_: i32);
+///     fn baz(_: i32);
 /// }
 /// ```
 ///
@@ -112,6 +112,7 @@ impl<'ast> FnItem<'ast> {
 
 #[cfg(feature = "driver-api")]
 impl<'ast> FnItem<'ast> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         data: CommonItemData<'ast>,
         generics: SynGenericParams<'ast>,

--- a/marker_rustc_driver/src/conversion/marker.rs
+++ b/marker_rustc_driver/src/conversion/marker.rs
@@ -219,3 +219,20 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
         ))
     }
 }
+
+macro_rules! with_body {
+    ($cx:expr, $id:expr, $with:expr) => {
+        // Body-Translation-Stack push
+        let prev_rustc_body_id = $cx.rustc_body.replace(Some($id));
+        let prev_rustc_ty_check = $cx.rustc_ty_check.take();
+        $cx.fill_rustc_ty_check();
+
+        // Operation
+        $with
+
+        // Body-Translation-Stack pop
+        $cx.rustc_body.replace(prev_rustc_body_id);
+        $cx.rustc_ty_check.replace(prev_rustc_ty_check);
+    };
+}
+use with_body;

--- a/marker_rustc_driver/src/conversion/marker/expr.rs
+++ b/marker_rustc_driver/src/conversion/marker/expr.rs
@@ -580,19 +580,12 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
 
     pub fn to_const_expr(&self, anon: hir::AnonConst) -> ConstExpr<'ast> {
         let body = self.rustc_cx.hir().body(anon.body);
+        let expr;
 
-        // The stack push and pop should be identical with the `item::to_body` function.
+        super::with_body!(self, body.id(), {
+            expr = ConstExpr::new(self.to_expr(body.value));
+        });
 
-        // Body-Translation-Stack push
-        let prev_rustc_body_id = self.rustc_body.replace(Some(body.id()));
-        let prev_rustc_ty_check = self.rustc_ty_check.take();
-        self.fill_rustc_ty_check();
-
-        let expr = ConstExpr::new(self.to_expr(body.value));
-
-        // Body-Translation-Stack pop
-        self.rustc_body.replace(prev_rustc_body_id);
-        self.rustc_ty_check.replace(prev_rustc_ty_check);
         expr
     }
 }

--- a/marker_uilints/src/lib.rs
+++ b/marker_uilints/src/lib.rs
@@ -103,9 +103,15 @@ impl LintPass for TestLintPass {
             item.ident().map(marker_api::ast::Ident::name),
             Some(name) if name.starts_with("PrintMe") || name.starts_with("PRINT_ME") || name.starts_with("print_me")
         ) {
-            cx.emit_lint(TEST_LINT, item.id(), "printing item", item.span(), |diag| {
-                diag.note(format!("{item:#?}"));
-            });
+            cx.emit_lint(
+                TEST_LINT,
+                item.id(),
+                "printing item",
+                item.ident().unwrap().span(),
+                |diag| {
+                    diag.note(format!("{item:#?}"));
+                },
+            );
         }
     }
 

--- a/marker_uilints/tests/ui/item/print_fn_item.rs
+++ b/marker_uilints/tests/ui/item/print_fn_item.rs
@@ -1,0 +1,17 @@
+pub fn print_me_simple() {}
+
+pub const unsafe fn print_me_special() {}
+
+pub fn print_me_params(_ident: u32, (_a, _b): (u32, i32)) -> String {
+    String::new()
+}
+
+pub trait SomethingCool {
+    fn print_me_trait_with_body(_ident: u8, (_a, _b): (u8, i8)) -> String {
+        String::new()
+    }
+
+    fn print_me_trait_no_body(_ident: u64, _pair: (u64, i64)) -> String;
+}
+
+fn main() {}

--- a/marker_uilints/tests/ui/item/print_fn_item.stderr
+++ b/marker_uilints/tests/ui/item/print_fn_item.stderr
@@ -1,0 +1,562 @@
+warning: printing item
+ --> $DIR/print_fn_item.rs:1:8
+  |
+1 | pub fn print_me_simple() {}
+  |        ^^^^^^^^^^^^^^^
+  |
+  = note: Fn(
+              FnItem {
+                  data: CommonItemData {
+                      id: ItemId(..),
+                      vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                      ident: Ident {
+                          name: "print_me_simple",
+                          span: Span {
+                              source: File(
+                                  "$DIR/print_fn_item.rs",
+                              ),
+                              start: 7,
+                              end: 22,
+                          },
+                      },
+                  },
+                  generics: SynGenericParams {
+                      params: [],
+                      clauses: [],
+                  },
+                  constness: NotConst,
+                  syncness: Sync,
+                  safety: Safe,
+                  is_extern: false,
+                  has_self: false,
+                  abi: Default,
+                  params: [],
+                  return_ty: None,
+                  body_id: Some(
+                      BodyId(..),
+                  ),
+              },
+          )
+  = note: `#[warn(marker::test_lint)]` on by default
+
+warning: printing item
+ --> $DIR/print_fn_item.rs:3:21
+  |
+3 | pub const unsafe fn print_me_special() {}
+  |                     ^^^^^^^^^^^^^^^^
+  |
+  = note: Fn(
+              FnItem {
+                  data: CommonItemData {
+                      id: ItemId(..),
+                      vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                      ident: Ident {
+                          name: "print_me_special",
+                          span: Span {
+                              source: File(
+                                  "$DIR/print_fn_item.rs",
+                              ),
+                              start: 49,
+                              end: 65,
+                          },
+                      },
+                  },
+                  generics: SynGenericParams {
+                      params: [],
+                      clauses: [],
+                  },
+                  constness: Const,
+                  syncness: Sync,
+                  safety: Unsafe,
+                  is_extern: false,
+                  has_self: false,
+                  abi: Default,
+                  params: [],
+                  return_ty: None,
+                  body_id: Some(
+                      BodyId(..),
+                  ),
+              },
+          )
+
+warning: printing item
+ --> $DIR/print_fn_item.rs:5:8
+  |
+5 | pub fn print_me_params(_ident: u32, (_a, _b): (u32, i32)) -> String {
+  |        ^^^^^^^^^^^^^^^
+  |
+  = note: Fn(
+              FnItem {
+                  data: CommonItemData {
+                      id: ItemId(..),
+                      vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                      ident: Ident {
+                          name: "print_me_params",
+                          span: Span {
+                              source: File(
+                                  "$DIR/print_fn_item.rs",
+                              ),
+                              start: 79,
+                              end: 94,
+                          },
+                      },
+                  },
+                  generics: SynGenericParams {
+                      params: [],
+                      clauses: [],
+                  },
+                  constness: NotConst,
+                  syncness: Sync,
+                  safety: Safe,
+                  is_extern: false,
+                  has_self: false,
+                  abi: Default,
+                  params: [
+                      FnParam {
+                          span: SpanId(..),
+                          pat: Ident(
+                              IdentPat {
+                                  data: CommonPatData {
+                                      _lifetime: PhantomData<&()>,
+                                      span: SpanId(..),
+                                  },
+                                  name: SymbolId(..),
+                                  var: VarId(..),
+                                  mutability: Unmut,
+                                  is_ref: false,
+                                  binding_pat: None,
+                              },
+                          ),
+                          ty: Num(
+                              SynNumTy {
+                                  data: CommonSynTyData {
+                                      _lifetime: PhantomData<&()>,
+                                      span: SpanId(..),
+                                  },
+                                  numeric_kind: U32,
+                              },
+                          ),
+                      },
+                      FnParam {
+                          span: SpanId(..),
+                          pat: Tuple(
+                              TuplePat {
+                                  data: CommonPatData {
+                                      _lifetime: PhantomData<&()>,
+                                      span: SpanId(..),
+                                  },
+                                  elements: [
+                                      Ident(
+                                          IdentPat {
+                                              data: CommonPatData {
+                                                  _lifetime: PhantomData<&()>,
+                                                  span: SpanId(..),
+                                              },
+                                              name: SymbolId(..),
+                                              var: VarId(..),
+                                              mutability: Unmut,
+                                              is_ref: false,
+                                              binding_pat: None,
+                                          },
+                                      ),
+                                      Ident(
+                                          IdentPat {
+                                              data: CommonPatData {
+                                                  _lifetime: PhantomData<&()>,
+                                                  span: SpanId(..),
+                                              },
+                                              name: SymbolId(..),
+                                              var: VarId(..),
+                                              mutability: Unmut,
+                                              is_ref: false,
+                                              binding_pat: None,
+                                          },
+                                      ),
+                                  ],
+                              },
+                          ),
+                          ty: Tuple(
+                              SynTupleTy {
+                                  data: CommonSynTyData {
+                                      _lifetime: PhantomData<&()>,
+                                      span: SpanId(..),
+                                  },
+                                  types: [
+                                      Num(
+                                          SynNumTy {
+                                              data: CommonSynTyData {
+                                                  _lifetime: PhantomData<&()>,
+                                                  span: SpanId(..),
+                                              },
+                                              numeric_kind: U32,
+                                          },
+                                      ),
+                                      Num(
+                                          SynNumTy {
+                                              data: CommonSynTyData {
+                                                  _lifetime: PhantomData<&()>,
+                                                  span: SpanId(..),
+                                              },
+                                              numeric_kind: I32,
+                                          },
+                                      ),
+                                  ],
+                              },
+                          ),
+                      },
+                  ],
+                  return_ty: Some(
+                      Path(
+                          SynPathTy {
+                              data: CommonSynTyData {
+                                  _lifetime: PhantomData<&()>,
+                                  span: SpanId(..),
+                              },
+                              path: AstQPath {
+                                  self_ty: None,
+                                  path_ty: None,
+                                  path: AstPath {
+                                      segments: [
+                                          AstPathSegment {
+                                              ident: Ident {
+                                                  name: "String",
+                                                  span: Span {
+                                                      source: File(
+                                                          "$DIR/print_fn_item.rs",
+                                                      ),
+                                                      start: 133,
+                                                      end: 139,
+                                                  },
+                                              },
+                                              generics: SynGenericArgs {
+                                                  args: [],
+                                              },
+                                          },
+                                      ],
+                                  },
+                                  target: Item(
+                                      ItemId(..),
+                                  ),
+                              },
+                          },
+                      ),
+                  ),
+                  body_id: Some(
+                      BodyId(..),
+                  ),
+              },
+          )
+
+warning: printing item
+  --> $DIR/print_fn_item.rs:10:8
+   |
+10 |     fn print_me_trait_with_body(_ident: u8, (_a, _b): (u8, i8)) -> String {
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: Fn(
+               FnItem {
+                   data: CommonItemData {
+                       id: ItemId(..),
+                       vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                       ident: Ident {
+                           name: "print_me_trait_with_body",
+                           span: Span {
+                               source: File(
+                                   "$DIR/print_fn_item.rs",
+                               ),
+                               start: 196,
+                               end: 220,
+                           },
+                       },
+                   },
+                   generics: SynGenericParams {
+                       params: [],
+                       clauses: [],
+                   },
+                   constness: NotConst,
+                   syncness: Sync,
+                   safety: Safe,
+                   is_extern: false,
+                   has_self: false,
+                   abi: Default,
+                   params: [
+                       FnParam {
+                           span: SpanId(..),
+                           pat: Ident(
+                               IdentPat {
+                                   data: CommonPatData {
+                                       _lifetime: PhantomData<&()>,
+                                       span: SpanId(..),
+                                   },
+                                   name: SymbolId(..),
+                                   var: VarId(..),
+                                   mutability: Unmut,
+                                   is_ref: false,
+                                   binding_pat: None,
+                               },
+                           ),
+                           ty: Num(
+                               SynNumTy {
+                                   data: CommonSynTyData {
+                                       _lifetime: PhantomData<&()>,
+                                       span: SpanId(..),
+                                   },
+                                   numeric_kind: U8,
+                               },
+                           ),
+                       },
+                       FnParam {
+                           span: SpanId(..),
+                           pat: Tuple(
+                               TuplePat {
+                                   data: CommonPatData {
+                                       _lifetime: PhantomData<&()>,
+                                       span: SpanId(..),
+                                   },
+                                   elements: [
+                                       Ident(
+                                           IdentPat {
+                                               data: CommonPatData {
+                                                   _lifetime: PhantomData<&()>,
+                                                   span: SpanId(..),
+                                               },
+                                               name: SymbolId(..),
+                                               var: VarId(..),
+                                               mutability: Unmut,
+                                               is_ref: false,
+                                               binding_pat: None,
+                                           },
+                                       ),
+                                       Ident(
+                                           IdentPat {
+                                               data: CommonPatData {
+                                                   _lifetime: PhantomData<&()>,
+                                                   span: SpanId(..),
+                                               },
+                                               name: SymbolId(..),
+                                               var: VarId(..),
+                                               mutability: Unmut,
+                                               is_ref: false,
+                                               binding_pat: None,
+                                           },
+                                       ),
+                                   ],
+                               },
+                           ),
+                           ty: Tuple(
+                               SynTupleTy {
+                                   data: CommonSynTyData {
+                                       _lifetime: PhantomData<&()>,
+                                       span: SpanId(..),
+                                   },
+                                   types: [
+                                       Num(
+                                           SynNumTy {
+                                               data: CommonSynTyData {
+                                                   _lifetime: PhantomData<&()>,
+                                                   span: SpanId(..),
+                                               },
+                                               numeric_kind: U8,
+                                           },
+                                       ),
+                                       Num(
+                                           SynNumTy {
+                                               data: CommonSynTyData {
+                                                   _lifetime: PhantomData<&()>,
+                                                   span: SpanId(..),
+                                               },
+                                               numeric_kind: I8,
+                                           },
+                                       ),
+                                   ],
+                               },
+                           ),
+                       },
+                   ],
+                   return_ty: Some(
+                       Path(
+                           SynPathTy {
+                               data: CommonSynTyData {
+                                   _lifetime: PhantomData<&()>,
+                                   span: SpanId(..),
+                               },
+                               path: AstQPath {
+                                   self_ty: None,
+                                   path_ty: None,
+                                   path: AstPath {
+                                       segments: [
+                                           AstPathSegment {
+                                               ident: Ident {
+                                                   name: "String",
+                                                   span: Span {
+                                                       source: File(
+                                                           "$DIR/print_fn_item.rs",
+                                                       ),
+                                                       start: 256,
+                                                       end: 262,
+                                                   },
+                                               },
+                                               generics: SynGenericArgs {
+                                                   args: [],
+                                               },
+                                           },
+                                       ],
+                                   },
+                                   target: Item(
+                                       ItemId(..),
+                                   ),
+                               },
+                           },
+                       ),
+                   ),
+                   body_id: Some(
+                       BodyId(..),
+                   ),
+               },
+           )
+
+warning: printing item
+  --> $DIR/print_fn_item.rs:14:8
+   |
+14 |     fn print_me_trait_no_body(_ident: u64, _pair: (u64, i64)) -> String;
+   |        ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: Fn(
+               FnItem {
+                   data: CommonItemData {
+                       id: ItemId(..),
+                       vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                       ident: Ident {
+                           name: "print_me_trait_no_body",
+                           span: Span {
+                               source: File(
+                                   "$DIR/print_fn_item.rs",
+                               ),
+                               start: 301,
+                               end: 323,
+                           },
+                       },
+                   },
+                   generics: SynGenericParams {
+                       params: [],
+                       clauses: [],
+                   },
+                   constness: NotConst,
+                   syncness: Sync,
+                   safety: Safe,
+                   is_extern: false,
+                   has_self: false,
+                   abi: Default,
+                   params: [
+                       FnParam {
+                           span: SpanId(..),
+                           pat: Ident(
+                               IdentPat {
+                                   data: CommonPatData {
+                                       _lifetime: PhantomData<&()>,
+                                       span: SpanId(..),
+                                   },
+                                   name: SymbolId(..),
+                                   var: VarId(..),
+                                   mutability: Unmut,
+                                   is_ref: false,
+                                   binding_pat: None,
+                               },
+                           ),
+                           ty: Num(
+                               SynNumTy {
+                                   data: CommonSynTyData {
+                                       _lifetime: PhantomData<&()>,
+                                       span: SpanId(..),
+                                   },
+                                   numeric_kind: U64,
+                               },
+                           ),
+                       },
+                       FnParam {
+                           span: SpanId(..),
+                           pat: Ident(
+                               IdentPat {
+                                   data: CommonPatData {
+                                       _lifetime: PhantomData<&()>,
+                                       span: SpanId(..),
+                                   },
+                                   name: SymbolId(..),
+                                   var: VarId(..),
+                                   mutability: Unmut,
+                                   is_ref: false,
+                                   binding_pat: None,
+                               },
+                           ),
+                           ty: Tuple(
+                               SynTupleTy {
+                                   data: CommonSynTyData {
+                                       _lifetime: PhantomData<&()>,
+                                       span: SpanId(..),
+                                   },
+                                   types: [
+                                       Num(
+                                           SynNumTy {
+                                               data: CommonSynTyData {
+                                                   _lifetime: PhantomData<&()>,
+                                                   span: SpanId(..),
+                                               },
+                                               numeric_kind: U64,
+                                           },
+                                       ),
+                                       Num(
+                                           SynNumTy {
+                                               data: CommonSynTyData {
+                                                   _lifetime: PhantomData<&()>,
+                                                   span: SpanId(..),
+                                               },
+                                               numeric_kind: I64,
+                                           },
+                                       ),
+                                   ],
+                               },
+                           ),
+                       },
+                   ],
+                   return_ty: Some(
+                       Path(
+                           SynPathTy {
+                               data: CommonSynTyData {
+                                   _lifetime: PhantomData<&()>,
+                                   span: SpanId(..),
+                               },
+                               path: AstQPath {
+                                   self_ty: None,
+                                   path_ty: None,
+                                   path: AstPath {
+                                       segments: [
+                                           AstPathSegment {
+                                               ident: Ident {
+                                                   name: "String",
+                                                   span: Span {
+                                                       source: File(
+                                                           "$DIR/print_fn_item.rs",
+                                                       ),
+                                                       start: 359,
+                                                       end: 365,
+                                                   },
+                                               },
+                                               generics: SynGenericArgs {
+                                                   args: [],
+                                               },
+                                           },
+                                       ],
+                                   },
+                                   target: Item(
+                                       ItemId(..),
+                                   ),
+                               },
+                           },
+                       ),
+                   ),
+                   body_id: None,
+               },
+           )
+
+warning: 5 warnings emitted
+

--- a/marker_uilints/tests/ui/print_adt_item.stderr
+++ b/marker_uilints/tests/ui/print_adt_item.stderr
@@ -1,12 +1,8 @@
 warning: printing item
- --> $DIR/print_adt_item.rs:1:1
+ --> $DIR/print_adt_item.rs:1:10
   |
-1 | / pub enum PrintMeEnum {
-2 | |     H = -1,
-3 | |     E = 0,
-4 | |     R = 17,
-5 | | }
-  | |_^
+1 | pub enum PrintMeEnum {
+  |          ^^^^^^^^^^^
   |
   = note: Enum(
               EnumItem {

--- a/marker_uilints/tests/ui/print_const_generics.stderr
+++ b/marker_uilints/tests/ui/print_const_generics.stderr
@@ -1,10 +1,8 @@
 warning: printing item
- --> $DIR/print_const_generics.rs:2:1
+ --> $DIR/print_const_generics.rs:2:8
   |
-2 | / struct PrintMeConstGenerics<const N: usize> {
-3 | |     data: [f32; N],
-4 | | }
-  | |_^
+2 | struct PrintMeConstGenerics<const N: usize> {
+  |        ^^^^^^^^^^^^^^^^^^^^
   |
   = note: Struct(
               StructItem {
@@ -115,12 +113,10 @@ warning: printing item
   = note: `#[warn(marker::test_lint)]` on by default
 
 warning: printing item
- --> $DIR/print_const_generics.rs:6:1
+ --> $DIR/print_const_generics.rs:6:4
   |
-6 | / fn print_me() -> PrintMeConstGenerics<3> {
-7 | |     todo!()
-8 | | }
-  | |_^
+6 | fn print_me() -> PrintMeConstGenerics<3> {
+  |    ^^^^^^^^
   |
   = note: Fn(
               FnItem {
@@ -142,70 +138,68 @@ warning: printing item
                       params: [],
                       clauses: [],
                   },
-                  callable_data: CommonCallableData {
-                      constness: NotConst,
-                      syncness: Sync,
-                      safety: Safe,
-                      is_extern: false,
-                      abi: Default,
-                      has_self: false,
-                      params: [],
-                      return_ty: Some(
-                          Path(
-                              SynPathTy {
-                                  data: CommonSynTyData {
-                                      _lifetime: PhantomData<&()>,
-                                      span: SpanId(..),
-                                  },
-                                  path: AstQPath {
-                                      self_ty: None,
-                                      path_ty: None,
-                                      path: AstPath {
-                                          segments: [
-                                              AstPathSegment {
-                                                  ident: Ident {
-                                                      name: "PrintMeConstGenerics",
-                                                      span: Span {
-                                                          source: File(
-                                                              "$DIR/print_const_generics.rs",
-                                                          ),
-                                                          start: 87,
-                                                          end: 107,
-                                                      },
-                                                  },
-                                                  generics: SynGenericArgs {
-                                                      args: [
-                                                          Const(
-                                                              SynConstArg {
-                                                                  span: SpanId(..),
-                                                                  expr: ConstExpr {
-                                                                      expr: IntLit(
-                                                                          IntLitExpr {
-                                                                              data: CommonExprData {
-                                                                                  _lifetime: PhantomData<&()>,
-                                                                                  id: ExprId(..),
-                                                                                  span: SpanId(..),
-                                                                              },
-                                                                              value: 3,
-                                                                              suffix: None,
-                                                                          },
-                                                                      ),
-                                                                  },
-                                                              },
-                                                          ),
-                                                      ],
+                  constness: NotConst,
+                  syncness: Sync,
+                  safety: Safe,
+                  is_extern: false,
+                  has_self: false,
+                  abi: Default,
+                  params: [],
+                  return_ty: Some(
+                      Path(
+                          SynPathTy {
+                              data: CommonSynTyData {
+                                  _lifetime: PhantomData<&()>,
+                                  span: SpanId(..),
+                              },
+                              path: AstQPath {
+                                  self_ty: None,
+                                  path_ty: None,
+                                  path: AstPath {
+                                      segments: [
+                                          AstPathSegment {
+                                              ident: Ident {
+                                                  name: "PrintMeConstGenerics",
+                                                  span: Span {
+                                                      source: File(
+                                                          "$DIR/print_const_generics.rs",
+                                                      ),
+                                                      start: 87,
+                                                      end: 107,
                                                   },
                                               },
-                                          ],
-                                      },
-                                      target: Item(
-                                          ItemId(..),
-                                      ),
+                                              generics: SynGenericArgs {
+                                                  args: [
+                                                      Const(
+                                                          SynConstArg {
+                                                              span: SpanId(..),
+                                                              expr: ConstExpr {
+                                                                  expr: IntLit(
+                                                                      IntLitExpr {
+                                                                          data: CommonExprData {
+                                                                              _lifetime: PhantomData<&()>,
+                                                                              id: ExprId(..),
+                                                                              span: SpanId(..),
+                                                                          },
+                                                                          value: 3,
+                                                                          suffix: None,
+                                                                      },
+                                                                  ),
+                                                              },
+                                                          },
+                                                      ),
+                                                  ],
+                                              },
+                                          },
+                                      ],
                                   },
+                                  target: Item(
+                                      ItemId(..),
+                                  ),
                               },
-                          ),
+                          },
                       ),
-                  },
+                  ),
                   body_id: Some(
                       BodyId(..),
                   ),

--- a/marker_uilints/tests/uitest.rs
+++ b/marker_uilints/tests/uitest.rs
@@ -12,6 +12,8 @@ fn main() -> color_eyre::Result<()> {
     let filters = [
         // Normalization for windows...
         (r"ui//", "ui/"),
+        (r"item//", "item/"),
+        (r"expr//", "expr/"),
     ];
     for (pat, repl) in filters {
         config.stderr_filter(pat, repl);


### PR DESCRIPTION


cc: rust-marker/marker#181