### PR TITLE
Cargo: Build CLAP command using derive

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [alias]
 bless   = "test --test uitest -- -- --bless"
-dogfood = "run --features dev-build --bin cargo-marker -- --forward-rust-flags"
+dogfood = "run --bin cargo-marker -- --forward-rust-flags"
 uilints = "test -p marker_uilints --test uitest"
 uitest  = "test --test uitest"
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [alias]
 bless   = "test --test uitest -- -- --bless"
-dogfood = "run --bin cargo-marker -- --forward-rust-flags"
+dogfood = "run --bin cargo-marker -- marker --forward-rust-flags"
 uilints = "test -p marker_uilints --test uitest"
 uitest  = "test --test uitest"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d"
 dependencies = [
  "clap_builder",
+ "clap_derive",
+ "once_cell",
 ]
 
 [[package]]
@@ -205,6 +207,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -339,6 +353,12 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"

--- a/cargo-marker/Cargo.toml
+++ b/cargo-marker/Cargo.toml
@@ -18,13 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 cargo_metadata = "0.15.4"
-clap           = { version = "4.0", features = ["string"] }
+clap           = { version = "4.0", features = ["string", "derive"] }
 once_cell      = "1.17.0"
 serde          = { version = "1.0", features = ["derive"] }
 toml           = { version = "0.7" }
-
-[features]
-default = []
-# This enables developer features used to automatically build the local version
-# assuming, that it's being executed at the root of the repo.
-dev-build = []

--- a/cargo-marker/src/backend/driver.rs
+++ b/cargo-marker/src/backend/driver.rs
@@ -71,11 +71,7 @@ impl DriverVersionInfo {
 }
 
 /// This tries to install the rustc driver specified in [`DEFAULT_DRIVER_INFO`].
