### PR TITLE
API: Always request `Span`s by id (Remove `SpanOwner` enum)

### DIFF
--- a/marker_adapter/src/context.rs
+++ b/marker_adapter/src/context.rs
@@ -7,7 +7,7 @@ use marker_api::{
     ast::{
         item::{Body, ItemKind},
         ty::SemTyKind,
-        BodyId, ExprId, ItemId, Span, SpanOwner, SymbolId, TyDefId,
+        BodyId, ExprId, ItemId, Span, SpanId, SymbolId, TyDefId,
     },
     context::DriverCallbacks,
     diagnostic::{Diagnostic, EmissionNode},
@@ -88,9 +88,9 @@ extern "C" fn expr_ty<'ast>(data: &(), expr: ExprId) -> SemTyKind<'ast> {
     wrapper.driver_cx.expr_ty(expr)
 }
 
-extern "C" fn span<'ast>(data: &(), owner: &SpanOwner) -> &'ast Span<'ast> {
+extern "C" fn span<'ast>(data: &(), span_id: SpanId) -> &'ast Span<'ast> {
     let wrapper = unsafe { &*(data as *const ()).cast::<DriverContextWrapper>() };
-    wrapper.driver_cx.span(owner)
+    wrapper.driver_cx.span(span_id)
 }
 
 extern "C" fn span_snippet<'ast>(data: &(), span: &Span<'ast>) -> ffi::FfiOption<ffi::FfiStr<'ast>> {
