### PR TITLE
Rustc: Avoid caching by tracking lint crates and env vars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,7 +443,6 @@ checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 name = "marker_adapter"
 version = "0.1.1"
 dependencies = [
- "cfg-if",
  "libloading",
  "marker_api",
  "marker_utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,7 @@ dependencies = [
  "libloading",
  "marker_api",
  "marker_utils",
+ "thiserror",
 ]
 
 [[package]]
@@ -764,18 +765,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/marker_adapter/Cargo.toml
+++ b/marker_adapter/Cargo.toml
@@ -14,6 +14,5 @@ repository  = "https://github.com/rust-marker/marker"
 marker_api   = { path = "../marker_api", version = "0.1.1", features = ["driver-api"] }
 marker_utils = { path = "../marker_utils", version = "0.1.1" }
 
-cfg-if     = "1.0.0"
 libloading = "0.8.0"
 thiserror  = "1.0.44"

--- a/marker_adapter/Cargo.toml
+++ b/marker_adapter/Cargo.toml
@@ -16,3 +16,4 @@ marker_utils = { path = "../marker_utils", version = "0.1.1" }
 
 cfg-if     = "1.0.0"
 libloading = "0.8.0"
+thiserror  = "1.0.44"

--- a/marker_rustc_driver/src/lint_pass.rs
+++ b/marker_rustc_driver/src/lint_pass.rs
@@ -25,9 +25,12 @@ pub struct RustcLintPass;
 
 impl RustcLintPass {
     pub fn init_adapter(lint_crates: &[LintCrateInfo]) -> Result<(), AdapterError> {
-        let adapter = Adapter::new(lint_crates)?;
-        ADAPTER.with(move |cell| cell.set(adapter)).unwrap();
-        Ok(())
+        ADAPTER.with(move |cell| {
+            if cell.get().is_none() {
+                cell.set(Adapter::new(lint_crates)?).unwrap();
+            };
+            Ok(())
+        })
     }
 
     pub fn marker_lints() -> Vec<&'static Lint> {

--- a/marker_rustc_driver/src/lint_pass.rs
+++ b/marker_rustc_driver/src/lint_pass.rs
@@ -1,6 +1,6 @@
-use std::cell::LazyCell;
+use std::cell::OnceCell;
 
-use marker_adapter::Adapter;
+use marker_adapter::{Adapter, LintCrateInfo};
 use marker_api::lint::Lint;
 
 use crate::context::{storage::Storage, RustcContext};
@@ -18,17 +18,22 @@ thread_local! {
     /// Storing the [`Adapter`] in a `thread_local` is safe, since rustc is currently
     /// only single threaded. This cell will therefore only be constructed once, and
     /// this driver will always use the same adapter.
-    static ADAPTER: LazyCell<Adapter> = LazyCell::new(|| {
-        Adapter::new_from_env()
-    });
+    static ADAPTER: OnceCell<Adapter> = OnceCell::new();
 }
 
 pub struct RustcLintPass;
 
 impl RustcLintPass {
+    pub fn init_adapter(lint_crates: &[LintCrateInfo]) {
+        let adapter = Adapter::new(lint_crates);
+        ADAPTER.with(move |cell| cell.set(adapter)).unwrap();
+    }
+
     pub fn marker_lints() -> Vec<&'static Lint> {
         ADAPTER.with(|adapter| {
             adapter
+                .get()
+                .unwrap()
                 .lint_pass_infos()
                 .iter()
                 .flat_map(marker_api::LintPassInfo::lints)
@@ -43,7 +48,7 @@ rustc_lint_defs::impl_lint_pass!(RustcLintPass => []);
 impl<'tcx> rustc_lint::LateLintPass<'tcx> for RustcLintPass {
     fn check_crate(&mut self, rustc_cx: &rustc_lint::LateContext<'tcx>) {
         ADAPTER.with(|adapter| {
-            process_crate(rustc_cx, adapter);
+            process_crate(rustc_cx, adapter.get().unwrap());
         });
     }
 }

--- a/marker_rustc_driver/src/lint_pass.rs
+++ b/marker_rustc_driver/src/lint_pass.rs
@@ -26,9 +26,7 @@ pub struct RustcLintPass;
 impl RustcLintPass {
     pub fn init_adapter(lint_crates: &[LintCrateInfo]) -> Result<(), AdapterError> {
         ADAPTER.with(move |cell| {
-            if cell.get().is_none() {
-                cell.set(Adapter::new(lint_crates)?).unwrap();
-            };
+            cell.get_or_try_init(|| Adapter::new(lint_crates))?;
             Ok(())
         })
     }

--- a/marker_rustc_driver/src/lint_pass.rs
+++ b/marker_rustc_driver/src/lint_pass.rs
@@ -1,6 +1,6 @@
 use std::cell::OnceCell;
 
-use marker_adapter::{Adapter, LintCrateInfo};
+use marker_adapter::{Adapter, AdapterError, LintCrateInfo};
 use marker_api::lint::Lint;
 
 use crate::context::{storage::Storage, RustcContext};
@@ -24,9 +24,10 @@ thread_local! {
 pub struct RustcLintPass;
 
 impl RustcLintPass {
-    pub fn init_adapter(lint_crates: &[LintCrateInfo]) {
-        let adapter = Adapter::new(lint_crates);
+    pub fn init_adapter(lint_crates: &[LintCrateInfo]) -> Result<(), AdapterError> {
+        let adapter = Adapter::new(lint_crates)?;
         ADAPTER.with(move |cell| cell.set(adapter)).unwrap();
+        Ok(())
     }
 
     pub fn marker_lints() -> Vec<&'static Lint> {

--- a/marker_rustc_driver/src/main.rs
+++ b/marker_rustc_driver/src/main.rs
@@ -38,6 +38,7 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::process::{exit, Command};
 
+use marker_adapter::{LintCrateInfo, LINT_CRATES_ENV};
 use rustc_session::config::ErrorOutputType;
 use rustc_session::EarlyErrorHandler;
 
@@ -45,18 +46,38 @@ use crate::conversion::rustc::RustcConverter;
 
 const RUSTC_TOOLCHAIN_VERSION: &str = "nightly-2023-07-13";
 
-struct DefaultCallbacks;
-impl rustc_driver::Callbacks for DefaultCallbacks {}
+struct DefaultCallbacks {
+    env_vars: Vec<(&'static str, String)>,
+}
+impl rustc_driver::Callbacks for DefaultCallbacks {
+    fn config(&mut self, config: &mut rustc_interface::Config) {
+        let env_vars = std::mem::take(&mut self.env_vars);
+        config.parse_sess_created = Some(Box::new(move |sess| {
+            register_tracked_env(sess, &env_vars);
+        }));
+    }
+}
 
-struct MarkerCallback;
+struct MarkerCallback {
+    env_vars: Vec<(&'static str, String)>,
+    lint_crates: Vec<LintCrateInfo>,
+}
 
 impl rustc_driver::Callbacks for MarkerCallback {
     fn config(&mut self, config: &mut rustc_interface::Config) {
+        lint_pass::RustcLintPass::init_adapter(&self.lint_crates);
+
+        let env_vars = std::mem::take(&mut self.env_vars);
+        let lint_crates = std::mem::take(&mut self.lint_crates);
+        config.parse_sess_created = Some(Box::new(move |sess| {
+            register_tracked_env(sess, &env_vars);
+            register_tracked_files(sess, &lint_crates);
+        }));
+
         // Clippy explicitly calls any previous `register_lints` functions. This
         // will not be done here to keep it simple and to ensure that only known
         // code is executed.
         assert!(config.register_lints.is_none());
-
         config.register_lints = Some(Box::new(|_sess, lint_store| {
             // Register lints from lint crates. This is required to have rustc track
             // the lint level correctly.
@@ -68,6 +89,49 @@ impl rustc_driver::Callbacks for MarkerCallback {
 
             lint_store.register_late_pass(|_| Box::new(lint_pass::RustcLintPass));
         }));
+    }
+}
+
+fn register_tracked_env(sess: &mut rustc_session::parse::ParseSess, vars: &[(&'static str, String)]) {
+    use rustc_span::Symbol;
+    let env = sess.env_depinfo.get_mut();
+
+    for (key, value) in vars {
+        env.insert((Symbol::intern(key), Some(Symbol::intern(value))));
+    }
+}
+
+fn register_tracked_files(sess: &mut rustc_session::parse::ParseSess, lint_crates: &[LintCrateInfo]) {
+    use rustc_span::Symbol;
+
+    let files = sess.file_depinfo.get_mut();
+
+    // Cargo sets the current directory, to the folder containing the `Cargo.toml`
+    // file of the compiled crate. Therefore, we can use the relative path.
+    let cargo_file = Path::new("./Cargo.toml");
+    if cargo_file.exists() {
+        files.insert(Symbol::intern("./Cargo.toml"));
+    }
+
+    // At this point, the lint crate paths should be absolute. Therefore, we
+    // can just throw it in the `files` set.
+    for lint_crate in lint_crates {
+        if let Some(name) = lint_crate.path.to_str() {
+            files.insert(Symbol::intern(name));
+        } else {
+            // The name is not a valid UTF-8 String. This is not ideal but at the
+            // same time not problematic enough to throw an error. It just means
+            // that the lint crate can't be tracked and the driver might reuse
+            // a cache if only that crate was changed.
+        }
+    }
+
+    // Track the driver executable in debug builds
+    if cfg!(debug_assertions)
+        && let Ok(current_exe) = env::current_exe()
+        && let Some(current_exe_str) = current_exe.to_str()
+    {
+        files.insert(Symbol::intern(current_exe_str));
     }
 }
 
@@ -121,22 +185,20 @@ fn toolchain_path(home: Option<String>, toolchain: Option<String>) -> Option<Pat
 fn display_help() {
     println!(
         "\
-Checks a package to catch common mistakes and improve your Rust code.
+Marker's rustc driver to run your lint crates.
 
 Usage:
-    cargo marker [options] [--] [<opts>...]
+    marker_rustc_driver [options] [--] [<opts>...]
 
 Common options:
     -h, --help               Print this message
-        --rustc              Pass all args to rustc
-    -V, --version            Print version info and exit
-        --toolchain          Print the required nightly toolchain
-
-Other options are the same as `cargo check`.
+        --rustc              Pass all arguments to rustc
+    -V, --version            Print version information and exit
+        --toolchain          Print the required toolchain and API version
 
 ---
 
-This message belongs to a specific driver, if possible you should avoid
+This message belongs to a specific  marker driver, if possible you should avoid
 interfacing with the driver directly and use `cargo marker` instead.
 "
     );
@@ -147,10 +209,11 @@ fn main() {
     let handler = EarlyErrorHandler::new(ErrorOutputType::default());
     rustc_driver::init_rustc_env_logger(&handler);
 
-    // FIXME: Add ICE hook. Ideally this would distinguish where the error happens.
-    // ICEs have to be reported like in Clippy. For lint impl ICEs we should have
-    // an extra ICE hook that identifies the lint impl and ideally continues with
-    // other registered lints
+    // FIXME(xFrednet): The ICE hook would ideally distinguish where the error
+    // happens. Panics from lint crates should probably not terminate Marker
+    // completely, but instead warn the user and continue linting with the other
+    // lint crate. It would also be cool if the ICE hook printed the node that
+    // caused the panic in the lint crate. rust-marker/marker#10
 
     rustc_driver::install_ice_hook(BUG_REPORT_URL, |handler| {
         handler.note_without_error(format!("{}", rustc_tools_util::get_version_info!()));
@@ -158,6 +221,10 @@ fn main() {
     });
 
     exit(rustc_driver::catch_with_exit_code(|| {
+        // Note: This driver has two different kinds of "arguments".
+        // 1. Normal arguments, passed directly to the binary. (Collected below)
+        // 2. Arguments provided to `cargo-marker` which are forwarded to this process as environment
+        //    values. These are usually driver-independent and handled by the adapter.
         let mut orig_args: Vec<String> = env::args().collect();
 
         let sys_root_arg = arg_value(&orig_args, "--sysroot", |_| true);
@@ -170,14 +237,14 @@ fn main() {
             orig_args.extend(vec!["--sysroot".into(), sys_root]);
         };
 
-        // make "marker-driver --rustc" work like a subcommand that passes further args to "rustc"
-        // for example `marker-driver --rustc --version` will print the rustc version that marker-driver
-        // uses
+        // make "marker_rustc_driver --rustc" work like a subcommand that passes
+        // all args to "rustc" for example `marker_rustc_driver --rustc --version`
+        // will print the rustc version that is used
         if let Some(pos) = orig_args.iter().position(|arg| arg == "--rustc") {
             orig_args.remove(pos);
             orig_args[0] = "rustc".to_string();
 
-            return rustc_driver::RunCompiler::new(&orig_args, &mut DefaultCallbacks).run();
+            return rustc_driver::RunCompiler::new(&orig_args, &mut DefaultCallbacks { env_vars: vec![] }).run();
         }
 
         if orig_args.iter().any(|a| a == "--version" || a == "-V") {
@@ -203,13 +270,14 @@ fn main() {
             orig_args.remove(1);
         }
 
+        // The `--rustc` argument has already been handled, therefore we can just
+        // check for this argument without caring about the position.
         if !wrapper_mode && orig_args.iter().any(|a| a == "--help" || a == "-h") {
             display_help();
             exit(0);
         }
 
         // We enable Marker if one of the following conditions is met
-        // - IF Marker is run on its test suite OR
         // - IF Marker is run on the main crate, not on deps (`!cap_lints_allow`) THEN
         //    - IF `--no-deps` is not set (`!no_deps`) OR
         //    - IF `--no-deps` is set and Marker is run on the specified primary package
@@ -219,10 +287,15 @@ fn main() {
         let in_primary_package = env::var("CARGO_PRIMARY_PACKAGE").is_ok();
 
         let enable_marker = !cap_lints_allow && (!no_deps || in_primary_package);
+        let env_vars = vec![(LINT_CRATES_ENV, std::env::var(LINT_CRATES_ENV).unwrap_or_default())];
         if enable_marker {
-            rustc_driver::RunCompiler::new(&orig_args, &mut MarkerCallback).run()
+            let mut callback = MarkerCallback {
+                env_vars,
+                lint_crates: LintCrateInfo::list_from_env().unwrap(),
+            };
+            rustc_driver::RunCompiler::new(&orig_args, &mut callback).run()
         } else {
-            rustc_driver::RunCompiler::new(&orig_args, &mut DefaultCallbacks).run()
+            rustc_driver::RunCompiler::new(&orig_args, &mut DefaultCallbacks { env_vars }).run()
         }
     }))
 }

--- a/marker_rustc_driver/src/main.rs
+++ b/marker_rustc_driver/src/main.rs
@@ -65,7 +65,7 @@ struct MarkerCallback {
 
 impl rustc_driver::Callbacks for MarkerCallback {
     fn config(&mut self, config: &mut rustc_interface::Config) {
-        lint_pass::RustcLintPass::init_adapter(&self.lint_crates);
+        lint_pass::RustcLintPass::init_adapter(&self.lint_crates).unwrap();
 
         let env_vars = std::mem::take(&mut self.env_vars);
         let lint_crates = std::mem::take(&mut self.lint_crates);


### PR DESCRIPTION
This was a fight, it required some refactoring in `marker_adapter` to get the information, which lint crates should actually be tracked.

The process of invoking the compiler programmatically is also confusing, IMO. I don't know how anyone should be able to figure this out, without the existence of Clippy as a reference. Even with the reference and my tries to leave helpful comments, it took some time to get back into it.

If anyone is interested in reviewing this, I suggest just taking a look at the `register_tracked_files` function and the `marker_adapter` changes. The rest is first class spaghetti code which will hopefully work flawlessly:tm:

---

Testing this is also... a challenge, in the end I had to manually install the driver, open a different project and add a path lint crate. Then I changed the lint crate to confirm that it avoids the caching. Not really recommendable, oh well :)

---

Closes: https://github.com/rust-marker/marker/issues/98
Closes: https://github.com/rust-marker/marker/issues/190
