### PR TITLE
CI: Fix Marker Book deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           PATH="$PATH:`pwd`"
           cd ./docs/book/
-          mdbook build
+          mdbook build --dest-dir ../../deploy/book
           cd ../../
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2


### PR DESCRIPTION
In rust-marker/marker#212 I broke the book, by using too much copy-pasta, this should fix the issue quickly.
 
Sorry :sweat_smile: 