@@ -118,7 +118,7 @@ pub trait DriverContext<'ast> {
     fn resolve_ty_ids(&'ast self, path: &str) -> &'ast [TyDefId];
 
     fn expr_ty(&'ast self, expr: ExprId) -> SemTyKind<'ast>;
-    fn span(&'ast self, owner: &SpanOwner) -> &'ast Span<'ast>;
+    fn span(&'ast self, owner: SpanId) -> &'ast Span<'ast>;
     fn span_snippet(&'ast self, span: &Span<'ast>) -> Option<&'ast str>;
     fn symbol_str(&'ast self, api_id: SymbolId) -> &'ast str;
     fn resolve_method_target(&'ast self, id: ExprId) -> ItemId;

--- a/marker_api/src/ast/common/span.rs
+++ b/marker_api/src/ast/common/span.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use crate::{context::with_cx, diagnostic::Applicability, ffi};
 
-use super::{ItemId, SpanId, SpanSrcId, SymbolId};
+use super::{SpanId, SpanSrcId, SymbolId};
 
 // FIXME(xFrednet): This enum is "limited" to say it lightly, it should contain
 // the more information about macros and their expansion etc. This covers the
@@ -129,33 +129,6 @@ impl<'ast> Span<'ast> {
 
     pub fn source(&self) -> &'ast SpanSource<'ast> {
         self.source
-    }
-}
-
-/// **Unstable**
-///
-/// This enum is used to request a [`Span`] instance from the driver context.
-/// it is only an internal type to avoid mapping every [`Span`], since they are
-/// most often not needed.
-#[repr(C)]
-#[allow(clippy::exhaustive_enums)]
-#[cfg_attr(feature = "driver-api", visibility::make(pub))]
-pub(crate) enum SpanOwner {
-    /// This requests the [`Span`] belonging to the [`ItemId`].
-    Item(ItemId),
-    /// This requests the [`Span`] belonging to a driver generated [`SpanId`]
-    SpecificSpan(SpanId),
-}
-
-impl From<ItemId> for SpanOwner {
-    fn from(id: ItemId) -> Self {
-        Self::Item(id)
-    }
-}
-
-impl From<SpanId> for SpanOwner {
-    fn from(id: SpanId) -> Self {
-        Self::SpecificSpan(id)
     }
 }
 

--- a/marker_api/src/ast/item.rs
+++ b/marker_api/src/ast/item.rs
@@ -4,7 +4,7 @@ use crate::private::Sealed;
 use crate::CtorBlocker;
 
 use super::expr::ExprKind;
-use super::{Ident, ItemId, Span};
+use super::{Ident, ItemId, Span, SpanId};
 
 // Item implementations
 mod extern_crate_item;
@@ -181,6 +181,7 @@ use impl_item_type_fn;
 #[cfg_attr(feature = "driver-api", visibility::make(pub))]
 struct CommonItemData<'ast> {
     id: ItemId,
+    span: SpanId,
     vis: Visibility<'ast>,
     ident: Ident<'ast>,
 }
@@ -193,7 +194,7 @@ macro_rules! impl_item_data {
             }
 
             fn span(&self) -> &crate::ast::Span<'ast> {
-                $crate::context::with_cx(self, |cx| cx.span(self.data.id))
+                $crate::context::with_cx(self, |cx| cx.span(self.data.span))
             }
 
             fn visibility(&self) -> &crate::ast::item::Visibility<'ast> {
@@ -225,9 +226,10 @@ use impl_item_data;
 
 #[cfg(feature = "driver-api")]
 impl<'ast> CommonItemData<'ast> {
-    pub fn new(id: ItemId, ident: Ident<'ast>) -> Self {
+    pub fn new(id: ItemId, span: SpanId, ident: Ident<'ast>) -> Self {
         Self {
             id,
+            span,
             vis: Visibility::new(id),
             ident,
         }
@@ -304,19 +306,19 @@ mod test {
     fn test_item_struct_size() {
         // These sizes are allowed to change, this is just a check to have a
         // general overview and to prevent accidental changes
-        assert_eq!(48, size_of::<ModItem<'_>>(), "ModItem");
-        assert_eq!(40, size_of::<ExternCrateItem<'_>>(), "ExternCrateItem");
-        assert_eq!(56, size_of::<UseItem<'_>>(), "UseItem");
-        assert_eq!(72, size_of::<StaticItem<'_>>(), "StaticItem");
-        assert_eq!(64, size_of::<ConstItem<'_>>(), "ConstItem");
-        assert_eq!(136, size_of::<FnItem<'_>>(), "FnItem");
-        assert_eq!(104, size_of::<TyAliasItem<'_>>(), "TyAliasItem");
-        assert_eq!(88, size_of::<StructItem<'_>>(), "StructItem");
-        assert_eq!(80, size_of::<EnumItem<'_>>(), "EnumItem");
-        assert_eq!(80, size_of::<UnionItem<'_>>(), "UnionItem");
-        assert_eq!(104, size_of::<TraitItem<'_>>(), "TraitItem");
-        assert_eq!(136, size_of::<ImplItem<'_>>(), "ImplItem");
-        assert_eq!(56, size_of::<ExternBlockItem<'_>>(), "ExternBlockItem");
-        assert_eq!(40, size_of::<UnstableItem<'_>>(), "UnstableItem");
+        assert_eq!(56, size_of::<ModItem<'_>>(), "ModItem");
+        assert_eq!(48, size_of::<ExternCrateItem<'_>>(), "ExternCrateItem");
+        assert_eq!(64, size_of::<UseItem<'_>>(), "UseItem");
+        assert_eq!(80, size_of::<StaticItem<'_>>(), "StaticItem");
+        assert_eq!(72, size_of::<ConstItem<'_>>(), "ConstItem");
+        assert_eq!(144, size_of::<FnItem<'_>>(), "FnItem");
+        assert_eq!(112, size_of::<TyAliasItem<'_>>(), "TyAliasItem");
+        assert_eq!(96, size_of::<StructItem<'_>>(), "StructItem");
+        assert_eq!(88, size_of::<EnumItem<'_>>(), "EnumItem");
+        assert_eq!(88, size_of::<UnionItem<'_>>(), "UnionItem");
+        assert_eq!(112, size_of::<TraitItem<'_>>(), "TraitItem");
+        assert_eq!(144, size_of::<ImplItem<'_>>(), "ImplItem");
+        assert_eq!(64, size_of::<ExternBlockItem<'_>>(), "ExternBlockItem");
+        assert_eq!(48, size_of::<UnstableItem<'_>>(), "UnstableItem");
     }
 }

--- a/marker_api/src/context.rs
+++ b/marker_api/src/context.rs
@@ -8,7 +8,7 @@ use crate::{
     ast::{
         item::{Body, ItemKind},
         ty::SemTyKind,
-        BodyId, ExprId, ItemId, Span, SpanOwner, SymbolId, TyDefId,
+        BodyId, ExprId, ItemId, Span, SpanId, SymbolId, TyDefId,
     },
     diagnostic::{Diagnostic, DiagnosticBuilder, EmissionNode},
     ffi,
@@ -191,8 +191,8 @@ impl<'ast> AstContext<'ast> {
         self.driver.call_span_snippet(span)
     }
 
-    pub(crate) fn span<T: Into<SpanOwner>>(&self, span_owner: T) -> &'ast Span<'ast> {
-        self.driver.call_span(&span_owner.into())
+    pub(crate) fn span(&self, span_id: SpanId) -> &'ast Span<'ast> {
+        self.driver.call_span(span_id)
     }
 
     pub(crate) fn symbol_str(&self, sym: SymbolId) -> &'ast str {
@@ -242,7 +242,7 @@ struct DriverCallbacks<'ast> {
 
     // Internal utility
     pub expr_ty: extern "C" fn(&'ast (), ExprId) -> SemTyKind<'ast>,
-    pub span: extern "C" fn(&'ast (), &SpanOwner) -> &'ast Span<'ast>,
+    pub span: extern "C" fn(&'ast (), SpanId) -> &'ast Span<'ast>,
     pub span_snippet: extern "C" fn(&'ast (), &Span<'ast>) -> ffi::FfiOption<ffi::FfiStr<'ast>>,
     pub symbol_str: extern "C" fn(&'ast (), SymbolId) -> ffi::FfiStr<'ast>,
     pub resolve_method_target: extern "C" fn(&'ast (), ExprId) -> ItemId,
@@ -267,8 +267,8 @@ impl<'ast> DriverCallbacks<'ast> {
     fn call_expr_ty(&self, expr: ExprId) -> SemTyKind<'ast> {
         (self.expr_ty)(self.driver_context, expr)
     }
-    fn call_span(&self, span_owner: &SpanOwner) -> &'ast Span<'ast> {
-        (self.span)(self.driver_context, span_owner)
+    fn call_span(&self, span_id: SpanId) -> &'ast Span<'ast> {
+        (self.span)(self.driver_context, span_id)
     }
     fn call_span_snippet(&self, span: &Span<'ast>) -> Option<String> {
         let result: Option<ffi::FfiStr> = (self.span_snippet)(self.driver_context, span).into();

--- a/marker_rustc_driver/src/context.rs
+++ b/marker_rustc_driver/src/context.rs
@@ -4,7 +4,7 @@ use marker_adapter::context::{DriverContext, DriverContextWrapper};
 use marker_api::{
     ast::{
         item::{Body, ItemKind},
-        BodyId, ExprId, ItemId, Span, SpanOwner, SymbolId, TyDefId,
+        BodyId, ExprId, ItemId, Span, SpanId, SymbolId, TyDefId,
     },
     context::AstContext,
     diagnostic::{Diagnostic, EmissionNode},
@@ -214,11 +214,8 @@ impl<'ast, 'tcx: 'ast> DriverContext<'ast> for RustcContext<'ast, 'tcx> {
         self.marker_converter.expr_ty(hir_id)
     }
 
-    fn span(&'ast self, owner: &SpanOwner) -> &'ast Span<'ast> {
-        let rustc_span = match owner {
-            SpanOwner::Item(item) => self.rustc_cx.hir().item(self.rustc_converter.to_item_id(*item)).span,
-            SpanOwner::SpecificSpan(span_id) => self.rustc_converter.to_span_from_id(*span_id),
-        };
+    fn span(&'ast self, span_id: SpanId) -> &'ast Span<'ast> {
+        let rustc_span = self.rustc_converter.to_span_from_id(span_id);
         self.storage.alloc(self.marker_converter.to_span(rustc_span))
     }
 

--- a/marker_rustc_driver/src/conversion/marker/item.rs
+++ b/marker_rustc_driver/src/conversion/marker/item.rs
@@ -45,7 +45,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
         }
 
         let ident = self.to_ident(rustc_item.ident);
-        let data = CommonItemData::new(id, ident);
+        let data = CommonItemData::new(id, self.to_span_id(rustc_item.span), ident);
         let item = match &rustc_item.kind {
             hir::ItemKind::ExternCrate(original_name) => ItemKind::ExternCrate(self.alloc({
                 ExternCrateItem::new(data, self.to_symbol_id(original_name.unwrap_or(rustc_item.ident.name)))
@@ -264,7 +264,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
         }
 
         let foreign_item = self.rustc_cx.hir().foreign_item(rustc_item.id);
-        let data = CommonItemData::new(id, self.to_ident(rustc_item.ident));
+        let data = CommonItemData::new(id, self.to_span_id(rustc_item.span), self.to_ident(rustc_item.ident));
         let item = match &foreign_item.kind {
             hir::ForeignItemKind::Fn(decl, idents, generics) => {
                 let return_ty = if let hir::FnRetTy::Return(rust_ty) = decl.output {
@@ -324,7 +324,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
         }
 
         let trait_item = self.rustc_cx.hir().trait_item(rustc_item.id);
-        let data = CommonItemData::new(id, self.to_ident(rustc_item.ident));
+        let data = CommonItemData::new(id, self.to_span_id(rustc_item.span), self.to_ident(rustc_item.ident));
 
         let item = match &trait_item.kind {
             hir::TraitItemKind::Const(ty, body_id) => AssocItemKind::Const(
@@ -373,7 +373,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
         }
 
         let impl_item = self.rustc_cx.hir().impl_item(rustc_item.id);
-        let data = CommonItemData::new(id, self.to_ident(rustc_item.ident));
+        let data = CommonItemData::new(id, self.to_span_id(rustc_item.span), self.to_ident(rustc_item.ident));
 
         let item = match &impl_item.kind {
             hir::ImplItemKind::Const(ty, body_id) => AssocItemKind::Const(

--- a/marker_uilints/tests/ui/item/print_fn_item.stderr
+++ b/marker_uilints/tests/ui/item/print_fn_item.stderr
@@ -8,6 +8,7 @@ warning: printing item
               FnItem {
                   data: CommonItemData {
                       id: ItemId(..),
+                      span: SpanId(..),
                       vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
                       ident: Ident {
                           name: "print_me_simple",
@@ -49,6 +50,7 @@ warning: printing item
               FnItem {
                   data: CommonItemData {
                       id: ItemId(..),
+                      span: SpanId(..),
                       vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
                       ident: Ident {
                           name: "print_me_special",
@@ -89,6 +91,7 @@ warning: printing item
               FnItem {
                   data: CommonItemData {
                       id: ItemId(..),
+                      span: SpanId(..),
                       vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
                       ident: Ident {
                           name: "print_me_params",
@@ -257,6 +260,7 @@ warning: printing item
                FnItem {
                    data: CommonItemData {
                        id: ItemId(..),
+                       span: SpanId(..),
                        vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
                        ident: Ident {
                            name: "print_me_trait_with_body",
@@ -425,6 +429,7 @@ warning: printing item
                FnItem {
                    data: CommonItemData {
                        id: ItemId(..),
+                       span: SpanId(..),
                        vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
                        ident: Ident {
                            name: "print_me_trait_no_body",

--- a/marker_uilints/tests/ui/print_adt_item.stderr
+++ b/marker_uilints/tests/ui/print_adt_item.stderr
@@ -8,6 +8,7 @@ warning: printing item
               EnumItem {
                   data: CommonItemData {
                       id: ItemId(..),
+                      span: SpanId(..),
                       vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
                       ident: Ident {
                           name: "PrintMeEnum",

--- a/marker_uilints/tests/ui/print_const_generics.stderr
+++ b/marker_uilints/tests/ui/print_const_generics.stderr
@@ -8,6 +8,7 @@ warning: printing item
               StructItem {
                   data: CommonItemData {
                       id: ItemId(..),
+                      span: SpanId(..),
                       vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
                       ident: Ident {
                           name: "PrintMeConstGenerics",
@@ -122,6 +123,7 @@ warning: printing item
               FnItem {
                   data: CommonItemData {
                       id: ItemId(..),
+                      span: SpanId(..),
                       vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
                       ident: Ident {
                           name: "print_me",


### PR DESCRIPTION
This fixes a panic for trait items without a body.

Closes: rust-marker/marker#192