### PR TITLE
cargo: Pass the toolchain to all instances of MetadataCommand

### DIFF
--- a/cargo-marker/src/backend/lints/fetch.rs
+++ b/cargo-marker/src/backend/lints/fetch.rs
@@ -17,7 +17,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use cargo_metadata::{Metadata, MetadataCommand};
+use cargo_metadata::Metadata;
 
 use crate::{backend::Config, config::LintDependencyEntry, ExitStatus};
 
@@ -141,10 +141,7 @@ fn call_cargo_fetch(manifest: &Path, config: &Config) -> Result<(), ExitStatus> 
 }
 
 fn call_cargo_metadata(manifest: &PathBuf, config: &Config) -> Result<Metadata, ExitStatus> {
-    let res = MetadataCommand::new()
-        .cargo_path(&config.toolchain.cargo_path)
-        .manifest_path(manifest)
-        .exec();
+    let res = config.toolchain.cargo_metadata_command().manifest_path(manifest).exec();
 
     // FIXME(xFrednet): Handle errors properly.
     res.map_err(|_| ExitStatus::LintCrateFetchFailed)

--- a/cargo-marker/src/backend/toolchain.rs
+++ b/cargo-marker/src/backend/toolchain.rs
@@ -78,10 +78,19 @@ impl Toolchain {
         cmd
     }
 
+    pub fn cargo_metadata_command(&self) -> MetadataCommand {
+        let mut command = MetadataCommand::new();
+        command.cargo_path(&self.cargo_path);
+        if let Some(toolchain) = self.toolchain.as_ref() {
+            command.env("RUSTUP_TOOLCHAIN", toolchain);
+        }
+        command
+    }
+
     pub fn find_target_dir(&self) -> Result<PathBuf, ExitStatus> {
         // FIXME(xFrednet): Handle errors properly.
-        let metadata = MetadataCommand::new()
-            .cargo_path(&self.cargo_path)
+        let metadata = self
+            .cargo_metadata_command()
             .exec()
             .map_err(|_| ExitStatus::NoTargetDir)?;
 


### PR DESCRIPTION
Closes #188

Tested using rust-toolchain 1.65.0