-pub fn install_driver(
-    auto_install_toolchain: bool,
-    dev_build: bool,
-    additional_rustc_flags: &str,
-) -> Result<(), ExitStatus> {
+pub fn install_driver(auto_install_toolchain: bool, additional_rustc_flags: &str) -> Result<(), ExitStatus> {
     // The toolchain, driver version and api version should ideally be configurable.
     // However, that will require more prototyping and has a low priority rn.
     // See #60
@@ -98,12 +94,7 @@ pub fn install_driver(
         return Err(ExitStatus::InvalidToolchain);
     }
 
-    build_driver(
-        toolchain,
-        &DEFAULT_DRIVER_INFO.version,
-        dev_build,
-        additional_rustc_flags,
-    )
+    build_driver(toolchain, &DEFAULT_DRIVER_INFO.version, additional_rustc_flags)
 }
 
 fn install_toolchain(toolchain: &str) -> Result<(), ExitStatus> {
@@ -133,13 +124,8 @@ fn install_toolchain(toolchain: &str) -> Result<(), ExitStatus> {
 }
 
 /// This tries to compile the driver.
-fn build_driver(
-    toolchain: &str,
-    version: &str,
-    dev_build: bool,
-    additional_rustc_flags: &str,
-) -> Result<(), ExitStatus> {
-    if dev_build {
+fn build_driver(toolchain: &str, version: &str, additional_rustc_flags: &str) -> Result<(), ExitStatus> {
+    if cfg!(debug_assertions) {
         println!("Compiling rustc driver");
     } else {
         println!("Compiling rustc driver v{version} with {toolchain}");
@@ -149,7 +135,7 @@ fn build_driver(
 
     // Build driver
     let mut cmd = Command::new("cargo");
-    if dev_build {
+    if cfg!(debug_assertions) {
         cmd.args(["build", "--bin", "marker_rustc_driver"]);
     } else {
         cmd.env("RUSTUP_TOOLCHAIN", toolchain);

--- a/cargo-marker/src/backend/toolchain.rs
+++ b/cargo-marker/src/backend/toolchain.rs
@@ -97,8 +97,8 @@ impl Toolchain {
         Ok(metadata.target_directory.into())
     }
 
-    pub fn try_find_toolchain(dev_build: bool, verbose: bool) -> Result<Toolchain, ExitStatus> {
-        if dev_build {
+    pub fn try_find_toolchain(verbose: bool) -> Result<Toolchain, ExitStatus> {
+        if cfg!(debug_assertions) {
             Self::search_next_to_cargo_marker(verbose)
         } else {
             // First check if there is a rustc driver for the current toolchain. This

--- a/cargo-marker/src/cli.rs
+++ b/cargo-marker/src/cli.rs
@@ -1,115 +1,151 @@
 use std::collections::HashMap;
 
-use clap::{builder::ValueParser, Arg, ArgAction, ArgMatches, Command};
+use clap::{Args, Parser, Subcommand};
+
+const CARGO_ARGS_SEPARATOR: &str = "--";
+
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+#[command(after_help = AFTER_HELP_MSG)]
+#[command(override_usage = "cargo marker [OPTIONS] [COMMAND] -- <CARGO ARGS>")]
+pub struct MarkerCli {
+    #[command(subcommand)]
+    pub command: Option<CliCommand>,
+
+    /// Used as the arguments to run Marker, when no command was specified
+    #[clap(flatten)]
+    pub check_args: CheckArgs,
+}
+
+impl MarkerCli {
+    /// Prefer using this over the normal `parse` method, to split the arguments
+    pub fn parse_args() -> Self {
+        let (marker_args, cargo_args) = split_args(std::env::args());
+        let mut cli = Self::parse_from(marker_args);
+
+        match &mut cli.command {
+            Some(CliCommand::Check(check_args) | CliCommand::TestSetup(check_args)) => {
+                check_args.cargo_args = cargo_args;
+            },
+            Some(CliCommand::Setup(_)) => {},
+            None => cli.check_args.cargo_args = cargo_args,
+        }
+
+        cli
+    }
+}
+
+/// This reads the arguments from the
+fn split_args<I>(args: I) -> (Vec<String>, Vec<String>)
+where
+    I: IntoIterator<Item = String>,
+{
+    let mut marker_args: Vec<_> = args
+        .into_iter()
+        // The second argument might be `marker` if `cargo-marker` was
+        // invoked as a subcommand by cargo. This filters out the name.
+        .enumerate()
+        .filter_map(|(index, value)| (!(index == 1 && value == "marker")).then_some(value))
+        .collect();
+
+    let cargo_args = if let Some(index) = marker_args.iter().position(|val| val == CARGO_ARGS_SEPARATOR) {
+        let mut cargo_args = marker_args.split_off(index);
+        // Remove `CARGO_ARGS_SEPARATOR` from the start
+        cargo_args.remove(0);
+        cargo_args
+    } else {
+        vec![]
+    };
+
+    (marker_args, cargo_args)
+}
+
+#[derive(Subcommand, Debug)]
+pub enum CliCommand {
+    /// Run Marker on the current package
+    Check(CheckArgs),
+    /// Setup the rustc driver for Marker
+    Setup(SetupArgs),
+    /// **UNSTABLE** Setup the specified lint crate for ui tests
+    #[command(hide = true)]
+    TestSetup(CheckArgs),
+}
+
+#[derive(Args, Debug)]
+#[command(override_usage = "cargo marker check [OPTIONS] -- <CARGO ARGS>")]
+pub struct CheckArgs {
+    /// Specifies lint crates which should be used. (Lints in `Cargo.toml` will be ignored)
+    #[arg(short, long)]
+    pub lints: Vec<String>,
+    /// Forwards the current `RUSTFLAGS` value during driver and lint crate compilation
+    #[arg(long, default_value_t = false)]
+    pub forward_rust_flags: bool,
+
+    /// Arguments specified after double dashes, which should be forwarded
+    #[clap(skip)]
+    pub cargo_args: Vec<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct SetupArgs {
+    /// Automatically installs the required toolchain using rustup
+    #[arg(long, default_value_t = false)]
+    pub auto_install_toolchain: bool,
+    /// Forwards the current `RUSTFLAGS` value during driver and lint crate compilation
+    #[arg(long, default_value_t = false)]
+    pub forward_rust_flags: bool,
+}
 
 use crate::{
     config::{Config, ConfigFetchError, LintDependency},
-    ExitStatus, VERSION,
+    ExitStatus,
 };
 
 const AFTER_HELP_MSG: &str = r#"CARGO ARGS
     All arguments after double dashes(`--`) will be passed to cargo.
     Run `cargo check --help` to see these options.
-
-EXAMPLES:
-    * `cargo marker -l "marker_uitest = { path = './marker_lints' }"`
 "#;
 
-#[allow(clippy::struct_excessive_bools)]
-#[derive(Debug)]
-pub struct Flags {
-    pub verbose: bool,
-    pub test_build: bool,
-    pub dev_build: bool,
-    pub forward_rust_flags: bool,
-}
-
-impl Flags {
-    pub fn from_args(args: &ArgMatches) -> Self {
-        Self {
-            verbose: args.get_flag("verbose"),
-            test_build: args.get_flag("test-setup"),
-            dev_build: cfg!(feature = "dev-build"),
-            forward_rust_flags: args.get_flag("forward-rust-flags"),
-        }
+pub fn collect_lint_deps(args: &CheckArgs) -> Result<HashMap<String, LintDependency>, ExitStatus> {
+    if args.lints.is_empty() {
+        return Err(ExitStatus::NoLints);
     }
-}
 
-pub fn collect_lint_deps(args: &ArgMatches) -> Result<HashMap<String, LintDependency>, ExitStatus> {
-    if let Some(lints) = args.get_many::<String>("lints") {
-        let mut virtual_manifest = "[workspace.metadata.marker.lints]\n".to_string();
-        for dep in lints {
-            virtual_manifest.push_str(dep);
-            virtual_manifest.push('\n');
-        }
-
-        let Config { lints } = Config::try_from_str(&virtual_manifest).map_err(ConfigFetchError::emit_and_convert)?;
-        Ok(lints)
-    } else {
-        Err(ExitStatus::NoLints)
+    let mut virtual_manifest = "[workspace.metadata.marker.lints]\n".to_string();
+    for dep in &args.lints {
+        virtual_manifest.push_str(dep);
+        virtual_manifest.push('\n');
     }
+
+    let Config { lints } = Config::try_from_str(&virtual_manifest).map_err(ConfigFetchError::emit_and_convert)?;
+    Ok(lints)
 }
 
-pub fn get_clap_config() -> Command {
-    Command::new(VERSION)
-        .arg(
-            Arg::new("version")
-                .short('V')
-                .long("version")
-                .action(ArgAction::SetTrue)
-                .help("Print version info and exit"),
-        )
-        .arg(
-            Arg::new("verbose")
-                .short('v')
-                .long("verbose")
-                .action(ArgAction::SetTrue)
-                .help("Print additional debug information to the console"),
-        )
-        .arg(
-            Arg::new("test-setup")
-                .long("test-setup")
-                .action(ArgAction::SetTrue)
-                .help("This flag will compile the lint crate and print all relevant environment values"),
-        )
-        .arg(
-            Arg::new("forward-rust-flags")
-                .long("forward-rust-flags")
-                .action(ArgAction::SetTrue)
-                .help("Forwards the current `RUSTFLAGS` value during driver and lint compilation"),
-        )
-        .subcommand(setup_command())
-        .subcommand(check_command())
-        .args(check_command_args())
-        .after_help(AFTER_HELP_MSG)
-        .override_usage("cargo-marker [OPTIONS] -- <CARGO ARGS>")
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn verify_cli() {
+        use clap::CommandFactory;
+        MarkerCli::command().debug_assert();
+    }
 
-fn setup_command() -> Command {
-    Command::new("setup")
-        .about("A collection of commands to setup marker")
-        .after_help("By default this will install the driver for rustc.")
-        .arg(
-            Arg::new("auto-install-toolchain")
-                .long("auto-install-toolchain")
-                .action(ArgAction::SetTrue)
-                .help("This automatically installs the required toolchain using rustup"),
-        )
-}
+    #[test]
+    fn test_split_args() {
+        let (a, b) = split_args(vec![]);
+        assert_eq!(a, &[] as &[&str]);
+        assert_eq!(b, &[] as &[&str]);
 
-fn check_command() -> Command {
-    Command::new("check")
-        .about("Run marker on a local package")
-        .args(check_command_args())
-}
+        let (a, b) = split_args(["check", "--something", "else"].iter().map(ToString::to_string));
+        assert_eq!(a, &["check", "--something", "else"] as &[&str]);
+        assert_eq!(b, &[] as &[&str]);
 
-fn check_command_args() -> impl IntoIterator<Item = impl Into<Arg>> {
-    vec![
-        Arg::new("lints")
-            .short('l')
-            .long("lints")
-            .num_args(1..)
-            .value_parser(ValueParser::string())
-            .help("Defines a set of lint crates that should be used"),
-    ]
+        let (a, b) = split_args(["check", "--", "cargo", "magic"].iter().map(ToString::to_string));
+        assert_eq!(a, &["check"] as &[&str]);
+        assert_eq!(b, &["cargo", "magic"] as &[&str]);
+
+        let (a, b) = split_args(["check", "--"].iter().map(ToString::to_string));
+        assert_eq!(a, &["check"] as &[&str]);
+        assert_eq!(b, &[] as &[&str]);
+    }
 }

--- a/cargo-marker/src/cli.rs
+++ b/cargo-marker/src/cli.rs
@@ -2,11 +2,23 @@ use std::collections::HashMap;
 
 use clap::{Args, Parser, Subcommand};
 
-const CARGO_ARGS_SEPARATOR: &str = "--";
+/// Marker's CLI interface
+///
+/// This binary should be invoked by Cargo with the new `marker` subcommand. If
+/// you're reading this, consider manually adding `marker` as the first argument.
+#[derive(Parser, Debug)]
+struct MarkerApp {
+    #[clap(subcommand)]
+    subcommand: MarkerSubcommand,
+}
+
+#[derive(Parser, Debug)]
+enum MarkerSubcommand {
+    Marker(MarkerCli),
+}
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
-#[command(after_help = AFTER_HELP_MSG)]
 #[command(override_usage = "cargo marker [OPTIONS] [COMMAND] -- <CARGO ARGS>")]
 pub struct MarkerCli {
     #[command(subcommand)]
@@ -20,44 +32,9 @@ pub struct MarkerCli {
 impl MarkerCli {
     /// Prefer using this over the normal `parse` method, to split the arguments
     pub fn parse_args() -> Self {
-        let (marker_args, cargo_args) = split_args(std::env::args());
-        let mut cli = Self::parse_from(marker_args);
-
-        match &mut cli.command {
-            Some(CliCommand::Check(check_args) | CliCommand::TestSetup(check_args)) => {
-                check_args.cargo_args = cargo_args;
-            },
-            Some(CliCommand::Setup(_)) => {},
-            None => cli.check_args.cargo_args = cargo_args,
-        }
-
+        let MarkerSubcommand::Marker(cli) = MarkerApp::parse().subcommand;
         cli
     }
-}
-
-/// This reads the arguments from the
-fn split_args<I>(args: I) -> (Vec<String>, Vec<String>)
-where
-    I: IntoIterator<Item = String>,
-{
-    let mut marker_args: Vec<_> = args
-        .into_iter()
-        // The second argument might be `marker` if `cargo-marker` was
-        // invoked as a subcommand by cargo. This filters out the name.
-        .enumerate()
-        .filter_map(|(index, value)| (!(index == 1 && value == "marker")).then_some(value))
-        .collect();
-
-    let cargo_args = if let Some(index) = marker_args.iter().position(|val| val == CARGO_ARGS_SEPARATOR) {
-        let mut cargo_args = marker_args.split_off(index);
-        // Remove `CARGO_ARGS_SEPARATOR` from the start
-        cargo_args.remove(0);
-        cargo_args
-    } else {
-        vec![]
-    };
-
-    (marker_args, cargo_args)
 }
 
 #[derive(Subcommand, Debug)]
@@ -78,21 +55,21 @@ pub struct CheckArgs {
     #[arg(short, long)]
     pub lints: Vec<String>,
     /// Forwards the current `RUSTFLAGS` value during driver and lint crate compilation
-    #[arg(long, default_value_t = false)]
+    #[arg(long)]
     pub forward_rust_flags: bool,
 
-    /// Arguments specified after double dashes, which should be forwarded
-    #[clap(skip)]
+    /// Arguments which will be forwarded to Cargo. See `cargo check --help`
+    #[clap(last = true)]
     pub cargo_args: Vec<String>,
 }
 
 #[derive(Args, Debug)]
 pub struct SetupArgs {
     /// Automatically installs the required toolchain using rustup
-    #[arg(long, default_value_t = false)]
+    #[arg(long)]
     pub auto_install_toolchain: bool,
     /// Forwards the current `RUSTFLAGS` value during driver and lint crate compilation
-    #[arg(long, default_value_t = false)]
+    #[arg(long)]
     pub forward_rust_flags: bool,
 }
 
@@ -100,11 +77,6 @@ use crate::{
     config::{Config, ConfigFetchError, LintDependency},
     ExitStatus,
 };
-
-const AFTER_HELP_MSG: &str = r#"CARGO ARGS
-    All arguments after double dashes(`--`) will be passed to cargo.
-    Run `cargo check --help` to see these options.
-"#;
 
 pub fn collect_lint_deps(args: &CheckArgs) -> Result<HashMap<String, LintDependency>, ExitStatus> {
     if args.lints.is_empty() {
@@ -131,21 +103,28 @@ mod tests {
     }
 
     #[test]
-    fn test_split_args() {
-        let (a, b) = split_args(vec![]);
-        assert_eq!(a, &[] as &[&str]);
-        assert_eq!(b, &[] as &[&str]);
+    fn test_marker_cli() {
+        let cli = MarkerCli::parse_from(&["cargo-marker", "check"]);
+        assert!(matches!(cli.command, Some(CliCommand::Check(_))));
 
-        let (a, b) = split_args(["check", "--something", "else"].iter().map(ToString::to_string));
-        assert_eq!(a, &["check", "--something", "else"] as &[&str]);
-        assert_eq!(b, &[] as &[&str]);
+        let cli = MarkerCli::parse_from(&["cargo-marker"]);
+        assert!(matches!(cli.command, None));
+        assert!(cli.check_args.cargo_args.is_empty());
 
-        let (a, b) = split_args(["check", "--", "cargo", "magic"].iter().map(ToString::to_string));
-        assert_eq!(a, &["check"] as &[&str]);
-        assert_eq!(b, &["cargo", "magic"] as &[&str]);
+        let cli = MarkerCli::parse_from(&["cargo-marker", "--", "ducks", "penguins"]);
+        assert!(matches!(cli.command, None));
+        assert!(cli.check_args.cargo_args.len() == 2);
+        assert!(cli.check_args.cargo_args[0] == "ducks");
+        assert!(cli.check_args.cargo_args[1] == "penguins");
 
-        let (a, b) = split_args(["check", "--"].iter().map(ToString::to_string));
-        assert_eq!(a, &["check"] as &[&str]);
-        assert_eq!(b, &[] as &[&str]);
+        let cli = MarkerCli::parse_from(&["cargo-marker", "check", "--", "ducks", "penguins"]);
+        assert!(cli.check_args.cargo_args.is_empty());
+        if let Some(CliCommand::Check(check_args)) = cli.command {
+            assert!(check_args.cargo_args.len() == 2);
+            assert!(check_args.cargo_args[0] == "ducks");
+            assert!(check_args.cargo_args[1] == "penguins");
+        } else {
+            assert!(false, "the `check` subcommand was not detected");
+        }
     }
 }

--- a/cargo-marker/src/main.rs
+++ b/cargo-marker/src/main.rs
@@ -22,7 +22,6 @@ use crate::backend::driver::DriverVersionInfo;
 #[allow(unreachable_code)]
 fn main() -> Result<(), ExitStatus> {
     let cli = MarkerCli::parse_args();
-    println!("{cli:#?}");
 
     let config = match Config::try_from_manifest() {
         Ok(v) => Some(v),

--- a/cargo-marker/src/main.rs
+++ b/cargo-marker/src/main.rs
@@ -12,30 +12,17 @@ mod utils;
 use std::{collections::HashMap, ffi::OsString};
 
 use backend::CheckInfo;
-use cli::{get_clap_config, Flags};
+use cli::{CheckArgs, CliCommand, MarkerCli};
 use config::Config;
 
 pub use exit::ExitStatus;
 
 use crate::backend::driver::DriverVersionInfo;
 
-const CARGO_ARGS_SEPARATOR: &str = "--";
-const VERSION: &str = concat!("cargo-marker ", env!("CARGO_PKG_VERSION"));
-
+#[allow(unreachable_code)]
 fn main() -> Result<(), ExitStatus> {
-    let matches = get_clap_config().get_matches_from(
-        std::env::args()
-            .enumerate()
-            .filter_map(|(index, value)| (!(index == 1 && value == "marker")).then_some(value))
-            .take_while(|s| s != CARGO_ARGS_SEPARATOR),
-    );
-
-    let flags = Flags::from_args(&matches);
-
-    if matches.get_flag("version") {
-        print_version();
-        return Ok(());
-    }
+    let cli = MarkerCli::parse_args();
+    println!("{cli:#?}");
 
     let config = match Config::try_from_manifest() {
         Ok(v) => Some(v),
@@ -45,22 +32,28 @@ fn main() -> Result<(), ExitStatus> {
         },
     };
 
-    match matches.subcommand() {
-        Some(("setup", args)) => {
-            let rustc_flags = if flags.forward_rust_flags {
+    match &cli.command {
+        Some(CliCommand::Setup(args)) => {
+            let rustc_flags = if args.forward_rust_flags {
                 std::env::var("RUSTFLAGS").unwrap_or_default()
             } else {
                 String::new()
             };
-            backend::driver::install_driver(args.get_flag("auto-install-toolchain"), flags.dev_build, &rustc_flags)
+            backend::driver::install_driver(args.auto_install_toolchain, &rustc_flags)
         },
-        Some(("check", args)) => run_check(args, config, &flags),
-        None => run_check(&matches, config, &flags),
-        _ => unreachable!(),
+        Some(CliCommand::Check(args)) => run_check(args, config, CheckKind::Normal),
+        Some(CliCommand::TestSetup(args)) => run_check(args, config, CheckKind::TestSetup),
+        None => run_check(&cli.check_args, config, CheckKind::Normal),
     }
 }
 
-fn run_check(args: &clap::ArgMatches, config: Option<Config>, flags: &Flags) -> Result<(), ExitStatus> {
+#[derive(Debug, Clone, Copy)]
+enum CheckKind {
+    Normal,
+    TestSetup,
+}
+
+fn run_check(args: &CheckArgs, config: Option<Config>, kind: CheckKind) -> Result<(), ExitStatus> {
     // determine lints
     let deps = match cli::collect_lint_deps(args) {
         Ok(deps) => deps,
@@ -84,14 +77,15 @@ fn run_check(args: &clap::ArgMatches, config: Option<Config>, flags: &Flags) -> 
     }
 
     // If this is a dev build, we want to rebuild the driver before checking
-    if flags.dev_build {
-        backend::driver::install_driver(false, flags.dev_build, "")?;
-    }
+    #[cfg(debug_assertions)]
+    backend::driver::install_driver(false, "")?;
 
     // Configure backend
-    let toolchain = backend::toolchain::Toolchain::try_find_toolchain(flags.dev_build, flags.verbose)?;
+    // FIXME(xFrednet): Implement better logging and remove verbose boolean in
+    // favor of debug logging.
+    let toolchain = backend::toolchain::Toolchain::try_find_toolchain(false)?;
     let backend_conf = backend::Config {
-        dev_build: flags.dev_build,
+        dev_build: cfg!(debug_assertions),
         lints,
         ..backend::Config::try_base_from(toolchain)?
     };
@@ -100,20 +94,13 @@ fn run_check(args: &clap::ArgMatches, config: Option<Config>, flags: &Flags) -> 
     let info = backend::prepare_check(&backend_conf)?;
 
     // Run backend
-    if flags.test_build {
-        print_test_info(&backend_conf, &info).unwrap();
-        Ok(())
-    } else {
-        let additional_cargo_args: Vec<_> = std::env::args()
-            .skip_while(|c| c != CARGO_ARGS_SEPARATOR)
-            .skip(1)
-            .collect();
-        backend::run_check(&backend_conf, info, &additional_cargo_args)
+    match kind {
+        CheckKind::Normal => backend::run_check(&backend_conf, info, &args.cargo_args),
+        CheckKind::TestSetup => {
+            print_test_info(&backend_conf, &info).unwrap();
+            Ok(())
+        },
     }
-}
-
-fn print_version() {
-    println!("cargo-marker version: {}", env!("CARGO_PKG_VERSION"));
 }
 
 fn print_test_info(config: &backend::Config, check: &CheckInfo) -> Result<(), ExitStatus> {

--- a/marker_uitest/src/lib.rs
+++ b/marker_uitest/src/lib.rs
@@ -100,7 +100,7 @@ fn retrieve_test_setup(crate_name: &str, pkg_dir: &Path) -> TestSetup {
     #[cfg(not(feature = "dev-build"))]
     const CARGO_MARKER_INVOCATION: &[&str] = &["marker"];
     #[cfg(feature = "dev-build")]
-    const CARGO_MARKER_INVOCATION: &[&str] = &["run", "--bin", "cargo-marker", "--features", "dev-build", "--"];
+    const CARGO_MARKER_INVOCATION: &[&str] = &["run", "--bin", "cargo-marker", "--"];
 
     #[cfg(not(feature = "dev-build"))]
     let command_dir = pkg_dir;
@@ -113,9 +113,9 @@ fn retrieve_test_setup(crate_name: &str, pkg_dir: &Path) -> TestSetup {
     let output = cmd
         .current_dir(command_dir)
         .args(CARGO_MARKER_INVOCATION)
+        .arg("test-setup")
         .arg("-l")
         .arg(lint_spec)
-        .arg("--test-setup")
         .output()
         .expect("Unable to run the test setup using `cargo-marker`");
     let stdout = String::from_utf8(output.stdout).unwrap();

--- a/marker_uitest/src/lib.rs
+++ b/marker_uitest/src/lib.rs
@@ -100,7 +100,7 @@ fn retrieve_test_setup(crate_name: &str, pkg_dir: &Path) -> TestSetup {
     #[cfg(not(feature = "dev-build"))]
     const CARGO_MARKER_INVOCATION: &[&str] = &["marker"];
     #[cfg(feature = "dev-build")]
-    const CARGO_MARKER_INVOCATION: &[&str] = &["run", "--bin", "cargo-marker", "--"];
+    const CARGO_MARKER_INVOCATION: &[&str] = &["run", "--bin", "cargo-marker", "--", "marker"];
 
     #[cfg(not(feature = "dev-build"))]
     let command_dir = pkg_dir;


### PR DESCRIPTION
Just a simple refactoring. At first, I was a bit hesitant, but I believe that this is the better way to handle Marker's CLI. Only the `--test-setup` argument changed into a hidden subcommand, the rest should be the same as before.

Nothing more to say otherwise. Reviews are appreciated. For everyone reading this, have a beautiful day! :D