### PR TITLE
API, Rustc: Rework spans (and fix a few errors)

### DIFF
--- a/marker_adapter/src/context.rs
+++ b/marker_adapter/src/context.rs
@@ -95,6 +95,8 @@ extern "C" fn span_snippet<'ast>(data: &'ast (), span: &Span<'ast>) -> ffi::FfiO
     unsafe { as_driver_cx(data) }.span_snippet(span).map(Into::into).into()
 }
 
+// False positive because `SpanSource` is non-exhaustive
+#[allow(improper_ctypes_definitions)]
 extern "C" fn span_source<'ast>(data: &'ast (), span: &Span<'_>) -> SpanSource<'ast> {
     unsafe { as_driver_cx(data) }.span_source(span)
 }

--- a/marker_adapter/src/context.rs
+++ b/marker_adapter/src/context.rs
@@ -5,7 +5,8 @@ use marker_api::{
     ast::{
         item::{Body, ItemKind},
         ty::SemTyKind,
-        BodyId, ExprId, ItemId, Span, SpanId, SymbolId, TyDefId,
+        BodyId, ExpnId, ExpnInfo, ExprId, FileInfo, FilePos, ItemId, Span, SpanId, SpanPos, SpanSource, SymbolId,
+        TyDefId,
     },
     context::DriverCallbacks,
     diagnostic::{Diagnostic, EmissionNode},
@@ -47,6 +48,9 @@ impl<'ast> DriverContextWrapper<'ast> {
             expr_ty,
             span,
             span_snippet,
+            span_source,
+            span_pos_to_file_loc,
+            span_expn_info,
             symbol_str,
             resolve_method_target,
         }
@@ -55,7 +59,7 @@ impl<'ast> DriverContextWrapper<'ast> {
 
 // False positive because `EmissionNode` are non-exhaustive
 #[allow(improper_ctypes_definitions)]
-extern "C" fn lint_level_at(data: &(), lint: &'static Lint, node: EmissionNode) -> Level {
+extern "C" fn lint_level_at<'ast>(data: &'ast (), lint: &'static Lint, node: EmissionNode) -> Level {
     unsafe { as_driver_cx(data) }.lint_level_at(lint, node)
 }
 
@@ -91,11 +95,27 @@ extern "C" fn span_snippet<'ast>(data: &'ast (), span: &Span<'ast>) -> ffi::FfiO
     unsafe { as_driver_cx(data) }.span_snippet(span).map(Into::into).into()
 }
 
+extern "C" fn span_source<'ast>(data: &'ast (), span: &Span<'_>) -> SpanSource<'ast> {
+    unsafe { as_driver_cx(data) }.span_source(span)
+}
+
+extern "C" fn span_pos_to_file_loc<'ast>(
+    data: &'ast (),
+    file: &FileInfo<'ast>,
+    pos: SpanPos,
+) -> ffi::FfiOption<FilePos<'ast>> {
+    unsafe { as_driver_cx(data) }.span_pos_to_file_loc(file, pos).into()
+}
+
+extern "C" fn span_expn_info<'ast>(data: &'ast (), expn_id: ExpnId) -> FfiOption<&'ast ExpnInfo<'ast>> {
+    unsafe { as_driver_cx(data) }.span_expn_info(expn_id).into()
+}
+
 extern "C" fn symbol_str<'ast>(data: &'ast (), sym: SymbolId) -> ffi::FfiStr<'ast> {
     unsafe { as_driver_cx(data) }.symbol_str(sym).into()
 }
 
-extern "C" fn resolve_method_target(data: &(), id: ExprId) -> ItemId {
+extern "C" fn resolve_method_target<'ast>(data: &'ast (), id: ExprId) -> ItemId {
     unsafe { as_driver_cx(data) }.resolve_method_target(id)
 }
 
@@ -117,7 +137,10 @@ pub trait DriverContext<'ast> {
 
     fn expr_ty(&'ast self, expr: ExprId) -> SemTyKind<'ast>;
     fn span(&'ast self, owner: SpanId) -> &'ast Span<'ast>;
-    fn span_snippet(&'ast self, span: &Span<'ast>) -> Option<&'ast str>;
+    fn span_snippet(&'ast self, span: &Span<'_>) -> Option<&'ast str>;
+    fn span_source(&'ast self, span: &Span<'_>) -> SpanSource<'ast>;
+    fn span_expn_info(&'ast self, expn_id: ExpnId) -> Option<&'ast ExpnInfo<'ast>>;
+    fn span_pos_to_file_loc(&'ast self, file: &FileInfo<'ast>, pos: SpanPos) -> Option<FilePos<'ast>>;
     fn symbol_str(&'ast self, api_id: SymbolId) -> &'ast str;
     fn resolve_method_target(&'ast self, id: ExprId) -> ItemId;
 }

--- a/marker_api/src/ast/common/id.rs
+++ b/marker_api/src/ast/common/id.rs
@@ -70,7 +70,7 @@ new_id! {
 }
 
 new_id! {
-    /// This ID uniquely identifies a user defined type during linting.
+    /// This ID uniquely identifies a macro during linting.
     pub MacroId: u64
 }
 

--- a/marker_api/src/ast/common/id.rs
+++ b/marker_api/src/ast/common/id.rs
@@ -125,6 +125,15 @@ new_id! {
 new_id! {
     /// **Unstable**
     ///
+    /// This id is used to identify a specific expansion. This type is only intended for internal
+    /// use. For now it's only intended for drivers to map spans back
+    #[cfg_attr(feature = "driver-api", visibility::make(pub))]
+    pub(crate) ExpnId: u64
+}
+
+new_id! {
+    /// **Unstable**
+    ///
     /// This id is used to identify symbols. This type is only intended for internal
     /// use. Lint crates should always get [`String`] or `&str`.
     #[cfg_attr(feature = "driver-api", visibility::make(pub))]

--- a/marker_api/src/ast/common/id.rs
+++ b/marker_api/src/ast/common/id.rs
@@ -70,6 +70,11 @@ new_id! {
 }
 
 new_id! {
+    /// This ID uniquely identifies a user defined type during linting.
+    pub MacroId: u64
+}
+
+new_id! {
     /// This ID uniquely identifies a body during linting.
     pub BodyId: u64
 }

--- a/marker_api/src/ast/common/span.rs
+++ b/marker_api/src/ast/common/span.rs
@@ -2,7 +2,175 @@ use std::marker::PhantomData;
 
 use crate::{context::with_cx, diagnostic::Applicability, ffi};
 
-use super::{SpanId, SpanSrcId, SymbolId};
+use super::{MacroId, SpanId, SpanSrcId, SymbolId};
+
+/// A byte position used for the start and end position of [`Span`]s.
+///
+/// This position can map to a source file or a virtual space, when it comes
+/// from the expansion of a macro. It's expected that a [`SpanPos`] always
+/// points to the start of a character. Indexing to the middle of a multi byte
+/// character can result in panics.
+///
+/// The start [`SpanPos`] doesn't have to start at zero, the order can be decided
+/// by the driver. A [`Span`] should always use [`SpanPos`] from the same span source.
+///
+/// **Stability notice**:
+/// * The position may not be stable between different sessions.
+/// * [`SpanPos`] should never be stored by lint crates, as drivers might change [`SpanPos`] between
+///   different `check_*` function calls.
+/// * The layout and size of this type might change. The type will continue to provide the current
+///   trait implementations.
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SpanPos(
+    /// Rustc only uses u32, therefore it should be safe to do the same. This
+    /// allows crates to have a total span size of ~4 GB (with expanded macros).
+    /// That sounds reasonable :D
+    u32,
+);
+
+#[cfg(feature = "driver-api")]
+impl SpanPos {
+    pub fn new(index: u32) -> Self {
+        Self(index)
+    }
+
+    pub fn index(self) -> u32 {
+        self.0
+    }
+}
+
+/// Information about a specific expansion.
+///
+/// [`Span`]s in Rust are structured in layers. The root layer is the source code
+/// written in a source file. Macros can be expanded to AST nodes with [`Span`]s.
+/// These are then added as a new layer, on top of the root. This struct provides
+/// the information about one expansion layer.
+///
+/// ### Simple Macro Rules
+///
+/// ```
+/// macro_rules! ex1 {
+///     () => {
+///         1 + 1
+///     };
+/// }
+///
+/// ex1!();
+/// ```
+///
+/// In this example `ex1!()` expands into the expression `1 + 1`. The [`Span`]
+/// of the binary expression and numbers will all be from an expansion. Snipping the
+/// [`Span`] of the binary expression would return `1 + 1` from inside the macro rules.
+///
+/// ### Macro Rules with Parameters
+///
+/// ```
+/// macro_rules! ex2 {
+///     ($a:literal, $b:literal) => {
+///         $a + $b
+///     };
+/// }
+///
+/// ex2!(1, 2);
+/// ```
+///
+/// In this example `ex2!(1, 2)` expands into the expression `1 + 2`. The [`Span`]
+/// of the binary expression is marked to come from the expansion of a macro.
+/// The `1` and `2` literals are marked as coming from the root layer, since
+/// they're actually written in the source file.
+///
+/// ### Macros Invoking Macros
+///
+/// ```
+/// macro_rules! ex3a {
+///     ($a:literal, $b:literal) => {
+///         $a + $b
+///     };
+/// }
+/// macro_rules! ex3b {
+///     ($a:literal) => {
+///         ex3a!($a, 3)
+///     };
+/// }
+///
+/// ex3b!(2);
+/// ```
+///
+/// In this example `ex3b!(2)` expands to `ex3a(2, 3)` which in turn expands to
+/// `2 + 3`. This expansion has three layers, first the root, which contains the
+/// `ex3b!(2)` call. The next layer is the `ex3a!(2, 3)` call. The binary expression
+/// comes from the third layer, the number 3 from the second, and the number 2 from
+/// the root layer, since this one was actually written by the user.
+///
+/// ### Macros Creating Macros
+///
+/// ```
+/// macro_rules! ex4a {
+///     () => {
+///         macro_rules! ex4b {
+///             () => {
+///                 4 + 4
+///             };
+///         }
+///     };
+/// }
+///
+/// ex4a!();
+/// ex4b!();
+/// ```
+///
+/// This example expands `ex4a` into a new `ex4b` macro, which in turn expands
+/// into a `4 + 4` expression. The [`Span`] of the binary expression has three
+/// layers. First the root layer calling the `ex4b` macro, this would then
+/// expand to the `4 + 4` expression, which actually comes from the `ex4a` expansion.
+///
+/// ### Proc Macros
+///
+/// Proc macros and some built-in macros are different from `macro_rules!` macros as
+/// they are opaque to the driver. It's just known that some tokens are provided as an
+/// input and somehow expanded. The [`Span`]s of the expanded tokens are marked as
+/// coming from an expansion by default. However, macro crates can sometimes override
+/// this with some trickery. (Please use this forbidden knowledge carefully.)
+#[repr(C)]
+#[derive(Debug)]
+pub struct ExpnInfo<'ast> {
+    _lifetime: PhantomData<&'ast ()>,
+    parent: SpanSrcId,
+    call_site: SpanId,
+    macro_id: MacroId,
+}
+
+impl<'ast> ExpnInfo<'ast> {
+    #[must_use]
+    pub fn parent(&self) -> Option<&ExpnInfo<'ast>> {
+        // TODO(xFrednet): Request info from Driver
+        todo!()
+    }
+
+    /// The [`Span`] that invoked the macro, that this expansion belongs to.
+    #[must_use]
+    pub fn call_site(&self) -> &Span<'ast> {
+        with_cx(self, |cx| cx.span(self.call_site))
+    }
+
+    pub fn macro_id(&self) -> MacroId {
+        self.macro_id
+    }
+}
+
+#[cfg(feature = "driver-api")]
+impl<'ast> ExpnInfo<'ast> {
+    #[must_use]
+    pub fn new(parent: SpanSrcId, call_site: SpanId, macro_id: MacroId) -> Self {
+        Self {
+            _lifetime: PhantomData,
+            parent,
+            call_site,
+            macro_id,
+        }
+    }
+}
 
 // FIXME(xFrednet): This enum is "limited" to say it lightly, it should contain
 // the more information about macros and their expansion etc. This covers the
@@ -11,7 +179,6 @@ use super::{SpanId, SpanSrcId, SymbolId};
 //
 // See: rust-marker/marker#175
 #[repr(C)]
-#[doc(hidden)]
 #[allow(clippy::exhaustive_enums)]
 #[derive(Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "driver-api", visibility::make(pub))]
@@ -22,112 +189,194 @@ enum SpanSource<'ast> {
     Macro(SpanSrcId),
     /// The span belongs to a file, but is the result of desugaring, they should
     /// be handled like normal files. This is variant mostly important for the driver.
+    // FIXME(xFrednet): All desugars are usually resugared by Marker, the driver should
+    // pass the span of the original sugared expression to the API.
     Sugar(ffi::FfiStr<'ast>, SpanSrcId),
 }
 
+/// A region of code, used for snipping, lint emission, and the retrieval of
+/// context information.
+///
+/// [`Span`]s provide context information, like the file location or macro expansion
+/// that created this span. [`SpanPos`] values from different sources or files should
+/// not be mixed. Check out the documentation of [`SpanPos`] for more information.
+///
+/// [`Span`]s don't provide any way to map back to the AST nodes, that they
+/// belonged to. If you require this information, consider passing the nodes
+/// instead or alongside the [`Span`].
+///
+/// [`Span`]s with invalid positions in the `start` or `end` value can cause panics
+/// in the driver. Please handle them with care, and also consider that UTF-8 allows
+/// multiple bytes per character. Instances provided by the API or driver directly,
+/// are always valid.
+///
+/// Handling macros during linting can be difficult, generally it's advised to
+/// abort, if the code originates from a macro. The API provides an automatic way
+/// by setting the [`MacroReport`][crate::lint::MacroReport] value during lint
+/// creation. If your lint is targeting code from macro expansions, please
+/// consider that users might not be able to influence the generated code. It's
+/// also worth checking that all linted nodes originate from the same macro expansion.
+/// Check out the documentation of [`ExpnInfo`].
 #[repr(C)]
 #[derive(Debug, Clone)]
 pub struct Span<'ast> {
-    source: &'ast SpanSource<'ast>,
-    /// The start marks the first byte in the [`SpanSource`] that is included in this
-    /// span. The span continues until the end position.
-    start: usize,
-    end: usize,
+    _lifetime: PhantomData<&'ast ()>,
+    /// The source of this [`Span`]. The id space and position distribution is
+    /// decided by the driver. To get the full source information it might be
+    /// necessary to also pass the start and end position to the driver.
+    source: SpanSrcId,
+    /// This information could also be retrieved, by requesting the [`ExpnInfo`]
+    /// of this span. However, from looking at Clippy and rustc lints, it looks
+    /// like the main interested is, if this comes from a macro expansion, not from
+    /// which one. Having this boolean flag will be sufficient to answer this simple
+    /// question and will save on extra [`SpanSrcId`] mappings.
+    from_expansion: bool,
+    start: SpanPos,
+    end: SpanPos,
 }
 
 impl<'ast> Span<'ast> {
-    pub fn is_from_file(&self) -> bool {
-        matches!(self.source, SpanSource::File(..) | SpanSource::Sugar(..))
+    /// Returns `true`, if this [`Span`] comes from a macro expansion.
+    pub fn is_from_expansion(&self) -> bool {
+        self.from_expansion
     }
 
-    pub fn is_from_macro(&self) -> bool {
-        matches!(self.source, SpanSource::Macro(..))
+    /// Returns the code snippet that this [`Span`] refers to or [`None`] if the
+    /// snippet is unavailable.
+    ///
+    /// ```ignore
+    /// let variable = 15_000;
+    /// //             ^^^^^^
+    /// //             lit_span
+    ///
+    /// lit_span.snippet(); // -> Some("15_000")
+    /// ```
+    ///
+    /// There are several reasons, why a snippet might be unavailable. Also
+    /// depend on the used driver. You can also checkout the other snippet
+    /// methods to better deal with these cases:
+    /// * [`snippet_or`](Self::snippet_or)
+    /// * [`snippet_with_applicability`](Self::snippet_with_applicability)
+    #[must_use]
+    pub fn snippet(&self) -> Option<&'ast str> {
+        with_cx(self, |cx| cx.span_snipped(self))
+    }
+
+    /// Returns the code snippet that this [`Span`] refers to or the given default
+    /// if the snippet is unavailable.
+    ///
+    /// For placeholders, it's recommended to use angle brackets with information
+    /// should be filled out. For example, if you want to snip an expression, you
+    /// should use `<expr>` as the default value.
+    ///
+    /// If you're planning to use this snippet in a suggestion, consider using
+    /// [`snippet_with_applicability`](Self::snippet_with_applicability) instead.
+    pub fn snippet_or(&self, default: &str) -> String {
+        self.snippet().unwrap_or(default).to_string()
+    }
+
+    /// Adjusts the given [`Applicability`] according to the context and returns the
+    /// code snippet that this [`Span`] refers to or the given default if the
+    /// snippet is unavailable.
+    ///
+    /// For the placeholder, it's recommended to use angle brackets with information
+    /// should be filled out. A placeholder for an expression should look like
+    /// this: `<expr>`
+    ///
+    /// The applicability will never be upgraded by this method. When you draft
+    /// suggestions, you'll generally start with the highest [`Applicability`]
+    /// your suggestion should have, and then use it with this snippet function
+    /// to adjust it accordingly. The applicability is then used to submit the
+    /// suggestion to the driver.
+    pub fn snippet_with_applicability(&self, placeholder: &str, applicability: &mut Applicability) -> String {
+        if *applicability != Applicability::Unspecified && self.is_from_expansion() {
+            *applicability = Applicability::MaybeIncorrect;
+        }
+        self.snippet()
+            .unwrap_or_else(|| {
+                if matches!(
+                    *applicability,
+                    Applicability::MachineApplicable | Applicability::MaybeIncorrect
+                ) {
+                    *applicability = Applicability::HasPlaceholders;
+                }
+                placeholder
+            })
+            .to_string()
+    }
+
+    /// Returns the length of the this [`Span`] in bytes.
+    pub fn len(&self) -> usize {
+        (self.start.0 - self.end.0)
+            .try_into()
+            .expect("Marker is not compiled for usize::BITs < 32")
     }
 
     /// Returns `true` if the span has a length of 0. This means that no bytes are
     /// inside the span.
     pub fn is_empty(&self) -> bool {
-        self.start == self.end
+        self.len() == 0
     }
 
-    /// Returns true, if both spans originate from the same source. For example, this can be the
-    /// same source file or macro expansion.
-    pub fn is_same_source(&self, other: &Span<'ast>) -> bool {
-        self.source == other.source
-    }
-
-    pub fn start(&self) -> usize {
+    /// Returns the start position of this [`Span`].
+    pub fn start(&self) -> SpanPos {
         self.start
     }
 
-    pub fn set_start(&mut self, start: usize) {
+    /// Sets the start position of this [`Span`].
+    pub fn set_start(&mut self, start: SpanPos) {
+        assert!(
+            start.0 <= self.end.0,
+            "the start position should always be <= of the end position"
+        );
         self.start = start;
     }
 
-    pub fn end(&self) -> usize {
+    /// Returns a new [`Span`] with the given start position.
+    #[must_use]
+    pub fn with_start(&self, start: SpanPos) -> Span<'ast> {
+        let mut new_span = self.clone();
+        new_span.set_start(start);
+        new_span
+    }
+
+    /// Returns the end position of this [`Span`].
+    pub fn end(&self) -> SpanPos {
         self.end
     }
 
-    pub fn set_end(&mut self, end: usize) {
+    /// Sets the end position of this [`Span`].
+    pub fn set_end(&mut self, end: SpanPos) {
+        assert!(
+            self.start.0 <= end.0,
+            "the start position should always be >= of the end position"
+        );
         self.end = end;
     }
 
-    /// Returns the code that this span references or [`None`] if the code is unavailable.
-    pub fn snippet(&self) -> Option<String> {
-        with_cx(self, |cx| cx.span_snipped(self))
-    }
-
-    /// Converts a span to a code snippet if available, otherwise returns the default.
-    ///
-    /// This is useful if you want to provide suggestions for your lint or more generally, if you
-    /// want to convert a given [`Span`] to a [`String`]. To create suggestions consider using
-    /// [`snippet_with_applicability()`](`Self::snippet_with_applicability`) to ensure that the
-    /// [`Applicability`] stays correct.
-    ///
-    /// # Example
-    /// ```rust,ignore
-    /// // Given two spans one for `value` and one for the `init` expression.
-    /// let value = Vec::new();
-    /// //  ^^^^^   ^^^^^^^^^^
-    /// //  span1   span2
-    ///
-    /// // The snipped call would return the corresponding code snippets
-    /// span1.snippet_or("..") // -> "value"
-    /// span2.snippet_or("..") // -> "Vec::new()"
-    /// ```
-    pub fn snippet_or(&self, default: &str) -> String {
-        self.snippet().unwrap_or_else(|| default.to_string())
-    }
-
-    /// Same as [`snippet()`](`Self::snippet`), but adapts the applicability level by following
-    /// rules:
-    ///
-    /// - Applicability level [`Unspecified`](`Applicability::Unspecified`) will never be changed.
-    /// - If the span is inside a macro, change the applicability level to
-    ///   [`MaybeIncorrect`](`Applicability::MaybeIncorrect`).
-    /// - If the default value is used and the applicability level is
-    ///   [`MachineApplicable`](`Applicability::MachineApplicable`), change it to
-    ///   [`HasPlaceholders`](`Applicability::HasPlaceholders`)
-    pub fn snippet_with_applicability(&self, default: &str, applicability: &mut Applicability) -> String {
-        if *applicability != Applicability::Unspecified && self.is_from_macro() {
-            *applicability = Applicability::MaybeIncorrect;
-        }
-        self.snippet().unwrap_or_else(|| {
-            if *applicability == Applicability::MachineApplicable {
-                *applicability = Applicability::HasPlaceholders;
-            }
-            default.to_string()
-        })
+    /// Returns a new [`Span`] with the given end position.
+    #[must_use]
+    pub fn with_end(&self, end: SpanPos) -> Span<'ast> {
+        let mut new_span = self.clone();
+        new_span.set_end(end);
+        new_span
     }
 }
 
 #[cfg(feature = "driver-api")]
 impl<'ast> Span<'ast> {
-    pub fn new(source: &'ast SpanSource<'ast>, start: usize, end: usize) -> Self {
-        Self { source, start, end }
+    #[must_use]
+    pub fn new(source: SpanSrcId, from_expansion: bool, start: SpanPos, end: SpanPos) -> Self {
+        Self {
+            _lifetime: PhantomData,
+            source,
+            from_expansion,
+            start,
+            end,
+        }
     }
 
-    pub fn source(&self) -> &'ast SpanSource<'ast> {
+    pub fn source_id(&self) -> SpanSrcId {
         self.source
     }
 }

--- a/marker_api/src/context.rs
+++ b/marker_api/src/context.rs
@@ -190,7 +190,7 @@ impl<'ast> AstContext<'ast> {
     pub(crate) fn span_snipped(&self, span: &Span<'ast>) -> Option<&'ast str> {
         (self.driver.span_snippet)(self.driver.driver_context, span)
             .get()
-            .map(|s| s.get())
+            .map(ffi::FfiStr::get)
     }
 
     pub(crate) fn span(&self, span_id: SpanId) -> &'ast Span<'ast> {

--- a/marker_rustc_driver/src/context.rs
+++ b/marker_rustc_driver/src/context.rs
@@ -53,7 +53,7 @@ impl<'ast, 'tcx> RustcContext<'ast, 'tcx> {
             lint_store,
             storage,
             marker_converter: MarkerConverter::new(rustc_cx, storage),
-            rustc_converter: RustcConverter::new(rustc_cx, storage),
+            rustc_converter: RustcConverter::new(rustc_cx),
             ast_cx: OnceCell::new(),
             resolved_ty_ids: RefCell::default(),
         });

--- a/marker_rustc_driver/src/context.rs
+++ b/marker_rustc_driver/src/context.rs
@@ -219,10 +219,28 @@ impl<'ast, 'tcx: 'ast> DriverContext<'ast> for RustcContext<'ast, 'tcx> {
         self.storage.alloc(self.marker_converter.to_span(rustc_span))
     }
 
-    fn span_snippet(&self, api_span: &Span<'ast>) -> Option<&'ast str> {
+    fn span_snippet(&self, api_span: &Span<'_>) -> Option<&'ast str> {
         let rust_span = self.rustc_converter.to_span(api_span);
         let snippet = self.rustc_cx.sess.source_map().span_to_snippet(rust_span).ok()?;
         Some(self.storage.alloc_str(&snippet))
+    }
+
+    fn span_source(&'ast self, api_span: &Span<'_>) -> marker_api::ast::SpanSource<'ast> {
+        let rust_span = self.rustc_converter.to_span(api_span);
+        self.marker_converter.to_span_source(rust_span)
+    }
+
+    fn span_pos_to_file_loc(
+        &'ast self,
+        _file: &marker_api::ast::FileInfo<'ast>,
+        _pos: marker_api::ast::SpanPos,
+    ) -> Option<marker_api::ast::FilePos<'ast>> {
+        todo!()
+    }
+
+    fn span_expn_info(&'ast self, expn_id: marker_api::ast::ExpnId) -> Option<&'ast marker_api::ast::ExpnInfo<'ast>> {
+        let id = self.rustc_converter.to_expn_id(expn_id);
+        self.marker_converter.try_to_expn_info(id)
     }
 
     fn symbol_str(&'ast self, api_id: SymbolId) -> &'ast str {

--- a/marker_rustc_driver/src/context.rs
+++ b/marker_rustc_driver/src/context.rs
@@ -232,10 +232,13 @@ impl<'ast, 'tcx: 'ast> DriverContext<'ast> for RustcContext<'ast, 'tcx> {
 
     fn span_pos_to_file_loc(
         &'ast self,
-        _file: &marker_api::ast::FileInfo<'ast>,
-        _pos: marker_api::ast::SpanPos,
+        file: &marker_api::ast::FileInfo<'ast>,
+        pos: marker_api::ast::SpanPos,
     ) -> Option<marker_api::ast::FilePos<'ast>> {
-        todo!()
+        self.marker_converter.try_to_span_pos(
+            self.rustc_converter.to_syntax_context(file.span_src()),
+            self.rustc_converter.to_byte_pos(pos),
+        )
     }
 
     fn span_expn_info(&'ast self, expn_id: marker_api::ast::ExpnId) -> Option<&'ast marker_api::ast::ExpnInfo<'ast>> {

--- a/marker_rustc_driver/src/context/storage.rs
+++ b/marker_rustc_driver/src/context/storage.rs
@@ -3,8 +3,10 @@ use std::marker::PhantomData;
 use bumpalo::Bump;
 
 pub struct Storage<'ast> {
-    /// The `'ast` lifetime is bound by the `buffer` field. Having it as a parameter
-    /// makes it easier to declare it in the return of functions
+    /// The `'ast` lifetime is the lifetime of the `buffer` field.
+    ///
+    /// Having it as an explicit parameter allows us to later add fields to cache
+    /// values.
     _lifetime: PhantomData<&'ast ()>,
     buffer: Bump,
 }

--- a/marker_rustc_driver/src/context/storage.rs
+++ b/marker_rustc_driver/src/context/storage.rs
@@ -1,21 +1,19 @@
-use std::cell::RefCell;
+use std::marker::PhantomData;
 
 use bumpalo::Bump;
-use marker_api::ast::SpanSource;
-use rustc_hash::FxHashMap;
-
-use crate::conversion::common::SpanSourceInfo;
 
 pub struct Storage<'ast> {
+    /// The `'ast` lifetime is bound by the `buffer` field. Having it as a parameter
+    /// makes it easier to declare it in the return of functions
+    _lifetime: PhantomData<&'ast ()>,
     buffer: Bump,
-    span_src_info: RefCell<FxHashMap<&'ast SpanSource<'ast>, (&'ast SpanSource<'ast>, SpanSourceInfo)>>,
 }
 
 impl<'ast> Default for Storage<'ast> {
     fn default() -> Self {
         Self {
+            _lifetime: PhantomData,
             buffer: Bump::new(),
-            span_src_info: RefCell::default(),
         }
     }
 }
@@ -38,37 +36,5 @@ impl<'ast> Storage<'ast> {
     #[must_use]
     pub fn alloc_str(&'ast self, value: &str) -> &'ast str {
         self.buffer.alloc_str(value)
-    }
-}
-
-impl<'ast> Storage<'ast> {
-    pub fn get_span_src_info<'a>(
-        &'ast self,
-        api_src: &'a SpanSource<'a>,
-    ) -> Option<(&'ast SpanSource<'ast>, SpanSourceInfo)> {
-        self.span_src_info.borrow().get(api_src).copied()
-    }
-
-    pub fn insert_span_src_info(
-        &'ast self,
-        api_src: &SpanSource<'_>,
-        src_info: SpanSourceInfo,
-    ) -> (&'ast SpanSource<'ast>, SpanSourceInfo) {
-        let alloc_api_src = self.alloc(match api_src {
-            SpanSource::File(name) => SpanSource::File(self.alloc_str(name.get()).into()),
-            SpanSource::Macro(id) => SpanSource::Macro(*id),
-            SpanSource::Sugar(name, id) => SpanSource::Sugar(self.alloc_str(name.get()).into(), *id),
-        });
-
-        let prev_item = self
-            .span_src_info
-            .borrow_mut()
-            .insert(alloc_api_src, (alloc_api_src, src_info));
-        debug_assert!(
-            prev_item.is_none(),
-            "`SpanSourceInfo`s should never be mapped and inserted twice"
-        );
-
-        (alloc_api_src, src_info)
     }
 }

--- a/marker_rustc_driver/src/conversion/common.rs
+++ b/marker_rustc_driver/src/conversion/common.rs
@@ -27,6 +27,12 @@ pub struct HirIdLayout {
     pub index: u32,
 }
 
+#[repr(C)]
+pub struct ExpnIdLayout {
+    pub krate: u32,
+    pub index: u32,
+}
+
 #[macro_export]
 macro_rules! transmute_id {
     ($t1:ty as $t2:ty = $e:expr) => {

--- a/marker_rustc_driver/src/conversion/common.rs
+++ b/marker_rustc_driver/src/conversion/common.rs
@@ -27,12 +27,6 @@ pub struct HirIdLayout {
     pub index: u32,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct SpanSourceInfo {
-    pub rustc_span_cx: rustc_span::hygiene::SyntaxContext,
-    pub rustc_start_offset: usize,
-}
-
 #[macro_export]
 macro_rules! transmute_id {
     ($t1:ty as $t2:ty = $e:expr) => {

--- a/marker_rustc_driver/src/conversion/marker.rs
+++ b/marker_rustc_driver/src/conversion/marker.rs
@@ -19,7 +19,7 @@ use marker_api::{
         expr::ExprKind,
         item::{Body, ItemKind},
         ty::SemTyKind,
-        BodyId, Crate, ExprId, ItemId, Span, SymbolId, TyDefId,
+        BodyId, Crate, ExpnInfo, ExprId, ItemId, Span, SpanSource, SymbolId, TyDefId,
     },
     lint::Level,
 };
@@ -76,6 +76,8 @@ impl<'ast, 'tcx> MarkerConverter<'ast, 'tcx> {
     forward_to_inner!(pub fn to_body(&self, body: &hir::Body<'tcx>) -> &'ast Body<'ast>);
     forward_to_inner!(pub fn to_ty_def_id(&self, id: hir::def_id::DefId) -> TyDefId);
     forward_to_inner!(pub fn to_span(&self, rustc_span: rustc_span::Span) -> Span<'ast>);
+    forward_to_inner!(pub fn to_span_source(&self, rust_span: rustc_span::Span) -> SpanSource<'ast>);
+    forward_to_inner!(pub fn try_to_expn_info(&self, expn_id: rustc_span::ExpnId) -> Option<&'ast ExpnInfo<'ast>>);
     forward_to_inner!(pub fn to_crate(
         &self,
         rustc_crate_id: hir::def_id::CrateNum,

--- a/marker_rustc_driver/src/conversion/marker.rs
+++ b/marker_rustc_driver/src/conversion/marker.rs
@@ -19,7 +19,7 @@ use marker_api::{
         expr::ExprKind,
         item::{Body, ItemKind},
         ty::SemTyKind,
-        BodyId, Crate, ExpnInfo, ExprId, ItemId, Span, SpanSource, SymbolId, TyDefId,
+        BodyId, Crate, ExpnInfo, ExprId, FilePos, ItemId, Span, SpanSource, SymbolId, TyDefId,
     },
     lint::Level,
 };
@@ -78,6 +78,11 @@ impl<'ast, 'tcx> MarkerConverter<'ast, 'tcx> {
     forward_to_inner!(pub fn to_span(&self, rustc_span: rustc_span::Span) -> Span<'ast>);
     forward_to_inner!(pub fn to_span_source(&self, rust_span: rustc_span::Span) -> SpanSource<'ast>);
     forward_to_inner!(pub fn try_to_expn_info(&self, expn_id: rustc_span::ExpnId) -> Option<&'ast ExpnInfo<'ast>>);
+    forward_to_inner!(pub fn try_to_span_pos(
+        &self,
+        scx: rustc_span::SyntaxContext,
+        pos: rustc_span::BytePos,
+    ) -> Option<FilePos<'ast>>);
     forward_to_inner!(pub fn to_crate(
         &self,
         rustc_crate_id: hir::def_id::CrateNum,

--- a/marker_rustc_driver/src/conversion/marker/common.rs
+++ b/marker_rustc_driver/src/conversion/marker/common.rs
@@ -3,14 +3,14 @@ use std::mem::{size_of, transmute};
 use marker_api::ast::generic::SynGenericArgs;
 use marker_api::ast::ty::SynTyKind;
 use marker_api::ast::{
-    Abi, AstPath, AstPathSegment, AstPathTarget, AstQPath, BodyId, Constness, CrateId, ExprId, FieldId, GenericId,
-    Ident, ItemId, LetStmtId, Mutability, Safety, SpanId, SpanSrcId, SymbolId, Syncness, TraitRef, TyDefId, VarId,
-    VariantId,
+    Abi, AstPath, AstPathSegment, AstPathTarget, AstQPath, BodyId, Constness, CrateId, ExpnId, ExprId, FieldId,
+    GenericId, Ident, ItemId, LetStmtId, MacroId, Mutability, Safety, SpanId, SpanSrcId, SymbolId, Syncness, TraitRef,
+    TyDefId, VarId, VariantId,
 };
 use marker_api::lint::Level;
 use rustc_hir as hir;
 
-use crate::conversion::common::{BodyIdLayout, DefIdLayout, HirIdLayout};
+use crate::conversion::common::{BodyIdLayout, DefIdLayout, ExpnIdLayout, HirIdLayout};
 use crate::transmute_id;
 
 use super::MarkerConverterInner;
@@ -108,6 +108,21 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     #[must_use]
     pub fn to_field_id(&self, id: impl Into<HirIdLayout>) -> FieldId {
         transmute_id!(HirIdLayout as FieldId = id.into())
+    }
+
+    #[must_use]
+    pub fn to_macro_id(&self, id: impl Into<DefIdLayout>) -> MacroId {
+        transmute_id!(DefIdLayout as MacroId = id.into())
+    }
+
+    #[must_use]
+    pub fn to_expn_id(&self, id: rustc_span::ExpnId) -> ExpnId {
+        transmute_id!(
+            ExpnIdLayout as ExpnId = ExpnIdLayout {
+                krate: id.krate.as_u32(),
+                index: id.local_id.as_u32(),
+            }
+        )
     }
 
     #[must_use]

--- a/marker_rustc_driver/src/conversion/marker/common.rs
+++ b/marker_rustc_driver/src/conversion/marker/common.rs
@@ -74,6 +74,15 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     }
 
     #[must_use]
+    pub fn to_resugared_span_id(&self, rustc_span: rustc_span::Span) -> SpanId {
+        if let Some(source_data) = rustc_span.source_callee() {
+            self.to_span_id(source_data.call_site)
+        } else {
+            panic!("driver requested resugared id for an unsugared span: {rustc_span:#?}");
+        }
+    }
+
+    #[must_use]
     pub fn to_symbol_id(&self, sym: rustc_span::Symbol) -> SymbolId {
         assert_eq!(size_of::<SymbolId>(), 4);
         SymbolId::new(sym.as_u32())

--- a/marker_rustc_driver/src/conversion/marker/common.rs
+++ b/marker_rustc_driver/src/conversion/marker/common.rs
@@ -4,16 +4,19 @@ use marker_api::ast::generic::SynGenericArgs;
 use marker_api::ast::ty::SynTyKind;
 use marker_api::ast::{
     Abi, AstPath, AstPathSegment, AstPathTarget, AstQPath, BodyId, Constness, CrateId, ExprId, FieldId, GenericId,
-    Ident, ItemId, LetStmtId, Mutability, Safety, Span, SpanId, SpanSource, SpanSrcId, SymbolId, Syncness, TraitRef,
-    TyDefId, VarId, VariantId,
+    Ident, ItemId, LetStmtId, Mutability, Safety, SpanId, SpanSrcId, SymbolId, Syncness, TraitRef, TyDefId, VarId,
+    VariantId,
 };
 use marker_api::lint::Level;
 use rustc_hir as hir;
 
-use crate::conversion::common::{BodyIdLayout, DefIdLayout, HirIdLayout, SpanSourceInfo};
+use crate::conversion::common::{BodyIdLayout, DefIdLayout, HirIdLayout};
 use crate::transmute_id;
 
 use super::MarkerConverterInner;
+
+mod span;
+pub use span::*;
 
 impl From<hir::def_id::LocalDefId> for DefIdLayout {
     fn from(value: hir::def_id::LocalDefId) -> Self {
@@ -134,6 +137,11 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
 
     #[must_use]
     pub fn to_span_src_id(&self, id: rustc_span::SyntaxContext) -> SpanSrcId {
+        // FIXME(xFrednet): This conversion is theoretically unsound, since
+        // `SyntaxContext` doesn't have a defined `#[repr(..)]`. Rustc sadly
+        // limits the direct access to the wrapped `u32`. Since the struct only
+        // wraps a single field, it'll most likely be safe enough, to do this
+        // transmute and expect the type to always be 32 bits long.
         transmute_id!(rustc_span::SyntaxContext as SpanSrcId = id)
     }
 }
@@ -390,81 +398,5 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
             _ => unreachable!("reached `PolyTraitRef` which can't be translated {trait_ref:#?}"),
         };
         TraitRef::new(trait_id, self.to_syn_generic_args_from_path(trait_ref.path))
-    }
-
-    pub fn to_span(&self, rustc_span: rustc_span::Span) -> Span<'ast> {
-        let ((src, src_info), span) = self.to_span_info(rustc_span);
-        let start = (span.lo().0 as usize) - src_info.rustc_start_offset;
-        let end = (span.hi().0 as usize) - src_info.rustc_start_offset;
-        Span::new(src, start, end)
-    }
-
-    fn to_span_info(
-        &self,
-        rustc_span: rustc_span::Span,
-    ) -> ((&'ast SpanSource<'ast>, SpanSourceInfo), rustc_span::Span) {
-        fn file_info(rustc_cx: rustc_middle::ty::TyCtxt<'_>, span: rustc_span::Span) -> (String, usize) {
-            let map = rustc_cx.sess.source_map();
-            let rustc_src = map.lookup_source_file(span.lo());
-            let name = if let rustc_span::FileName::Real(
-                rustc_span::RealFileName::LocalPath(path)
-                | rustc_span::RealFileName::Remapped { virtual_name: path, .. },
-            ) = &rustc_src.name
-            {
-                path.to_string_lossy().to_string()
-            } else {
-                unreachable!("spans which don't come from from expansion always belong to a file")
-            };
-
-            let offset = rustc_src.start_pos.0 as usize;
-            (name, offset)
-        }
-
-        let syn_cx = rustc_span.ctxt();
-        if !rustc_span.from_expansion() {
-            // This is a normal source file
-            let (name, offset) = file_info(self.rustc_cx, rustc_span);
-
-            // Check Marker's cache
-            let api_hash_source = SpanSource::File((&name).into());
-            if let Some(span_info) = self.storage.get_span_src_info(&api_hash_source) {
-                return (span_info, rustc_span);
-            }
-
-            // Create and insert data
-            let api_info = SpanSourceInfo {
-                rustc_span_cx: syn_cx,
-                rustc_start_offset: offset,
-            };
-
-            (
-                self.storage.insert_span_src_info(&api_hash_source, api_info),
-                rustc_span,
-            )
-        } else if let Some(expansion_data) = rustc_span.source_callee() {
-            // This span comes from a macro or other desugared magic.
-            let sugar_file_name: String;
-            let api_hash_source = if matches!(expansion_data.kind, rustc_span::ExpnKind::Macro(..)) {
-                SpanSource::Macro(self.to_span_src_id(syn_cx))
-            } else {
-                (sugar_file_name, _) = file_info(self.rustc_cx, rustc_span);
-                SpanSource::Sugar((&sugar_file_name).into(), self.to_span_src_id(syn_cx))
-            };
-            if let Some(span_info) = self.storage.get_span_src_info(&api_hash_source) {
-                return (span_info, expansion_data.call_site);
-            }
-
-            let api_info = SpanSourceInfo {
-                rustc_span_cx: syn_cx,
-                rustc_start_offset: expansion_data.call_site.lo().0 as usize,
-            };
-
-            (
-                self.storage.insert_span_src_info(&api_hash_source, api_info),
-                expansion_data.call_site,
-            )
-        } else {
-            unreachable!("the api should only receive and request spans from files and macros")
-        }
     }
 }

--- a/marker_rustc_driver/src/conversion/marker/common/span.rs
+++ b/marker_rustc_driver/src/conversion/marker/common/span.rs
@@ -25,23 +25,18 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
         let ctxt = rust_span.ctxt();
         if ctxt.is_root() {
             let src_file = self.rustc_cx.sess.source_map().lookup_source_file(rust_span.lo());
-            let name;
-            match &src_file.name {
+            let name = match &src_file.name {
                 rustc_span::FileName::Real(
                     rustc_span::RealFileName::LocalPath(file_path)
                     | rustc_span::RealFileName::Remapped {
                         virtual_name: file_path,
                         ..
                     },
-                ) => {
-                    name = file_path.to_string_lossy().to_string();
-                },
+                ) => file_path.to_string_lossy().to_string(),
                 _ => {
-                    name = format!(
-                        "MarkerConverter::to_span_source(): Unexpected file name: {rust_span:#?} -> {src_file:#?}"
-                    );
+                    format!("MarkerConverter::to_span_source(): Unexpected file name: {rust_span:#?} -> {src_file:#?}")
                 },
-            }
+            };
             SpanSource::File(self.alloc(FileInfo::new(self.storage.alloc_str(&name), self.to_span_src_id(ctxt))))
         } else {
             SpanSource::Macro(self.alloc(self.to_expn_info(&ctxt.outer_expn_data())))

--- a/marker_rustc_driver/src/conversion/marker/common/span.rs
+++ b/marker_rustc_driver/src/conversion/marker/common/span.rs
@@ -1,0 +1,20 @@
+use marker_api::{ast::SpanPos, prelude::Span};
+
+use crate::conversion::marker::MarkerConverterInner;
+
+impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
+    pub fn to_span(&self, rustc_span: rustc_span::Span) -> Span<'ast> {
+        Span::new(
+            self.to_span_src_id(rustc_span.ctxt()),
+            // The driver resugars all expressions and spans, this should therefore
+            // only be true for spans from macro expansion.
+            rustc_span.from_expansion(),
+            self.to_span_pos(rustc_span.lo()),
+            self.to_span_pos(rustc_span.hi()),
+        )
+    }
+
+    pub fn to_span_pos(&self, byte_pos: rustc_span::BytePos) -> SpanPos {
+        SpanPos::new(byte_pos.0)
+    }
+}

--- a/marker_rustc_driver/src/conversion/marker/common/span.rs
+++ b/marker_rustc_driver/src/conversion/marker/common/span.rs
@@ -1,4 +1,7 @@
-use marker_api::{ast::SpanPos, prelude::Span};
+use marker_api::{
+    ast::{ExpnInfo, FileInfo, SpanPos, SpanSource},
+    prelude::Span,
+};
 
 use crate::conversion::marker::MarkerConverterInner;
 
@@ -16,5 +19,48 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
 
     pub fn to_span_pos(&self, byte_pos: rustc_span::BytePos) -> SpanPos {
         SpanPos::new(byte_pos.0)
+    }
+
+    pub fn to_span_source(&self, rust_span: rustc_span::Span) -> SpanSource<'ast> {
+        let ctxt = rust_span.ctxt();
+        if ctxt.is_root() {
+            let src_file = self.rustc_cx.sess.source_map().lookup_source_file(rust_span.lo());
+            let name;
+            match &src_file.name {
+                rustc_span::FileName::Real(
+                    rustc_span::RealFileName::LocalPath(file_path)
+                    | rustc_span::RealFileName::Remapped {
+                        virtual_name: file_path,
+                        ..
+                    },
+                ) => {
+                    name = file_path.to_string_lossy().to_string();
+                },
+                _ => {
+                    name = format!(
+                        "MarkerConverter::to_span_source(): Unexpected file name: {rust_span:#?} -> {src_file:#?}"
+                    );
+                },
+            }
+            SpanSource::File(self.alloc(FileInfo::new(self.storage.alloc_str(&name), self.to_span_src_id(ctxt))))
+        } else {
+            SpanSource::Macro(self.alloc(self.to_expn_info(&ctxt.outer_expn_data())))
+        }
+    }
+
+    pub fn try_to_expn_info(&self, id: rustc_span::ExpnId) -> Option<&'ast ExpnInfo<'ast>> {
+        (id != rustc_span::ExpnId::root()).then(|| self.alloc(self.to_expn_info(&id.expn_data())))
+    }
+
+    pub fn to_expn_info(&self, data: &rustc_span::ExpnData) -> ExpnInfo<'ast> {
+        debug_assert!(
+            matches!(&data.kind, rustc_span::ExpnKind::Macro(_, _)),
+            "this expansion data doesn't belong to a macro: {data:#?}"
+        );
+        ExpnInfo::new(
+            self.to_expn_id(data.parent),
+            self.to_span_id(data.call_site),
+            self.to_macro_id(data.macro_def_id.expect("filled, because this belongs to a macro")),
+        )
     }
 }

--- a/marker_rustc_driver/src/conversion/marker/common/span.rs
+++ b/marker_rustc_driver/src/conversion/marker/common/span.rs
@@ -1,5 +1,5 @@
 use marker_api::{
-    ast::{ExpnInfo, FileInfo, SpanPos, SpanSource},
+    ast::{ExpnInfo, FileInfo, FilePos, SpanPos, SpanSource},
     prelude::Span,
 };
 
@@ -57,5 +57,14 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
             self.to_span_id(data.call_site),
             self.to_macro_id(data.macro_def_id.expect("filled, because this belongs to a macro")),
         )
+    }
+
+    pub fn try_to_span_pos(&self, scx: rustc_span::SyntaxContext, pos: rustc_span::BytePos) -> Option<FilePos<'ast>> {
+        (scx == rustc_span::SyntaxContext::root())
+            .then(|| self.to_file_pos(&self.rustc_cx.sess.source_map().lookup_char_pos(pos)))
+    }
+
+    fn to_file_pos(&self, loc: &rustc_span::Loc) -> FilePos<'ast> {
+        FilePos::new(loc.line, loc.col.0 + 1)
     }
 }

--- a/marker_rustc_driver/src/conversion/rustc.rs
+++ b/marker_rustc_driver/src/conversion/rustc.rs
@@ -1,12 +1,10 @@
 mod common;
 mod unstable;
 
-use std::cell::RefCell;
+use std::{cell::RefCell, marker::PhantomData};
 
 use marker_api::lint::Lint;
 use rustc_hash::FxHashMap;
-
-use crate::context::storage::Storage;
 
 thread_local! {
     /// This maps marker lints to lint instances used by rustc.
@@ -23,12 +21,17 @@ thread_local! {
 }
 
 pub struct RustcConverter<'ast, 'tcx> {
+    /// It's likely that this converter will need the lifetime at some point
+    _lifetime: PhantomData<&'ast ()>,
     rustc_cx: rustc_middle::ty::TyCtxt<'tcx>,
-    storage: &'ast Storage<'ast>,
 }
 
 impl<'ast, 'tcx> RustcConverter<'ast, 'tcx> {
-    pub fn new(rustc_cx: rustc_middle::ty::TyCtxt<'tcx>, storage: &'ast Storage<'ast>) -> Self {
-        Self { rustc_cx, storage }
+    #[must_use]
+    pub fn new(rustc_cx: rustc_middle::ty::TyCtxt<'tcx>) -> Self {
+        Self {
+            _lifetime: PhantomData,
+            rustc_cx,
+        }
     }
 }

--- a/marker_rustc_driver/src/conversion/rustc/common.rs
+++ b/marker_rustc_driver/src/conversion/rustc/common.rs
@@ -2,15 +2,15 @@ use std::mem::{size_of, transmute};
 
 use marker_api::{
     ast::{
-        BodyId, CrateId, ExprId, FieldId, GenericId, ItemId, LetStmtId, Span, SpanId, SpanSrcId, StmtIdInner, SymbolId,
-        TyDefId, VarId, VariantId,
+        BodyId, CrateId, ExpnId, ExprId, FieldId, GenericId, ItemId, LetStmtId, Span, SpanId, SpanSrcId, StmtIdInner,
+        SymbolId, TyDefId, VarId, VariantId,
     },
     diagnostic::{Applicability, EmissionNode},
     lint::Level,
 };
 use rustc_hir as hir;
 
-use crate::conversion::common::{BodyIdLayout, DefIdInfo, DefIdLayout, HirIdLayout};
+use crate::conversion::common::{BodyIdLayout, DefIdInfo, DefIdLayout, ExpnIdLayout, HirIdLayout};
 use crate::transmute_id;
 
 use super::RustcConverter;
@@ -167,6 +167,15 @@ impl<'ast, 'tcx> RustcConverter<'ast, 'tcx> {
         // FIXME(xFrednet): This is unsound, since `SyntaxContext` doesn't have
         // `#[repr(...)]`. See comment in `MarkerConverterInner::to_span_src_id`
         transmute_id!(SpanSrcId as rustc_span::SyntaxContext = src)
+    }
+
+    #[must_use]
+    pub(crate) fn to_expn_id(&self, expn_id: ExpnId) -> rustc_span::ExpnId {
+        let layout = transmute_id!(ExpnId as ExpnIdLayout = expn_id);
+        rustc_span::ExpnId {
+            krate: rustc_span::def_id::CrateNum::from_u32(layout.krate),
+            local_id: rustc_span::hygiene::ExpnIndex::from_u32(layout.index),
+        }
     }
 }
 

--- a/marker_rustc_driver/src/conversion/rustc/common.rs
+++ b/marker_rustc_driver/src/conversion/rustc/common.rs
@@ -2,8 +2,8 @@ use std::mem::{size_of, transmute};
 
 use marker_api::{
     ast::{
-        BodyId, CrateId, ExpnId, ExprId, FieldId, GenericId, ItemId, LetStmtId, Span, SpanId, SpanSrcId, StmtIdInner,
-        SymbolId, TyDefId, VarId, VariantId,
+        BodyId, CrateId, ExpnId, ExprId, FieldId, GenericId, ItemId, LetStmtId, Span, SpanId, SpanPos, SpanSrcId,
+        StmtIdInner, SymbolId, TyDefId, VarId, VariantId,
     },
     diagnostic::{Applicability, EmissionNode},
     lint::Level,
@@ -217,5 +217,10 @@ impl<'ast, 'tcx> RustcConverter<'ast, 'tcx> {
         let lo = rustc_span::BytePos(api_span.start().index());
         let hi = rustc_span::BytePos(api_span.end().index());
         rustc_span::Span::new(lo, hi, self.to_syntax_context(api_span.source_id()), None)
+    }
+
+    #[must_use]
+    pub fn to_byte_pos(&self, span_pos: SpanPos) -> rustc_span::BytePos {
+        rustc_span::BytePos(span_pos.index())
     }
 }

--- a/marker_uilints/src/lib.rs
+++ b/marker_uilints/src/lib.rs
@@ -45,6 +45,15 @@ marker_api::declare_lint! {
     Warn,
 }
 
+marker_api::declare_lint! {
+    /// # What it does
+    /// A lint used for markers uitests.
+    ///
+    /// It warns about about item names starting with `FindMe`, `find_me` or `FIND_ME`.
+    PRINT_EVERY_EXPR,
+    Allow,
+}
+
 fn emit_item_with_test_name_lint<'ast>(
     cx: &'ast AstContext<'ast>,
     node: impl Into<EmissionNode>,
@@ -57,7 +66,7 @@ fn emit_item_with_test_name_lint<'ast>(
 
 impl LintPass for TestLintPass {
     fn info(&self) -> LintPassInfo {
-        LintPassInfoBuilder::new(Box::new([TEST_LINT, ITEM_WITH_TEST_NAME])).build()
+        LintPassInfoBuilder::new(Box::new([TEST_LINT, ITEM_WITH_TEST_NAME, PRINT_EVERY_EXPR])).build()
     }
 
     fn check_item<'ast>(&mut self, cx: &'ast AstContext<'ast>, item: ItemKind<'ast>) {
@@ -186,6 +195,13 @@ impl LintPass for TestLintPass {
                 });
             }
         }
+    }
+
+    fn check_expr<'ast>(&mut self, cx: &'ast AstContext<'ast>, expr: ExprKind<'ast>) {
+        cx.emit_lint(PRINT_EVERY_EXPR, expr.id(), "expr", expr.span(), |diag| {
+            diag.note(&format!("SpanSource: {:#?}", expr.span().source()));
+            diag.note(&format!("Snippet: {:#?}", expr.span().snippet_or("<..>")));
+        });
     }
 }
 

--- a/marker_uilints/src/lib.rs
+++ b/marker_uilints/src/lib.rs
@@ -167,6 +167,7 @@ impl LintPass for TestLintPass {
                     let span = expr.span();
                     diag.note(format!("Debug: {span:#?}"));
                     diag.note(format!("Snippet: {}", span.snippet_or("..")));
+                    diag.note(format!("Source: {:#?}", span.source()));
                 });
             } else if ident.name().starts_with("_ty") {
                 cx.emit_lint(TEST_LINT, stmt.id(), "print type test", stmt.span(), |diag| {

--- a/marker_uilints/tests/ui/expr/print_async_block.stderr
+++ b/marker_uilints/tests/ui/expr/print_async_block.stderr
@@ -35,13 +35,7 @@ warning: print test
                                                   AstPathSegment {
                                                       ident: Ident {
                                                           name: "x",
-                                                          span: Span {
-                                                              source: File(
-                                                                  "$DIR/print_async_block.rs",
-                                                              ),
-                                                              start: 66,
-                                                              end: 67,
-                                                          },
+                                                          span: $DIR/print_async_block.rs:2:44 - 2:45,
                                                       },
                                                       generics: SynGenericArgs {
                                                           args: [],

--- a/marker_uilints/tests/ui/expr/print_await_expr.rs
+++ b/marker_uilints/tests/ui/expr/print_await_expr.rs
@@ -4,7 +4,7 @@ async fn foo() -> u8 {
 
 async fn bar() {
     let _print_await = foo().await;
-    
+
     let future = foo();
     let _print_await = future.await;
 

--- a/marker_uilints/tests/ui/expr/print_await_expr.stderr
+++ b/marker_uilints/tests/ui/expr/print_await_expr.stderr
@@ -33,13 +33,7 @@ warning: print test
                                               AstPathSegment {
                                                   ident: Ident {
                                                       name: "foo",
-                                                      span: Span {
-                                                          source: File(
-                                                              "$DIR/print_await_expr.rs",
-                                                          ),
-                                                          start: 73,
-                                                          end: 76,
-                                                      },
+                                                      span: $DIR/print_await_expr.rs:6:24 - 6:27,
                                                   },
                                                   generics: SynGenericArgs {
                                                       args: [],
@@ -88,13 +82,7 @@ warning: print test
                                       AstPathSegment {
                                           ident: Ident {
                                               name: "future",
-                                              span: Span {
-                                                  source: File(
-                                                      "$DIR/print_await_expr.rs",
-                                                  ),
-                                                  start: 138,
-                                                  end: 144,
-                                              },
+                                              span: $DIR/print_await_expr.rs:9:24 - 9:30,
                                           },
                                           generics: SynGenericArgs {
                                               args: [],

--- a/marker_uilints/tests/ui/expr/sugar/README.md
+++ b/marker_uilints/tests/ui/expr/sugar/README.md
@@ -1,0 +1,1 @@
+This folder contains tests, to check that expressions are resugared correctly and their spans also match up.

--- a/marker_uilints/tests/ui/expr/sugar/for_loop.rs
+++ b/marker_uilints/tests/ui/expr/sugar/for_loop.rs
@@ -1,0 +1,14 @@
+#![feature(register_tool)]
+#![register_tool(marker)]
+
+fn main() {
+    let range = 1..10;
+    let mut total = 0;
+
+    #[warn(marker::print_every_expr)]
+    for i in range {
+        total += i;
+    }
+
+    println!("{total}");
+}

--- a/marker_uilints/tests/ui/expr/sugar/for_loop.stderr
+++ b/marker_uilints/tests/ui/expr/sugar/for_loop.stderr
@@ -1,0 +1,82 @@
+warning: expr
+  --> $DIR/for_loop.rs:9:5
+   |
+9  | /     for i in range {
+10 | |         total += i;
+11 | |     }
+   | |_____^
+   |
+   = note: SpanSource: File(
+               FileInfo {
+                   file: "$DIR/for_loop.rs",
+                   span_src: SpanSrcId(..),
+               },
+           )
+   = note: Snippet: "for i in range {/n        total += i;/n    }"
+note: the lint level is defined here
+  --> $DIR/for_loop.rs:8:12
+   |
+8  |     #[warn(marker::print_every_expr)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: expr
+ --> $DIR/for_loop.rs:9:14
+  |
+9 |     for i in range {
+  |              ^^^^^
+  |
+  = note: SpanSource: File(
+              FileInfo {
+                  file: "$DIR/for_loop.rs",
+                  span_src: SpanSrcId(..),
+              },
+          )
+  = note: Snippet: "range"
+
+warning: expr
+  --> $DIR/for_loop.rs:9:20
+   |
+9  |       for i in range {
+   |  ____________________^
+10 | |         total += i;
+11 | |     }
+   | |_____^
+   |
+   = note: SpanSource: File(
+               FileInfo {
+                   file: "$DIR/for_loop.rs",
+                   span_src: SpanSrcId(..),
+               },
+           )
+   = note: Snippet: "{/n        total += i;/n    }"
+
+warning: expr
+  --> $DIR/for_loop.rs:10:9
+   |
+10 |         total += i;
+   |         ^^^^^^^^^^
+   |
+   = note: SpanSource: File(
+               FileInfo {
+                   file: "$DIR/for_loop.rs",
+                   span_src: SpanSrcId(..),
+               },
+           )
+   = note: Snippet: "total += i"
+
+warning: expr
+  --> $DIR/for_loop.rs:10:18
+   |
+10 |         total += i;
+   |                  ^
+   |
+   = note: SpanSource: File(
+               FileInfo {
+                   file: "$DIR/for_loop.rs",
+                   span_src: SpanSrcId(..),
+               },
+           )
+   = note: Snippet: "i"
+
+warning: 5 warnings emitted
+

--- a/marker_uilints/tests/ui/expr/sugar/ranges.rs
+++ b/marker_uilints/tests/ui/expr/sugar/ranges.rs
@@ -1,0 +1,13 @@
+#![feature(register_tool)]
+#![register_tool(marker)]
+
+fn main() {
+    #[warn(marker::print_every_expr)]
+    let _ = 1..2;
+    #[warn(marker::print_every_expr)]
+    let _ = ..2;
+    #[warn(marker::print_every_expr)]
+    let _ = 1..;
+    #[warn(marker::print_every_expr)]
+    let _ = ..;
+}

--- a/marker_uilints/tests/ui/expr/sugar/ranges.stderr
+++ b/marker_uilints/tests/ui/expr/sugar/ranges.stderr
@@ -1,0 +1,134 @@
+warning: expr
+ --> $DIR/ranges.rs:6:13
+  |
+6 |     let _ = 1..2;
+  |             ^^^^
+  |
+  = note: SpanSource: File(
+              FileInfo {
+                  file: "$DIR/ranges.rs",
+                  span_src: SpanSrcId(..),
+              },
+          )
+  = note: Snippet: "1..2"
+note: the lint level is defined here
+ --> $DIR/ranges.rs:5:12
+  |
+5 |     #[warn(marker::print_every_expr)]
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: expr
+ --> $DIR/ranges.rs:6:13
+  |
+6 |     let _ = 1..2;
+  |             ^
+  |
+  = note: SpanSource: File(
+              FileInfo {
+                  file: "$DIR/ranges.rs",
+                  span_src: SpanSrcId(..),
+              },
+          )
+  = note: Snippet: "1"
+
+warning: expr
+ --> $DIR/ranges.rs:6:16
+  |
+6 |     let _ = 1..2;
+  |                ^
+  |
+  = note: SpanSource: File(
+              FileInfo {
+                  file: "$DIR/ranges.rs",
+                  span_src: SpanSrcId(..),
+              },
+          )
+  = note: Snippet: "2"
+
+warning: expr
+ --> $DIR/ranges.rs:8:13
+  |
+8 |     let _ = ..2;
+  |             ^^^
+  |
+  = note: SpanSource: File(
+              FileInfo {
+                  file: "$DIR/ranges.rs",
+                  span_src: SpanSrcId(..),
+              },
+          )
+  = note: Snippet: "..2"
+note: the lint level is defined here
+ --> $DIR/ranges.rs:7:12
+  |
+7 |     #[warn(marker::print_every_expr)]
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: expr
+ --> $DIR/ranges.rs:8:15
+  |
+8 |     let _ = ..2;
+  |               ^
+  |
+  = note: SpanSource: File(
+              FileInfo {
+                  file: "$DIR/ranges.rs",
+                  span_src: SpanSrcId(..),
+              },
+          )
+  = note: Snippet: "2"
+
+warning: expr
+  --> $DIR/ranges.rs:10:13
+   |
+10 |     let _ = 1..;
+   |             ^^^
+   |
+   = note: SpanSource: File(
+               FileInfo {
+                   file: "$DIR/ranges.rs",
+                   span_src: SpanSrcId(..),
+               },
+           )
+   = note: Snippet: "1.."
+note: the lint level is defined here
+  --> $DIR/ranges.rs:9:12
+   |
+9  |     #[warn(marker::print_every_expr)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: expr
+  --> $DIR/ranges.rs:10:13
+   |
+10 |     let _ = 1..;
+   |             ^
+   |
+   = note: SpanSource: File(
+               FileInfo {
+                   file: "$DIR/ranges.rs",
+                   span_src: SpanSrcId(..),
+               },
+           )
+   = note: Snippet: "1"
+
+warning: expr
+  --> $DIR/ranges.rs:12:13
+   |
+12 |     let _ = ..;
+   |             ^^
+   |
+   = note: SpanSource: File(
+               FileInfo {
+                   file: "$DIR/ranges.rs",
+                   span_src: SpanSrcId(..),
+               },
+           )
+   = note: Snippet: ".."
+note: the lint level is defined here
+  --> $DIR/ranges.rs:11:12
+   |
+11 |     #[warn(marker::print_every_expr)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: 8 warnings emitted
+

--- a/marker_uilints/tests/ui/expr/sugar/try_expr.rs
+++ b/marker_uilints/tests/ui/expr/sugar/try_expr.rs
@@ -1,0 +1,17 @@
+#![feature(register_tool)]
+#![register_tool(marker)]
+
+fn try_something() -> Option<u32> {
+    #[warn(marker::print_every_expr)]
+    Some(21)?;
+    None
+}
+
+fn kanske_option() -> Result<i32, u32> {
+    let x: Result<i32, u32> = Err(1);
+    #[warn(marker::print_every_expr)]
+    x?;
+    Ok(42)
+}
+
+fn main() {}

--- a/marker_uilints/tests/ui/expr/sugar/try_expr.stderr
+++ b/marker_uilints/tests/ui/expr/sugar/try_expr.stderr
@@ -1,0 +1,82 @@
+warning: expr
+ --> $DIR/try_expr.rs:6:5
+  |
+6 |     Some(21)?;
+  |     ^^^^^^^^^
+  |
+  = note: SpanSource: File(
+              FileInfo {
+                  file: "$DIR/try_expr.rs",
+                  span_src: SpanSrcId(..),
+              },
+          )
+  = note: Snippet: "Some(21)?"
+note: the lint level is defined here
+ --> $DIR/try_expr.rs:5:12
+  |
+5 |     #[warn(marker::print_every_expr)]
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: expr
+ --> $DIR/try_expr.rs:6:5
+  |
+6 |     Some(21)?;
+  |     ^^^^^^^^
+  |
+  = note: SpanSource: File(
+              FileInfo {
+                  file: "$DIR/try_expr.rs",
+                  span_src: SpanSrcId(..),
+              },
+          )
+  = note: Snippet: "Some(21)"
+
+warning: expr
+ --> $DIR/try_expr.rs:6:10
+  |
+6 |     Some(21)?;
+  |          ^^
+  |
+  = note: SpanSource: File(
+              FileInfo {
+                  file: "$DIR/try_expr.rs",
+                  span_src: SpanSrcId(..),
+              },
+          )
+  = note: Snippet: "21"
+
+warning: expr
+  --> $DIR/try_expr.rs:13:5
+   |
+13 |     x?;
+   |     ^^
+   |
+   = note: SpanSource: File(
+               FileInfo {
+                   file: "$DIR/try_expr.rs",
+                   span_src: SpanSrcId(..),
+               },
+           )
+   = note: Snippet: "x?"
+note: the lint level is defined here
+  --> $DIR/try_expr.rs:12:12
+   |
+12 |     #[warn(marker::print_every_expr)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: expr
+  --> $DIR/try_expr.rs:13:5
+   |
+13 |     x?;
+   |     ^
+   |
+   = note: SpanSource: File(
+               FileInfo {
+                   file: "$DIR/try_expr.rs",
+                   span_src: SpanSrcId(..),
+               },
+           )
+   = note: Snippet: "x"
+
+warning: 5 warnings emitted
+

--- a/marker_uilints/tests/ui/expr/sugar/while_loop.rs
+++ b/marker_uilints/tests/ui/expr/sugar/while_loop.rs
@@ -1,0 +1,11 @@
+#![feature(register_tool)]
+#![register_tool(marker)]
+
+fn main() {
+    let mut something = Some(12);
+
+    #[warn(marker::print_every_expr)]
+    while let Some(_) = something {
+        something = None;
+    }
+}

--- a/marker_uilints/tests/ui/expr/sugar/while_loop.stderr
+++ b/marker_uilints/tests/ui/expr/sugar/while_loop.stderr
@@ -1,0 +1,96 @@
+warning: expr
+  --> $DIR/while_loop.rs:8:5
+   |
+8  | /     while let Some(_) = something {
+9  | |         something = None;
+10 | |     }
+   | |_____^
+   |
+   = note: SpanSource: File(
+               FileInfo {
+                   file: "$DIR/while_loop.rs",
+                   span_src: SpanSrcId(..),
+               },
+           )
+   = note: Snippet: "while let Some(_) = something {/n        something = None;/n    }"
+note: the lint level is defined here
+  --> $DIR/while_loop.rs:7:12
+   |
+7  |     #[warn(marker::print_every_expr)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: expr
+ --> $DIR/while_loop.rs:8:11
+  |
+8 |     while let Some(_) = something {
+  |           ^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: SpanSource: File(
+              FileInfo {
+                  file: "$DIR/while_loop.rs",
+                  span_src: SpanSrcId(..),
+              },
+          )
+  = note: Snippet: "let Some(_) = something"
+
+warning: expr
+ --> $DIR/while_loop.rs:8:25
+  |
+8 |     while let Some(_) = something {
+  |                         ^^^^^^^^^
+  |
+  = note: SpanSource: File(
+              FileInfo {
+                  file: "$DIR/while_loop.rs",
+                  span_src: SpanSrcId(..),
+              },
+          )
+  = note: Snippet: "something"
+
+warning: expr
+  --> $DIR/while_loop.rs:8:35
+   |
+8  |       while let Some(_) = something {
+   |  ___________________________________^
+9  | |         something = None;
+10 | |     }
+   | |_____^
+   |
+   = note: SpanSource: File(
+               FileInfo {
+                   file: "$DIR/while_loop.rs",
+                   span_src: SpanSrcId(..),
+               },
+           )
+   = note: Snippet: "{/n        something = None;/n    }"
+
+warning: expr
+ --> $DIR/while_loop.rs:9:9
+  |
+9 |         something = None;
+  |         ^^^^^^^^^^^^^^^^
+  |
+  = note: SpanSource: File(
+              FileInfo {
+                  file: "$DIR/while_loop.rs",
+                  span_src: SpanSrcId(..),
+              },
+          )
+  = note: Snippet: "something = None"
+
+warning: expr
+ --> $DIR/while_loop.rs:9:21
+  |
+9 |         something = None;
+  |                     ^^^^
+  |
+  = note: SpanSource: File(
+              FileInfo {
+                  file: "$DIR/while_loop.rs",
+                  span_src: SpanSrcId(..),
+              },
+          )
+  = note: Snippet: "None"
+
+warning: 6 warnings emitted
+

--- a/marker_uilints/tests/ui/item/print_async_fn.stderr
+++ b/marker_uilints/tests/ui/item/print_async_fn.stderr
@@ -12,13 +12,7 @@ warning: printing item with body
                       vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
                       ident: Ident {
                           name: "print_with_body_foo",
-                          span: Span {
-                              source: File(
-                                  "$DIR/print_async_fn.rs",
-                              ),
-                              start: 9,
-                              end: 28,
-                          },
+                          span: $DIR/print_async_fn.rs:1:10 - 1:29,
                       },
                   },
                   generics: SynGenericParams {
@@ -94,13 +88,7 @@ warning: printing item with body
                       vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
                       ident: Ident {
                           name: "print_with_body_bar",
-                          span: Span {
-                              source: File(
-                                  "$DIR/print_async_fn.rs",
-                              ),
-                              start: 91,
-                              end: 110,
-                          },
+                          span: $DIR/print_async_fn.rs:9:10 - 9:29,
                       },
                   },
                   generics: SynGenericParams {
@@ -198,13 +186,7 @@ warning: printing item with body
                                                                           AstPathSegment {
                                                                               ident: Ident {
                                                                                   name: "foo",
-                                                                                  span: Span {
-                                                                                      source: File(
-                                                                                          "$DIR/print_async_fn.rs",
-                                                                                      ),
-                                                                                      start: 137,
-                                                                                      end: 140,
-                                                                                  },
+                                                                                  span: $DIR/print_async_fn.rs:10:17 - 10:20,
                                                                               },
                                                                               generics: SynGenericArgs {
                                                                                   args: [],
@@ -285,13 +267,7 @@ warning: printing item with body
                                                                           AstPathSegment {
                                                                               ident: Ident {
                                                                                   name: "foo",
-                                                                                  span: Span {
-                                                                                      source: File(
-                                                                                          "$DIR/print_async_fn.rs",
-                                                                                      ),
-                                                                                      start: 166,
-                                                                                      end: 169,
-                                                                                  },
+                                                                                  span: $DIR/print_async_fn.rs:11:17 - 11:20,
                                                                               },
                                                                               generics: SynGenericArgs {
                                                                                   args: [],
@@ -372,13 +348,7 @@ warning: printing item with body
                                                                           AstPathSegment {
                                                                               ident: Ident {
                                                                                   name: "foo",
-                                                                                  span: Span {
-                                                                                      source: File(
-                                                                                          "$DIR/print_async_fn.rs",
-                                                                                      ),
-                                                                                      start: 195,
-                                                                                      end: 198,
-                                                                                  },
+                                                                                  span: $DIR/print_async_fn.rs:12:17 - 12:20,
                                                                               },
                                                                               generics: SynGenericArgs {
                                                                                   args: [],
@@ -432,13 +402,7 @@ warning: printing item with body
                                                               AstPathSegment {
                                                                   ident: Ident {
                                                                       name: "a",
-                                                                      span: Span {
-                                                                          source: File(
-                                                                              "$DIR/print_async_fn.rs",
-                                                                          ),
-                                                                          start: 212,
-                                                                          end: 213,
-                                                                      },
+                                                                      span: $DIR/print_async_fn.rs:13:5 - 13:6,
                                                                   },
                                                                   generics: SynGenericArgs {
                                                                       args: [],
@@ -467,13 +431,7 @@ warning: printing item with body
                                                               AstPathSegment {
                                                                   ident: Ident {
                                                                       name: "b",
-                                                                      span: Span {
-                                                                          source: File(
-                                                                              "$DIR/print_async_fn.rs",
-                                                                          ),
-                                                                          start: 216,
-                                                                          end: 217,
-                                                                      },
+                                                                      span: $DIR/print_async_fn.rs:13:9 - 13:10,
                                                                   },
                                                                   generics: SynGenericArgs {
                                                                       args: [],
@@ -505,13 +463,7 @@ warning: printing item with body
                                                       AstPathSegment {
                                                           ident: Ident {
                                                               name: "c",
-                                                              span: Span {
-                                                                  source: File(
-                                                                      "$DIR/print_async_fn.rs",
-                                                                  ),
-                                                                  start: 220,
-                                                                  end: 221,
-                                                              },
+                                                              span: $DIR/print_async_fn.rs:13:13 - 13:14,
                                                           },
                                                           generics: SynGenericArgs {
                                                               args: [],
@@ -551,13 +503,7 @@ warning: printing item with body
                        vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
                        ident: Ident {
                            name: "print_with_body_with_lifetime",
-                           span: Span {
-                               source: File(
-                                   "$DIR/print_async_fn.rs",
-                               ),
-                               start: 234,
-                               end: 263,
-                           },
+                           span: $DIR/print_async_fn.rs:16:10 - 16:39,
                        },
                    },
                    generics: SynGenericParams {
@@ -656,13 +602,7 @@ warning: printing item with body
                                                        AstPathSegment {
                                                            ident: Ident {
                                                                name: "x",
-                                                               span: Span {
-                                                                   source: File(
-                                                                       "$DIR/print_async_fn.rs",
-                                                                   ),
-                                                                   start: 285,
-                                                                   end: 286,
-                                                               },
+                                                               span: $DIR/print_async_fn.rs:17:6 - 17:7,
                                                            },
                                                            generics: SynGenericArgs {
                                                                args: [],

--- a/marker_uilints/tests/ui/item/print_fn_item.stderr
+++ b/marker_uilints/tests/ui/item/print_fn_item.stderr
@@ -12,13 +12,7 @@ warning: printing item
                       vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
                       ident: Ident {
                           name: "print_me_simple",
-                          span: Span {
-                              source: File(
-                                  "$DIR/print_fn_item.rs",
-                              ),
-                              start: 7,
-                              end: 22,
-                          },
+                          span: $DIR/print_fn_item.rs:1:8 - 1:23,
                       },
                   },
                   generics: SynGenericParams {
@@ -54,13 +48,7 @@ warning: printing item
                       vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
                       ident: Ident {
                           name: "print_me_special",
-                          span: Span {
-                              source: File(
-                                  "$DIR/print_fn_item.rs",
-                              ),
-                              start: 49,
-                              end: 65,
-                          },
+                          span: $DIR/print_fn_item.rs:3:21 - 3:37,
                       },
                   },
                   generics: SynGenericParams {
@@ -95,13 +83,7 @@ warning: printing item
                       vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
                       ident: Ident {
                           name: "print_me_params",
-                          span: Span {
-                              source: File(
-                                  "$DIR/print_fn_item.rs",
-                              ),
-                              start: 79,
-                              end: 94,
-                          },
+                          span: $DIR/print_fn_item.rs:5:8 - 5:23,
                       },
                   },
                   generics: SynGenericParams {
@@ -223,13 +205,7 @@ warning: printing item
                                           AstPathSegment {
                                               ident: Ident {
                                                   name: "String",
-                                                  span: Span {
-                                                      source: File(
-                                                          "$DIR/print_fn_item.rs",
-                                                      ),
-                                                      start: 133,
-                                                      end: 139,
-                                                  },
+                                                  span: $DIR/print_fn_item.rs:5:62 - 5:68,
                                               },
                                               generics: SynGenericArgs {
                                                   args: [],
@@ -264,13 +240,7 @@ warning: printing item
                        vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
                        ident: Ident {
                            name: "print_me_trait_with_body",
-                           span: Span {
-                               source: File(
-                                   "$DIR/print_fn_item.rs",
-                               ),
-                               start: 196,
-                               end: 220,
-                           },
+                           span: $DIR/print_fn_item.rs:10:8 - 10:32,
                        },
                    },
                    generics: SynGenericParams {
@@ -392,13 +362,7 @@ warning: printing item
                                            AstPathSegment {
                                                ident: Ident {
                                                    name: "String",
-                                                   span: Span {
-                                                       source: File(
-                                                           "$DIR/print_fn_item.rs",
-                                                       ),
-                                                       start: 256,
-                                                       end: 262,
-                                                   },
+                                                   span: $DIR/print_fn_item.rs:10:68 - 10:74,
                                                },
                                                generics: SynGenericArgs {
                                                    args: [],
@@ -433,13 +397,7 @@ warning: printing item
                        vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
                        ident: Ident {
                            name: "print_me_trait_no_body",
-                           span: Span {
-                               source: File(
-                                   "$DIR/print_fn_item.rs",
-                               ),
-                               start: 301,
-                               end: 323,
-                           },
+                           span: $DIR/print_fn_item.rs:14:8 - 14:30,
                        },
                    },
                    generics: SynGenericParams {
@@ -538,13 +496,7 @@ warning: printing item
                                            AstPathSegment {
                                                ident: Ident {
                                                    name: "String",
-                                                   span: Span {
-                                                       source: File(
-                                                           "$DIR/print_fn_item.rs",
-                                                       ),
-                                                       start: 359,
-                                                       end: 365,
-                                                   },
+                                                   span: $DIR/print_fn_item.rs:14:66 - 14:72,
                                                },
                                                generics: SynGenericArgs {
                                                    args: [],

--- a/marker_uilints/tests/ui/print_adt_item.stderr
+++ b/marker_uilints/tests/ui/print_adt_item.stderr
@@ -12,13 +12,7 @@ warning: printing item
                       vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
                       ident: Ident {
                           name: "PrintMeEnum",
-                          span: Span {
-                              source: File(
-                                  "$DIR/print_adt_item.rs",
-                              ),
-                              start: 9,
-                              end: 20,
-                          },
+                          span: $DIR/print_adt_item.rs:1:10 - 1:21,
                       },
                   },
                   generics: SynGenericParams {

--- a/marker_uilints/tests/ui/print_assign_expr.stderr
+++ b/marker_uilints/tests/ui/print_assign_expr.stderr
@@ -42,13 +42,7 @@ warning: print test
                                                            AstPathSegment {
                                                                ident: Ident {
                                                                    name: "a",
-                                                                   span: Span {
-                                                                       source: File(
-                                                                           "$DIR/print_assign_expr.rs",
-                                                                       ),
-                                                                       start: 204,
-                                                                       end: 205,
-                                                                   },
+                                                                   span: $DIR/print_assign_expr.rs:15:9 - 15:10,
                                                                },
                                                                generics: SynGenericArgs {
                                                                    args: [],
@@ -86,13 +80,7 @@ warning: print test
                                                                AstPathSegment {
                                                                    ident: Ident {
                                                                        name: "bar",
-                                                                       span: Span {
-                                                                           source: File(
-                                                                               "$DIR/print_assign_expr.rs",
-                                                                           ),
-                                                                           start: 208,
-                                                                           end: 211,
-                                                                       },
+                                                                       span: $DIR/print_assign_expr.rs:15:13 - 15:16,
                                                                    },
                                                                    generics: SynGenericArgs {
                                                                        args: [],
@@ -138,13 +126,7 @@ warning: print test
                                                            AstPathSegment {
                                                                ident: Ident {
                                                                    name: "a",
-                                                                   span: Span {
-                                                                       source: File(
-                                                                           "$DIR/print_assign_expr.rs",
-                                                                       ),
-                                                                       start: 223,
-                                                                       end: 224,
-                                                                   },
+                                                                   span: $DIR/print_assign_expr.rs:16:9 - 16:10,
                                                                },
                                                                generics: SynGenericArgs {
                                                                    args: [],
@@ -209,13 +191,7 @@ warning: print test
                                                                        AstPathSegment {
                                                                            ident: Ident {
                                                                                name: "a",
-                                                                               span: Span {
-                                                                                   source: File(
-                                                                                       "$DIR/print_assign_expr.rs",
-                                                                                   ),
-                                                                                   start: 240,
-                                                                                   end: 241,
-                                                                               },
+                                                                               span: $DIR/print_assign_expr.rs:17:10 - 17:11,
                                                                            },
                                                                            generics: SynGenericArgs {
                                                                                args: [],
@@ -247,13 +223,7 @@ warning: print test
                                                                        AstPathSegment {
                                                                            ident: Ident {
                                                                                name: "b",
-                                                                               span: Span {
-                                                                                   source: File(
-                                                                                       "$DIR/print_assign_expr.rs",
-                                                                                   ),
-                                                                                   start: 243,
-                                                                                   end: 244,
-                                                                               },
+                                                                               span: $DIR/print_assign_expr.rs:17:13 - 17:14,
                                                                            },
                                                                            generics: SynGenericArgs {
                                                                                args: [],
@@ -333,13 +303,7 @@ warning: print test
                                                        AstPathSegment {
                                                            ident: Ident {
                                                                name: "S",
-                                                               span: Span {
-                                                                   source: File(
-                                                                       "$DIR/print_assign_expr.rs",
-                                                                   ),
-                                                                   start: 264,
-                                                                   end: 265,
-                                                               },
+                                                               span: $DIR/print_assign_expr.rs:18:9 - 18:10,
                                                            },
                                                            generics: SynGenericArgs {
                                                                args: [],
@@ -386,13 +350,7 @@ warning: print test
                                                                                        AstPathSegment {
                                                                                            ident: Ident {
                                                                                                name: "a",
-                                                                                               span: Span {
-                                                                                                   source: File(
-                                                                                                       "$DIR/print_assign_expr.rs",
-                                                                                                   ),
-                                                                                                   start: 291,
-                                                                                                   end: 292,
-                                                                                               },
+                                                                                               span: $DIR/print_assign_expr.rs:19:24 - 19:25,
                                                                                            },
                                                                                            generics: SynGenericArgs {
                                                                                                args: [],
@@ -446,13 +404,7 @@ warning: print test
                                                                                        AstPathSegment {
                                                                                            ident: Ident {
                                                                                                name: "b",
-                                                                                               span: Span {
-                                                                                                   source: File(
-                                                                                                       "$DIR/print_assign_expr.rs",
-                                                                                                   ),
-                                                                                                   start: 319,
-                                                                                                   end: 320,
-                                                                                               },
+                                                                                               span: $DIR/print_assign_expr.rs:20:21 - 20:22,
                                                                                            },
                                                                                            generics: SynGenericArgs {
                                                                                                args: [],
@@ -515,13 +467,7 @@ warning: print test
                                                                                AstPathSegment {
                                                                                    ident: Ident {
                                                                                        name: "S",
-                                                                                       span: Span {
-                                                                                           source: File(
-                                                                                               "$DIR/print_assign_expr.rs",
-                                                                                           ),
-                                                                                           start: 339,
-                                                                                           end: 340,
-                                                                                       },
+                                                                                       span: $DIR/print_assign_expr.rs:21:13 - 21:14,
                                                                                    },
                                                                                    generics: SynGenericArgs {
                                                                                        args: [],
@@ -541,13 +487,7 @@ warning: print test
                                                                AstPathSegment {
                                                                    ident: Ident {
                                                                        name: "S",
-                                                                       span: Span {
-                                                                           source: File(
-                                                                               "$DIR/print_assign_expr.rs",
-                                                                           ),
-                                                                           start: 339,
-                                                                           end: 340,
-                                                                       },
+                                                                       span: $DIR/print_assign_expr.rs:21:13 - 21:14,
                                                                    },
                                                                    generics: SynGenericArgs {
                                                                        args: [],
@@ -556,13 +496,7 @@ warning: print test
                                                                AstPathSegment {
                                                                    ident: Ident {
                                                                        name: "default",
-                                                                       span: Span {
-                                                                           source: File(
-                                                                               "$DIR/print_assign_expr.rs",
-                                                                           ),
-                                                                           start: 342,
-                                                                           end: 349,
-                                                                       },
+                                                                       span: $DIR/print_assign_expr.rs:21:16 - 21:23,
                                                                    },
                                                                    generics: SynGenericArgs {
                                                                        args: [],

--- a/marker_uilints/tests/ui/print_cond_expr.stderr
+++ b/marker_uilints/tests/ui/print_cond_expr.stderr
@@ -32,13 +32,7 @@ warning: print test
                                        AstPathSegment {
                                            ident: Ident {
                                                name: "cond",
-                                               span: Span {
-                                                   source: File(
-                                                       "$DIR/print_cond_expr.rs",
-                                                   ),
-                                                   start: 55,
-                                                   end: 59,
-                                               },
+                                               span: $DIR/print_cond_expr.rs:3:24 - 3:28,
                                            },
                                            generics: SynGenericArgs {
                                                args: [],
@@ -83,13 +77,7 @@ warning: print test
                                                                AstPathSegment {
                                                                    ident: Ident {
                                                                        name: "cond",
-                                                                       span: Span {
-                                                                           source: File(
-                                                                               "$DIR/print_cond_expr.rs",
-                                                                           ),
-                                                                           start: 209,
-                                                                           end: 213,
-                                                                       },
+                                                                       span: $DIR/print_cond_expr.rs:6:12 - 6:16,
                                                                    },
                                                                    generics: SynGenericArgs {
                                                                        args: [],
@@ -210,13 +198,7 @@ warning: print test
                                                AstPathSegment {
                                                    ident: Ident {
                                                        name: "Some",
-                                                       span: Span {
-                                                           source: File(
-                                                               "$DIR/print_cond_expr.rs",
-                                                           ),
-                                                           start: 312,
-                                                           end: 316,
-                                                       },
+                                                       span: $DIR/print_cond_expr.rs:13:32 - 13:36,
                                                    },
                                                    generics: SynGenericArgs {
                                                        args: [],
@@ -260,13 +242,7 @@ warning: print test
                                                AstPathSegment {
                                                    ident: Ident {
                                                        name: "opt",
-                                                       span: Span {
-                                                           source: File(
-                                                               "$DIR/print_cond_expr.rs",
-                                                           ),
-                                                           start: 322,
-                                                           end: 325,
-                                                       },
+                                                       span: $DIR/print_cond_expr.rs:13:42 - 13:45,
                                                    },
                                                    generics: SynGenericArgs {
                                                        args: [],
@@ -379,13 +355,7 @@ warning: print test
                                        AstPathSegment {
                                            ident: Ident {
                                                name: "a",
-                                               span: Span {
-                                                   source: File(
-                                                       "$DIR/print_cond_expr.rs",
-                                                   ),
-                                                   start: 419,
-                                                   end: 420,
-                                               },
+                                               span: $DIR/print_cond_expr.rs:17:29 - 17:30,
                                            },
                                            generics: SynGenericArgs {
                                                args: [],
@@ -449,13 +419,7 @@ warning: print test
                                                    AstPathSegment {
                                                        ident: Ident {
                                                            name: "b",
-                                                           span: Span {
-                                                               source: File(
-                                                                   "$DIR/print_cond_expr.rs",
-                                                               ),
-                                                               start: 447,
-                                                               end: 448,
-                                                           },
+                                                           span: $DIR/print_cond_expr.rs:19:15 - 19:16,
                                                        },
                                                        generics: SynGenericArgs {
                                                            args: [],
@@ -565,13 +529,7 @@ warning: print test
                                        AstPathSegment {
                                            ident: Ident {
                                                name: "scrutinee",
-                                               span: Span {
-                                                   source: File(
-                                                       "$DIR/print_cond_expr.rs",
-                                                   ),
-                                                   start: 555,
-                                                   end: 564,
-                                               },
+                                               span: $DIR/print_cond_expr.rs:27:30 - 27:39,
                                            },
                                            generics: SynGenericArgs {
                                                args: [],
@@ -658,13 +616,7 @@ warning: print test
                                                            AstPathSegment {
                                                                ident: Ident {
                                                                    name: "check",
-                                                                   span: Span {
-                                                                       source: File(
-                                                                           "$DIR/print_cond_expr.rs",
-                                                                       ),
-                                                                       start: 599,
-                                                                       end: 604,
-                                                                   },
+                                                                   span: $DIR/print_cond_expr.rs:29:16 - 29:21,
                                                                },
                                                                generics: SynGenericArgs {
                                                                    args: [],
@@ -694,13 +646,7 @@ warning: print test
                                                                AstPathSegment {
                                                                    ident: Ident {
                                                                        name: "x",
-                                                                       span: Span {
-                                                                           source: File(
-                                                                               "$DIR/print_cond_expr.rs",
-                                                                           ),
-                                                                           start: 605,
-                                                                           end: 606,
-                                                                       },
+                                                                       span: $DIR/print_cond_expr.rs:29:22 - 29:23,
                                                                    },
                                                                    generics: SynGenericArgs {
                                                                        args: [],
@@ -806,13 +752,7 @@ warning: print test
                                        AstPathSegment {
                                            ident: Ident {
                                                name: "opt",
-                                               span: Span {
-                                                   source: File(
-                                                       "$DIR/print_cond_expr.rs",
-                                                   ),
-                                                   start: 769,
-                                                   end: 772,
-                                               },
+                                               span: $DIR/print_cond_expr.rs:37:40 - 37:43,
                                            },
                                            generics: SynGenericArgs {
                                                args: [],
@@ -843,13 +783,7 @@ warning: print test
                                                AstPathSegment {
                                                    ident: Ident {
                                                        name: "Some",
-                                                       span: Span {
-                                                           source: File(
-                                                               "$DIR/print_cond_expr.rs",
-                                                           ),
-                                                           start: 783,
-                                                           end: 787,
-                                                       },
+                                                       span: $DIR/print_cond_expr.rs:38:9 - 38:13,
                                                    },
                                                    generics: SynGenericArgs {
                                                        args: [],
@@ -923,13 +857,7 @@ warning: print test
                                                AstPathSegment {
                                                    ident: Ident {
                                                        name: "Some",
-                                                       span: Span {
-                                                           source: File(
-                                                               "$DIR/print_cond_expr.rs",
-                                                           ),
-                                                           start: 807,
-                                                           end: 811,
-                                                       },
+                                                       span: $DIR/print_cond_expr.rs:39:9 - 39:13,
                                                    },
                                                    generics: SynGenericArgs {
                                                        args: [],
@@ -992,13 +920,7 @@ warning: print test
                                                AstPathSegment {
                                                    ident: Ident {
                                                        name: "Some",
-                                                       span: Span {
-                                                           source: File(
-                                                               "$DIR/print_cond_expr.rs",
-                                                           ),
-                                                           start: 830,
-                                                           end: 834,
-                                                       },
+                                                       span: $DIR/print_cond_expr.rs:40:9 - 40:13,
                                                    },
                                                    generics: SynGenericArgs {
                                                        args: [],
@@ -1060,13 +982,7 @@ warning: print test
                                                AstPathSegment {
                                                    ident: Ident {
                                                        name: "None",
-                                                       span: Span {
-                                                           source: File(
-                                                               "$DIR/print_cond_expr.rs",
-                                                           ),
-                                                           start: 853,
-                                                           end: 857,
-                                                       },
+                                                       span: $DIR/print_cond_expr.rs:41:9 - 41:13,
                                                    },
                                                    generics: SynGenericArgs {
                                                        args: [],
@@ -1109,86 +1025,33 @@ warning: print test
                        id: ExprId(..),
                        span: SpanId(..),
                    },
-                   expr: Call(
-                       CallExpr {
+                   expr: Path(
+                       PathExpr {
                            data: CommonExprData {
                                _lifetime: PhantomData<&()>,
                                id: ExprId(..),
                                span: SpanId(..),
                            },
-                           operand: Path(
-                               PathExpr {
-                                   data: CommonExprData {
-                                       _lifetime: PhantomData<&()>,
-                                       id: ExprId(..),
-                                       span: SpanId(..),
-                                   },
-                                   path: AstQPath {
-                                       self_ty: None,
-                                       path_ty: None,
-                                       path: AstPath {
-                                           segments: [
-                                               AstPathSegment {
-                                                   ident: Ident {
-                                                       name: "Try::branch",
-                                                       span: Span {
-                                                           source: Sugar(
-                                                               "$DIR/print_cond_expr.rs",
-                                                               SpanSrcId(..),
-                                                           ),
-                                                           start: 0,
-                                                           end: 2,
-                                                       },
-                                                   },
-                                                   generics: SynGenericArgs {
-                                                       args: [],
-                                                   },
-                                               },
-                                           ],
-                                       },
-                                       target: Item(
-                                           ItemId(..),
-                                       ),
-                                   },
-                               },
-                           ),
-                           args: [
-                               Path(
-                                   PathExpr {
-                                       data: CommonExprData {
-                                           _lifetime: PhantomData<&()>,
-                                           id: ExprId(..),
-                                           span: SpanId(..),
-                                       },
-                                       path: AstQPath {
-                                           self_ty: None,
-                                           path_ty: None,
-                                           path: AstPath {
-                                               segments: [
-                                                   AstPathSegment {
-                                                       ident: Ident {
-                                                           name: "x",
-                                                           span: Span {
-                                                               source: File(
-                                                                   "$DIR/print_cond_expr.rs",
-                                                               ),
-                                                               start: 994,
-                                                               end: 995,
-                                                           },
-                                                       },
-                                                       generics: SynGenericArgs {
-                                                           args: [],
-                                                       },
-                                                   },
-                                               ],
+                           path: AstQPath {
+                               self_ty: None,
+                               path_ty: None,
+                               path: AstPath {
+                                   segments: [
+                                       AstPathSegment {
+                                           ident: Ident {
+                                               name: "x",
+                                               span: $DIR/print_cond_expr.rs:48:35 - 48:36,
                                            },
-                                           target: Var(
-                                               VarId(..),
-                                           ),
+                                           generics: SynGenericArgs {
+                                               args: [],
+                                           },
                                        },
-                                   },
+                                   ],
+                               },
+                               target: Var(
+                                   VarId(..),
                                ),
-                           ],
+                           },
                        },
                    ),
                },
@@ -1207,86 +1070,33 @@ warning: print test
                        id: ExprId(..),
                        span: SpanId(..),
                    },
-                   expr: Call(
-                       CallExpr {
+                   expr: Path(
+                       PathExpr {
                            data: CommonExprData {
                                _lifetime: PhantomData<&()>,
                                id: ExprId(..),
                                span: SpanId(..),
                            },
-                           operand: Path(
-                               PathExpr {
-                                   data: CommonExprData {
-                                       _lifetime: PhantomData<&()>,
-                                       id: ExprId(..),
-                                       span: SpanId(..),
-                                   },
-                                   path: AstQPath {
-                                       self_ty: None,
-                                       path_ty: None,
-                                       path: AstPath {
-                                           segments: [
-                                               AstPathSegment {
-                                                   ident: Ident {
-                                                       name: "Try::branch",
-                                                       span: Span {
-                                                           source: Sugar(
-                                                               "$DIR/print_cond_expr.rs",
-                                                               SpanSrcId(..),
-                                                           ),
-                                                           start: 0,
-                                                           end: 2,
-                                                       },
-                                                   },
-                                                   generics: SynGenericArgs {
-                                                       args: [],
-                                                   },
-                                               },
-                                           ],
-                                       },
-                                       target: Item(
-                                           ItemId(..),
-                                       ),
-                                   },
-                               },
-                           ),
-                           args: [
-                               Path(
-                                   PathExpr {
-                                       data: CommonExprData {
-                                           _lifetime: PhantomData<&()>,
-                                           id: ExprId(..),
-                                           span: SpanId(..),
-                                       },
-                                       path: AstQPath {
-                                           self_ty: None,
-                                           path_ty: None,
-                                           path: AstPath {
-                                               segments: [
-                                                   AstPathSegment {
-                                                       ident: Ident {
-                                                           name: "x",
-                                                           span: Span {
-                                                               source: File(
-                                                                   "$DIR/print_cond_expr.rs",
-                                                               ),
-                                                               start: 1138,
-                                                               end: 1139,
-                                                           },
-                                                       },
-                                                       generics: SynGenericArgs {
-                                                           args: [],
-                                                       },
-                                                   },
-                                               ],
+                           path: AstQPath {
+                               self_ty: None,
+                               path_ty: None,
+                               path: AstPath {
+                                   segments: [
+                                       AstPathSegment {
+                                           ident: Ident {
+                                               name: "x",
+                                               span: $DIR/print_cond_expr.rs:54:35 - 54:36,
                                            },
-                                           target: Var(
-                                               VarId(..),
-                                           ),
+                                           generics: SynGenericArgs {
+                                               args: [],
+                                           },
                                        },
-                                   },
+                                   ],
+                               },
+                               target: Var(
+                                   VarId(..),
                                ),
-                           ],
+                           },
                        },
                    ),
                },

--- a/marker_uilints/tests/ui/print_const_generics.rs
+++ b/marker_uilints/tests/ui/print_const_generics.rs
@@ -1,4 +1,3 @@
-
 struct PrintMeConstGenerics<const N: usize> {
     data: [f32; N],
 }
@@ -10,7 +9,5 @@ fn print_me() -> PrintMeConstGenerics<3> {
 impl<const N: usize> PrintMeConstGenerics<N> {}
 
 fn main() {
-    let _ty: PrintMeConstGenerics<3> = PrintMeConstGenerics {
-        data: [1.0, 1.5, 2.0],
-    };
+    let _ty: PrintMeConstGenerics<3> = PrintMeConstGenerics { data: [1.0, 1.5, 2.0] };
 }

--- a/marker_uilints/tests/ui/print_const_generics.stderr
+++ b/marker_uilints/tests/ui/print_const_generics.stderr
@@ -1,7 +1,7 @@
 warning: printing item
- --> $DIR/print_const_generics.rs:2:8
+ --> $DIR/print_const_generics.rs:1:8
   |
-2 | struct PrintMeConstGenerics<const N: usize> {
+1 | struct PrintMeConstGenerics<const N: usize> {
   |        ^^^^^^^^^^^^^^^^^^^^
   |
   = note: Struct(
@@ -12,13 +12,7 @@ warning: printing item
                       vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
                       ident: Ident {
                           name: "PrintMeConstGenerics",
-                          span: Span {
-                              source: File(
-                                  "$DIR/print_const_generics.rs",
-                              ),
-                              start: 8,
-                              end: 28,
-                          },
+                          span: $DIR/print_const_generics.rs:1:8 - 1:28,
                       },
                   },
                   generics: SynGenericParams {
@@ -81,13 +75,7 @@ warning: printing item
                                                                   AstPathSegment {
                                                                       ident: Ident {
                                                                           name: "N",
-                                                                          span: Span {
-                                                                              source: File(
-                                                                                  "$DIR/print_const_generics.rs",
-                                                                              ),
-                                                                              start: 63,
-                                                                              end: 64,
-                                                                          },
+                                                                          span: $DIR/print_const_generics.rs:2:17 - 2:18,
                                                                       },
                                                                       generics: SynGenericArgs {
                                                                           args: [],
@@ -114,9 +102,9 @@ warning: printing item
   = note: `#[warn(marker::test_lint)]` on by default
 
 warning: printing item
- --> $DIR/print_const_generics.rs:6:4
+ --> $DIR/print_const_generics.rs:5:4
   |
-6 | fn print_me() -> PrintMeConstGenerics<3> {
+5 | fn print_me() -> PrintMeConstGenerics<3> {
   |    ^^^^^^^^
   |
   = note: Fn(
@@ -127,13 +115,7 @@ warning: printing item
                       vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
                       ident: Ident {
                           name: "print_me",
-                          span: Span {
-                              source: File(
-                                  "$DIR/print_const_generics.rs",
-                              ),
-                              start: 73,
-                              end: 81,
-                          },
+                          span: $DIR/print_const_generics.rs:5:4 - 5:12,
                       },
                   },
                   generics: SynGenericParams {
@@ -162,13 +144,7 @@ warning: printing item
                                           AstPathSegment {
                                               ident: Ident {
                                                   name: "PrintMeConstGenerics",
-                                                  span: Span {
-                                                      source: File(
-                                                          "$DIR/print_const_generics.rs",
-                                                      ),
-                                                      start: 87,
-                                                      end: 107,
-                                                  },
+                                                  span: $DIR/print_const_generics.rs:5:18 - 5:38,
                                               },
                                               generics: SynGenericArgs {
                                                   args: [
@@ -209,12 +185,10 @@ warning: printing item
           )
 
 warning: print type test
-  --> $DIR/print_const_generics.rs:13:5
+  --> $DIR/print_const_generics.rs:12:5
    |
-13 | /     let _ty: PrintMeConstGenerics<3> = PrintMeConstGenerics {
-14 | |         data: [1.0, 1.5, 2.0],
-15 | |     };
-   | |______^
+12 |     let _ty: PrintMeConstGenerics<3> = PrintMeConstGenerics { data: [1.0, 1.5, 2.0] };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: Adt(
                SemAdtTy {

--- a/marker_uilints/tests/ui/print_ctor.stderr
+++ b/marker_uilints/tests/ui/print_ctor.stderr
@@ -365,13 +365,7 @@ warning: print test
                                AstPathSegment {
                                    ident: Ident {
                                        name: "FieldStruct",
-                                       span: Span {
-                                           source: File(
-                                               "$DIR/print_ctor.rs",
-                                           ),
-                                           start: 519,
-                                           end: 530,
-                                       },
+                                       span: $DIR/print_ctor.rs:29:23 - 29:34,
                                    },
                                    generics: SynGenericArgs {
                                        args: [],
@@ -388,13 +382,7 @@ warning: print test
                            span: SpanId(..),
                            ident: Ident {
                                name: "a",
-                               span: Span {
-                                   source: File(
-                                       "$DIR/print_ctor.rs",
-                                   ),
-                                   start: 533,
-                                   end: 534,
-                               },
+                               span: $DIR/print_ctor.rs:29:37 - 29:38,
                            },
                            expr: IntLit(
                                IntLitExpr {
@@ -412,13 +400,7 @@ warning: print test
                            span: SpanId(..),
                            ident: Ident {
                                name: "b",
-                               span: Span {
-                                   source: File(
-                                       "$DIR/print_ctor.rs",
-                                   ),
-                                   start: 539,
-                                   end: 540,
-                               },
+                               span: $DIR/print_ctor.rs:29:43 - 29:44,
                            },
                            expr: IntLit(
                                IntLitExpr {
@@ -461,13 +443,7 @@ warning: print test
                                AstPathSegment {
                                    ident: Ident {
                                        name: "FieldStruct",
-                                       span: Span {
-                                           source: File(
-                                               "$DIR/print_ctor.rs",
-                                           ),
-                                           start: 569,
-                                           end: 580,
-                                       },
+                                       span: $DIR/print_ctor.rs:30:23 - 30:34,
                                    },
                                    generics: SynGenericArgs {
                                        args: [],
@@ -484,13 +460,7 @@ warning: print test
                            span: SpanId(..),
                            ident: Ident {
                                name: "a",
-                               span: Span {
-                                   source: File(
-                                       "$DIR/print_ctor.rs",
-                                   ),
-                                   start: 591,
-                                   end: 592,
-                               },
+                               span: $DIR/print_ctor.rs:31:9 - 31:10,
                            },
                            expr: IntLit(
                                IntLitExpr {
@@ -537,13 +507,7 @@ warning: print test
                                                                    AstPathSegment {
                                                                        ident: Ident {
                                                                            name: "FieldStruct",
-                                                                           span: Span {
-                                                                               source: File(
-                                                                                   "$DIR/print_ctor.rs",
-                                                                               ),
-                                                                               start: 608,
-                                                                               end: 619,
-                                                                           },
+                                                                           span: $DIR/print_ctor.rs:32:11 - 32:22,
                                                                        },
                                                                        generics: SynGenericArgs {
                                                                            args: [],
@@ -563,13 +527,7 @@ warning: print test
                                                    AstPathSegment {
                                                        ident: Ident {
                                                            name: "FieldStruct",
-                                                           span: Span {
-                                                               source: File(
-                                                                   "$DIR/print_ctor.rs",
-                                                               ),
-                                                               start: 608,
-                                                               end: 619,
-                                                           },
+                                                           span: $DIR/print_ctor.rs:32:11 - 32:22,
                                                        },
                                                        generics: SynGenericArgs {
                                                            args: [],
@@ -578,13 +536,7 @@ warning: print test
                                                    AstPathSegment {
                                                        ident: Ident {
                                                            name: "default",
-                                                           span: Span {
-                                                               source: File(
-                                                                   "$DIR/print_ctor.rs",
-                                                               ),
-                                                               start: 621,
-                                                               end: 628,
-                                                           },
+                                                           span: $DIR/print_ctor.rs:32:24 - 32:31,
                                                        },
                                                        generics: SynGenericArgs {
                                                            args: [],
@@ -626,13 +578,7 @@ warning: print test
                                AstPathSegment {
                                    ident: Ident {
                                        name: "Union",
-                                       span: Span {
-                                           source: File(
-                                               "$DIR/print_ctor.rs",
-                                           ),
-                                           start: 661,
-                                           end: 666,
-                                       },
+                                       span: $DIR/print_ctor.rs:35:23 - 35:28,
                                    },
                                    generics: SynGenericArgs {
                                        args: [],
@@ -649,13 +595,7 @@ warning: print test
                            span: SpanId(..),
                            ident: Ident {
                                name: "a",
-                               span: Span {
-                                   source: File(
-                                       "$DIR/print_ctor.rs",
-                                   ),
-                                   start: 669,
-                                   end: 670,
-                               },
+                               span: $DIR/print_ctor.rs:35:31 - 35:32,
                            },
                            expr: IntLit(
                                IntLitExpr {
@@ -695,13 +635,7 @@ warning: print test
                                AstPathSegment {
                                    ident: Ident {
                                        name: "TupleStruct",
-                                       span: Span {
-                                           source: File(
-                                               "$DIR/print_ctor.rs",
-                                           ),
-                                           start: 700,
-                                           end: 711,
-                                       },
+                                       span: $DIR/print_ctor.rs:37:23 - 37:34,
                                    },
                                    generics: SynGenericArgs {
                                        args: [],
@@ -718,13 +652,7 @@ warning: print test
                            span: SpanId(..),
                            ident: Ident {
                                name: "0",
-                               span: Span {
-                                   source: File(
-                                       "$DIR/print_ctor.rs",
-                                   ),
-                                   start: 0,
-                                   end: 0,
-                               },
+                               span: $DIR/print_ctor.rs:1:1 - 1:1,
                            },
                            expr: IntLit(
                                IntLitExpr {
@@ -742,13 +670,7 @@ warning: print test
                            span: SpanId(..),
                            ident: Ident {
                                name: "1",
-                               span: Span {
-                                   source: File(
-                                       "$DIR/print_ctor.rs",
-                                   ),
-                                   start: 0,
-                                   end: 0,
-                               },
+                               span: $DIR/print_ctor.rs:1:1 - 1:1,
                            },
                            expr: IntLit(
                                IntLitExpr {
@@ -791,13 +713,7 @@ warning: print test
                                AstPathSegment {
                                    ident: Ident {
                                        name: "TupleStruct",
-                                       span: Span {
-                                           source: File(
-                                               "$DIR/print_ctor.rs",
-                                           ),
-                                           start: 741,
-                                           end: 752,
-                                       },
+                                       span: $DIR/print_ctor.rs:38:23 - 38:34,
                                    },
                                    generics: SynGenericArgs {
                                        args: [],
@@ -814,13 +730,7 @@ warning: print test
                            span: SpanId(..),
                            ident: Ident {
                                name: "0",
-                               span: Span {
-                                   source: File(
-                                       "$DIR/print_ctor.rs",
-                                   ),
-                                   start: 763,
-                                   end: 764,
-                               },
+                               span: $DIR/print_ctor.rs:39:9 - 39:10,
                            },
                            expr: IntLit(
                                IntLitExpr {
@@ -867,13 +777,7 @@ warning: print test
                                                                    AstPathSegment {
                                                                        ident: Ident {
                                                                            name: "TupleStruct",
-                                                                           span: Span {
-                                                                               source: File(
-                                                                                   "$DIR/print_ctor.rs",
-                                                                               ),
-                                                                               start: 779,
-                                                                               end: 790,
-                                                                           },
+                                                                           span: $DIR/print_ctor.rs:40:11 - 40:22,
                                                                        },
                                                                        generics: SynGenericArgs {
                                                                            args: [],
@@ -893,13 +797,7 @@ warning: print test
                                                    AstPathSegment {
                                                        ident: Ident {
                                                            name: "TupleStruct",
-                                                           span: Span {
-                                                               source: File(
-                                                                   "$DIR/print_ctor.rs",
-                                                               ),
-                                                               start: 779,
-                                                               end: 790,
-                                                           },
+                                                           span: $DIR/print_ctor.rs:40:11 - 40:22,
                                                        },
                                                        generics: SynGenericArgs {
                                                            args: [],
@@ -908,13 +806,7 @@ warning: print test
                                                    AstPathSegment {
                                                        ident: Ident {
                                                            name: "default",
-                                                           span: Span {
-                                                               source: File(
-                                                                   "$DIR/print_ctor.rs",
-                                                               ),
-                                                               start: 792,
-                                                               end: 799,
-                                                           },
+                                                           span: $DIR/print_ctor.rs:40:24 - 40:31,
                                                        },
                                                        generics: SynGenericArgs {
                                                            args: [],
@@ -956,13 +848,7 @@ warning: print test
                                AstPathSegment {
                                    ident: Ident {
                                        name: "Enum",
-                                       span: Span {
-                                           source: File(
-                                               "$DIR/print_ctor.rs",
-                                           ),
-                                           start: 832,
-                                           end: 836,
-                                       },
+                                       span: $DIR/print_ctor.rs:43:23 - 43:27,
                                    },
                                    generics: SynGenericArgs {
                                        args: [],
@@ -971,13 +857,7 @@ warning: print test
                                AstPathSegment {
                                    ident: Ident {
                                        name: "A",
-                                       span: Span {
-                                           source: File(
-                                               "$DIR/print_ctor.rs",
-                                           ),
-                                           start: 838,
-                                           end: 839,
-                                       },
+                                       span: $DIR/print_ctor.rs:43:29 - 43:30,
                                    },
                                    generics: SynGenericArgs {
                                        args: [],
@@ -1015,13 +895,7 @@ warning: print test
                                AstPathSegment {
                                    ident: Ident {
                                        name: "Enum",
-                                       span: Span {
-                                           source: File(
-                                               "$DIR/print_ctor.rs",
-                                           ),
-                                           start: 863,
-                                           end: 867,
-                                       },
+                                       span: $DIR/print_ctor.rs:44:23 - 44:27,
                                    },
                                    generics: SynGenericArgs {
                                        args: [],
@@ -1030,13 +904,7 @@ warning: print test
                                AstPathSegment {
                                    ident: Ident {
                                        name: "B",
-                                       span: Span {
-                                           source: File(
-                                               "$DIR/print_ctor.rs",
-                                           ),
-                                           start: 869,
-                                           end: 870,
-                                       },
+                                       span: $DIR/print_ctor.rs:44:29 - 44:30,
                                    },
                                    generics: SynGenericArgs {
                                        args: [],
@@ -1053,13 +921,7 @@ warning: print test
                            span: SpanId(..),
                            ident: Ident {
                                name: "0",
-                               span: Span {
-                                   source: File(
-                                       "$DIR/print_ctor.rs",
-                                   ),
-                                   start: 0,
-                                   end: 0,
-                               },
+                               span: $DIR/print_ctor.rs:1:1 - 1:1,
                            },
                            expr: IntLit(
                                IntLitExpr {
@@ -1099,13 +961,7 @@ warning: print test
                                AstPathSegment {
                                    ident: Ident {
                                        name: "Enum",
-                                       span: Span {
-                                           source: File(
-                                               "$DIR/print_ctor.rs",
-                                           ),
-                                           start: 897,
-                                           end: 901,
-                                       },
+                                       span: $DIR/print_ctor.rs:45:23 - 45:27,
                                    },
                                    generics: SynGenericArgs {
                                        args: [],
@@ -1114,13 +970,7 @@ warning: print test
                                AstPathSegment {
                                    ident: Ident {
                                        name: "C",
-                                       span: Span {
-                                           source: File(
-                                               "$DIR/print_ctor.rs",
-                                           ),
-                                           start: 903,
-                                           end: 904,
-                                       },
+                                       span: $DIR/print_ctor.rs:45:29 - 45:30,
                                    },
                                    generics: SynGenericArgs {
                                        args: [],
@@ -1137,13 +987,7 @@ warning: print test
                            span: SpanId(..),
                            ident: Ident {
                                name: "f1",
-                               span: Span {
-                                   source: File(
-                                       "$DIR/print_ctor.rs",
-                                   ),
-                                   start: 907,
-                                   end: 909,
-                               },
+                               span: $DIR/print_ctor.rs:45:33 - 45:35,
                            },
                            expr: IntLit(
                                IntLitExpr {
@@ -1161,13 +1005,7 @@ warning: print test
                            span: SpanId(..),
                            ident: Ident {
                                name: "f2",
-                               span: Span {
-                                   source: File(
-                                       "$DIR/print_ctor.rs",
-                                   ),
-                                   start: 915,
-                                   end: 917,
-                               },
+                               span: $DIR/print_ctor.rs:45:41 - 45:43,
                            },
                            expr: IntLit(
                                IntLitExpr {

--- a/marker_uilints/tests/ui/print_loop_expr.stderr
+++ b/marker_uilints/tests/ui/print_loop_expr.stderr
@@ -29,13 +29,7 @@ warning: print test
                                   label: Some(
                                       Ident {
                                           name: "'label",
-                                          span: Span {
-                                              source: File(
-                                                  "$DIR/print_loop_expr.rs",
-                                              ),
-                                              start: 45,
-                                              end: 51,
-                                          },
+                                          span: $DIR/print_loop_expr.rs:3:9 - 3:15,
                                       },
                                   ),
                                   block: Block(
@@ -57,13 +51,7 @@ warning: print test
                                                           label: Some(
                                                               Ident {
                                                                   name: "'label",
-                                                                  span: Span {
-                                                                      source: File(
-                                                                          "$DIR/print_loop_expr.rs",
-                                                                      ),
-                                                                      start: 78,
-                                                                      end: 84,
-                                                                  },
+                                                                  span: $DIR/print_loop_expr.rs:4:19 - 4:25,
                                                               },
                                                           ),
                                                           target_id: ExprId(..),
@@ -164,13 +152,7 @@ warning: print test
                                                        AstPathSegment {
                                                            ident: Ident {
                                                                name: "cond",
-                                                               span: Span {
-                                                                   source: File(
-                                                                       "$DIR/print_loop_expr.rs",
-                                                                   ),
-                                                                   start: 210,
-                                                                   end: 214,
-                                                               },
+                                                               span: $DIR/print_loop_expr.rs:13:15 - 13:19,
                                                            },
                                                            generics: SynGenericArgs {
                                                                args: [],
@@ -234,13 +216,7 @@ warning: print test
                                                            AstPathSegment {
                                                                ident: Ident {
                                                                    name: "Some",
-                                                                   span: Span {
-                                                                       source: File(
-                                                                           "$DIR/print_loop_expr.rs",
-                                                                       ),
-                                                                       start: 237,
-                                                                       end: 241,
-                                                                   },
+                                                                   span: $DIR/print_loop_expr.rs:15:19 - 15:23,
                                                                },
                                                                generics: SynGenericArgs {
                                                                    args: [],
@@ -284,13 +260,7 @@ warning: print test
                                                            AstPathSegment {
                                                                ident: Ident {
                                                                    name: "opt",
-                                                                   span: Span {
-                                                                       source: File(
-                                                                           "$DIR/print_loop_expr.rs",
-                                                                       ),
-                                                                       start: 247,
-                                                                       end: 250,
-                                                                   },
+                                                                   span: $DIR/print_loop_expr.rs:15:29 - 15:32,
                                                                },
                                                                generics: SynGenericArgs {
                                                                    args: [],
@@ -338,13 +308,7 @@ warning: print test
                                                                                AstPathSegment {
                                                                                    ident: Ident {
                                                                                        name: "opt",
-                                                                                       span: Span {
-                                                                                           source: File(
-                                                                                               "$DIR/print_loop_expr.rs",
-                                                                                           ),
-                                                                                           start: 265,
-                                                                                           end: 268,
-                                                                                       },
+                                                                                       span: $DIR/print_loop_expr.rs:16:13 - 16:16,
                                                                                    },
                                                                                    generics: SynGenericArgs {
                                                                                        args: [],
@@ -375,13 +339,7 @@ warning: print test
                                                                            AstPathSegment {
                                                                                ident: Ident {
                                                                                    name: "None",
-                                                                                   span: Span {
-                                                                                       source: File(
-                                                                                           "$DIR/print_loop_expr.rs",
-                                                                                       ),
-                                                                                       start: 271,
-                                                                                       end: 275,
-                                                                                   },
+                                                                                   span: $DIR/print_loop_expr.rs:16:19 - 16:23,
                                                                                },
                                                                                generics: SynGenericArgs {
                                                                                    args: [],
@@ -573,13 +531,7 @@ warning: print test
                                                    AstPathSegment {
                                                        ident: Ident {
                                                            name: "tuple_slice",
-                                                           span: Span {
-                                                               source: File(
-                                                                   "$DIR/print_loop_expr.rs",
-                                                               ),
-                                                               start: 428,
-                                                               end: 439,
-                                                           },
+                                                           span: $DIR/print_loop_expr.rs:25:23 - 25:34,
                                                        },
                                                        generics: SynGenericArgs {
                                                            args: [],
@@ -625,13 +577,7 @@ warning: print test
                                                                                AstPathSegment {
                                                                                    ident: Ident {
                                                                                        name: "c",
-                                                                                       span: Span {
-                                                                                           source: File(
-                                                                                               "$DIR/print_loop_expr.rs",
-                                                                                           ),
-                                                                                           start: 454,
-                                                                                           end: 455,
-                                                                                       },
+                                                                                       span: $DIR/print_loop_expr.rs:26:13 - 26:14,
                                                                                    },
                                                                                    generics: SynGenericArgs {
                                                                                        args: [],
@@ -669,13 +615,7 @@ warning: print test
                                                                                    AstPathSegment {
                                                                                        ident: Ident {
                                                                                            name: "a",
-                                                                                           span: Span {
-                                                                                               source: File(
-                                                                                                   "$DIR/print_loop_expr.rs",
-                                                                                               ),
-                                                                                               start: 459,
-                                                                                               end: 460,
-                                                                                           },
+                                                                                           span: $DIR/print_loop_expr.rs:26:18 - 26:19,
                                                                                        },
                                                                                        generics: SynGenericArgs {
                                                                                            args: [],
@@ -704,13 +644,7 @@ warning: print test
                                                                                    AstPathSegment {
                                                                                        ident: Ident {
                                                                                            name: "b",
-                                                                                           span: Span {
-                                                                                               source: File(
-                                                                                                   "$DIR/print_loop_expr.rs",
-                                                                                               ),
-                                                                                               start: 463,
-                                                                                               end: 464,
-                                                                                           },
+                                                                                           span: $DIR/print_loop_expr.rs:26:22 - 26:23,
                                                                                        },
                                                                                        generics: SynGenericArgs {
                                                                                            args: [],

--- a/marker_uilints/tests/ui/print_object_exprs.stderr
+++ b/marker_uilints/tests/ui/print_object_exprs.stderr
@@ -26,13 +26,7 @@ warning: print test
                                        AstPathSegment {
                                            ident: Ident {
                                                name: "foo",
-                                               span: Span {
-                                                   source: File(
-                                                       "$DIR/print_object_exprs.rs",
-                                                   ),
-                                                   start: 273,
-                                                   end: 276,
-                                               },
+                                               span: $DIR/print_object_exprs.rs:18:25 - 18:28,
                                            },
                                            generics: SynGenericArgs {
                                                args: [],
@@ -49,13 +43,7 @@ warning: print test
                    method: AstPathSegment {
                        ident: Ident {
                            name: "print",
-                           span: Span {
-                               source: File(
-                                   "$DIR/print_object_exprs.rs",
-                               ),
-                               start: 277,
-                               end: 282,
-                           },
+                           span: $DIR/print_object_exprs.rs:18:29 - 18:34,
                        },
                        generics: SynGenericArgs {
                            args: [],
@@ -94,13 +82,7 @@ warning: print test
                                        AstPathSegment {
                                            ident: Ident {
                                                name: "foo",
-                                               span: Span {
-                                                   source: File(
-                                                       "$DIR/print_object_exprs.rs",
-                                                   ),
-                                                   start: 310,
-                                                   end: 313,
-                                               },
+                                               span: $DIR/print_object_exprs.rs:19:25 - 19:28,
                                            },
                                            generics: SynGenericArgs {
                                                args: [],
@@ -117,13 +99,7 @@ warning: print test
                    method: AstPathSegment {
                        ident: Ident {
                            name: "inc",
-                           span: Span {
-                               source: File(
-                                   "$DIR/print_object_exprs.rs",
-                               ),
-                               start: 314,
-                               end: 317,
-                           },
+                           span: $DIR/print_object_exprs.rs:19:29 - 19:32,
                        },
                        generics: SynGenericArgs {
                            args: [],

--- a/marker_uilints/tests/ui/print_op.stderr
+++ b/marker_uilints/tests/ui/print_op.stderr
@@ -200,13 +200,7 @@ warning: print test
                                       AstPathSegment {
                                           ident: Ident {
                                               name: "value",
-                                              span: Span {
-                                                  source: File(
-                                                      "$DIR/print_op.rs",
-                                                  ),
-                                                  start: 201,
-                                                  end: 206,
-                                              },
+                                              span: $DIR/print_op.rs:9:27 - 9:32,
                                           },
                                           generics: SynGenericArgs {
                                               args: [],

--- a/marker_uilints/tests/ui/print_path_expr.stderr
+++ b/marker_uilints/tests/ui/print_path_expr.stderr
@@ -26,13 +26,7 @@ warning: print test
                                        AstPathSegment {
                                            ident: Ident {
                                                name: "rand",
-                                               span: Span {
-                                                   source: File(
-                                                       "$DIR/print_path_expr.rs",
-                                                   ),
-                                                   start: 359,
-                                                   end: 363,
-                                               },
+                                               span: $DIR/print_path_expr.rs:29:23 - 29:27,
                                            },
                                            generics: SynGenericArgs {
                                                args: [],
@@ -100,13 +94,7 @@ warning: print test
                                                        AstPathSegment {
                                                            ident: Ident {
                                                                name: "Vec",
-                                                               span: Span {
-                                                                   source: File(
-                                                                       "$DIR/print_path_expr.rs",
-                                                                   ),
-                                                                   start: 390,
-                                                                   end: 393,
-                                                               },
+                                                               span: $DIR/print_path_expr.rs:30:23 - 30:26,
                                                            },
                                                            generics: SynGenericArgs {
                                                                args: [
@@ -140,13 +128,7 @@ warning: print test
                                        AstPathSegment {
                                            ident: Ident {
                                                name: "Vec",
-                                               span: Span {
-                                                   source: File(
-                                                       "$DIR/print_path_expr.rs",
-                                                   ),
-                                                   start: 390,
-                                                   end: 393,
-                                               },
+                                               span: $DIR/print_path_expr.rs:30:23 - 30:26,
                                            },
                                            generics: SynGenericArgs {
                                                args: [
@@ -169,13 +151,7 @@ warning: print test
                                        AstPathSegment {
                                            ident: Ident {
                                                name: "new",
-                                               span: Span {
-                                                   source: File(
-                                                       "$DIR/print_path_expr.rs",
-                                                   ),
-                                                   start: 402,
-                                                   end: 405,
-                                               },
+                                               span: $DIR/print_path_expr.rs:30:35 - 30:38,
                                            },
                                            generics: SynGenericArgs {
                                                args: [],
@@ -238,13 +214,7 @@ warning: print test
                                                                        AstPathSegment {
                                                                            ident: Ident {
                                                                                name: "Magic",
-                                                                               span: Span {
-                                                                                   source: File(
-                                                                                       "$DIR/print_path_expr.rs",
-                                                                                   ),
-                                                                                   start: 432,
-                                                                                   end: 437,
-                                                                               },
+                                                                               span: $DIR/print_path_expr.rs:31:24 - 31:29,
                                                                            },
                                                                            generics: SynGenericArgs {
                                                                                args: [],
@@ -265,13 +235,7 @@ warning: print test
                                                        AstPathSegment {
                                                            ident: Ident {
                                                                name: "B",
-                                                               span: Span {
-                                                                   source: File(
-                                                                       "$DIR/print_path_expr.rs",
-                                                                   ),
-                                                                   start: 441,
-                                                                   end: 442,
-                                                               },
+                                                               span: $DIR/print_path_expr.rs:31:33 - 31:34,
                                                            },
                                                            generics: SynGenericArgs {
                                                                args: [],
@@ -280,13 +244,7 @@ warning: print test
                                                        AstPathSegment {
                                                            ident: Ident {
                                                                name: "CoolTy",
-                                                               span: Span {
-                                                                   source: File(
-                                                                       "$DIR/print_path_expr.rs",
-                                                                   ),
-                                                                   start: 445,
-                                                                   end: 451,
-                                                               },
+                                                               span: $DIR/print_path_expr.rs:31:37 - 31:43,
                                                            },
                                                            generics: SynGenericArgs {
                                                                args: [],
@@ -306,13 +264,7 @@ warning: print test
                                        AstPathSegment {
                                            ident: Ident {
                                                name: "B",
-                                               span: Span {
-                                                   source: File(
-                                                       "$DIR/print_path_expr.rs",
-                                                   ),
-                                                   start: 441,
-                                                   end: 442,
-                                               },
+                                               span: $DIR/print_path_expr.rs:31:33 - 31:34,
                                            },
                                            generics: SynGenericArgs {
                                                args: [],
@@ -321,13 +273,7 @@ warning: print test
                                        AstPathSegment {
                                            ident: Ident {
                                                name: "CoolTy",
-                                               span: Span {
-                                                   source: File(
-                                                       "$DIR/print_path_expr.rs",
-                                                   ),
-                                                   start: 445,
-                                                   end: 451,
-                                               },
+                                               span: $DIR/print_path_expr.rs:31:37 - 31:43,
                                            },
                                            generics: SynGenericArgs {
                                                args: [],
@@ -336,13 +282,7 @@ warning: print test
                                        AstPathSegment {
                                            ident: Ident {
                                                name: "a",
-                                               span: Span {
-                                                   source: File(
-                                                       "$DIR/print_path_expr.rs",
-                                                   ),
-                                                   start: 453,
-                                                   end: 454,
-                                               },
+                                               span: $DIR/print_path_expr.rs:31:45 - 31:46,
                                            },
                                            generics: SynGenericArgs {
                                                args: [],
@@ -404,13 +344,7 @@ warning: print test
                                                                        AstPathSegment {
                                                                            ident: Ident {
                                                                                name: "Magic",
-                                                                               span: Span {
-                                                                                   source: File(
-                                                                                       "$DIR/print_path_expr.rs",
-                                                                                   ),
-                                                                                   start: 482,
-                                                                                   end: 487,
-                                                                               },
+                                                                               span: $DIR/print_path_expr.rs:32:25 - 32:30,
                                                                            },
                                                                            generics: SynGenericArgs {
                                                                                args: [],
@@ -431,13 +365,7 @@ warning: print test
                                                        AstPathSegment {
                                                            ident: Ident {
                                                                name: "B",
-                                                               span: Span {
-                                                                   source: File(
-                                                                       "$DIR/print_path_expr.rs",
-                                                                   ),
-                                                                   start: 491,
-                                                                   end: 492,
-                                                               },
+                                                               span: $DIR/print_path_expr.rs:32:34 - 32:35,
                                                            },
                                                            generics: SynGenericArgs {
                                                                args: [],
@@ -446,13 +374,7 @@ warning: print test
                                                        AstPathSegment {
                                                            ident: Ident {
                                                                name: "CoolTy",
-                                                               span: Span {
-                                                                   source: File(
-                                                                       "$DIR/print_path_expr.rs",
-                                                                   ),
-                                                                   start: 495,
-                                                                   end: 501,
-                                                               },
+                                                               span: $DIR/print_path_expr.rs:32:38 - 32:44,
                                                            },
                                                            generics: SynGenericArgs {
                                                                args: [],
@@ -473,13 +395,7 @@ warning: print test
                                        AstPathSegment {
                                            ident: Ident {
                                                name: "A",
-                                               span: Span {
-                                                   source: File(
-                                                       "$DIR/print_path_expr.rs",
-                                                   ),
-                                                   start: 505,
-                                                   end: 506,
-                                               },
+                                               span: $DIR/print_path_expr.rs:32:48 - 32:49,
                                            },
                                            generics: SynGenericArgs {
                                                args: [],
@@ -488,13 +404,7 @@ warning: print test
                                        AstPathSegment {
                                            ident: Ident {
                                                name: "a",
-                                               span: Span {
-                                                   source: File(
-                                                       "$DIR/print_path_expr.rs",
-                                                   ),
-                                                   start: 509,
-                                                   end: 510,
-                                               },
+                                               span: $DIR/print_path_expr.rs:32:52 - 32:53,
                                            },
                                            generics: SynGenericArgs {
                                                args: [],
@@ -533,13 +443,7 @@ warning: print test
                                AstPathSegment {
                                    ident: Ident {
                                        name: "var",
-                                       span: Span {
-                                           source: File(
-                                               "$DIR/print_path_expr.rs",
-                                           ),
-                                           start: 554,
-                                           end: 557,
-                                       },
+                                       span: $DIR/print_path_expr.rs:35:23 - 35:26,
                                    },
                                    generics: SynGenericArgs {
                                        args: [],

--- a/marker_uilints/tests/ui/print_place_expr.stderr
+++ b/marker_uilints/tests/ui/print_place_expr.stderr
@@ -26,13 +26,7 @@ warning: print test
                                        AstPathSegment {
                                            ident: Ident {
                                                name: "object",
-                                               span: Span {
-                                                   source: File(
-                                                       "$DIR/print_place_expr.rs",
-                                                   ),
-                                                   start: 192,
-                                                   end: 198,
-                                               },
+                                               span: $DIR/print_place_expr.rs:11:31 - 11:37,
                                            },
                                            generics: SynGenericArgs {
                                                args: [],
@@ -48,13 +42,7 @@ warning: print test
                    ),
                    field: Ident {
                        name: "a",
-                       span: Span {
-                           source: File(
-                               "$DIR/print_place_expr.rs",
-                           ),
-                           start: 199,
-                           end: 200,
-                       },
+                       span: $DIR/print_place_expr.rs:11:38 - 11:39,
                    },
                },
            )
@@ -88,13 +76,7 @@ warning: print test
                                        AstPathSegment {
                                            ident: Ident {
                                                name: "tuple",
-                                               span: Span {
-                                                   source: File(
-                                                       "$DIR/print_place_expr.rs",
-                                                   ),
-                                                   start: 231,
-                                                   end: 236,
-                                               },
+                                               span: $DIR/print_place_expr.rs:12:30 - 12:35,
                                            },
                                            generics: SynGenericArgs {
                                                args: [],
@@ -110,13 +92,7 @@ warning: print test
                    ),
                    field: Ident {
                        name: "0",
-                       span: Span {
-                           source: File(
-                               "$DIR/print_place_expr.rs",
-                           ),
-                           start: 237,
-                           end: 238,
-                       },
+                       span: $DIR/print_place_expr.rs:12:36 - 12:37,
                    },
                },
            )
@@ -149,13 +125,7 @@ warning: print test
                                        AstPathSegment {
                                            ident: Ident {
                                                name: "array",
-                                               span: Span {
-                                                   source: File(
-                                                       "$DIR/print_place_expr.rs",
-                                                   ),
-                                                   start: 269,
-                                                   end: 274,
-                                               },
+                                               span: $DIR/print_place_expr.rs:13:30 - 13:35,
                                            },
                                            generics: SynGenericArgs {
                                                args: [],

--- a/marker_uilints/tests/ui/print_span.rs
+++ b/marker_uilints/tests/ui/print_span.rs
@@ -5,6 +5,11 @@ macro_rules! magic_macro {
 }
 use magic_macro;
 
+fn try_something() -> Option<u32> {
+    let _span_try = Some(21)?;
+    None
+}
+
 fn main() {
     let _span_normal = 178;
 

--- a/marker_uilints/tests/ui/print_span.stderr
+++ b/marker_uilints/tests/ui/print_span.stderr
@@ -1,33 +1,50 @@
 warning: print span
  --> $DIR/print_span.rs:9:5
   |
-9 |     let _span_normal = 178;
-  |     ^^^^^^^^^^^^^^^^^^^^^^^
+9 |     let _span_try = Some(21)?;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: Debug: Span {
-              source: File(
-                  "$DIR/print_span.rs",
-              ),
-              start: 134,
-              end: 137,
-          }
-  = note: Snippet: 178
+  = note: Debug: $DIR/print_span.rs:9:21 - 9:30
+  = note: Snippet: Some(21)?
+  = note: Source: File(
+              FileInfo {
+                  file: "$DIR/print_span.rs",
+                  span_src: SpanSrcId(..),
+              },
+          )
   = note: `#[warn(marker::print_span_lint)]` on by default
 
 warning: print span
-  --> $DIR/print_span.rs:11:5
+  --> $DIR/print_span.rs:14:5
    |
-11 |     let _span_macro = magic_macro!();
+14 |     let _span_normal = 178;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: Debug: $DIR/print_span.rs:14:24 - 14:27
+   = note: Snippet: 178
+   = note: Source: File(
+               FileInfo {
+                   file: "$DIR/print_span.rs",
+                   span_src: SpanSrcId(..),
+               },
+           )
+
+warning: print span
+  --> $DIR/print_span.rs:16:5
+   |
+16 |     let _span_macro = magic_macro!();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: Debug: Span {
-               source: Macro(
-                   SpanSrcId(..),
-               ),
-               start: 0,
-               end: 14,
-           }
-   = note: Snippet: magic_macro!()
+   = note: Debug: [Inside Macro] $DIR/print_span.rs:16:23 - 16:37
+   = note: Snippet: "*magic penguin noises*"
+   = note: Source: Macro(
+               ExpnInfo {
+                   _lifetime: PhantomData<&()>,
+                   parent: ExpnId(..),
+                   call_site: SpanId(..),
+                   macro_id: MacroId(..),
+               },
+           )
 
-warning: 2 warnings emitted
+warning: 3 warnings emitted
 

--- a/marker_uilints/tests/ui/print_ty.stderr
+++ b/marker_uilints/tests/ui/print_ty.stderr
@@ -20,13 +20,7 @@ Path(
                     AstPathSegment {
                         ident: Ident {
                             name: "Option",
-                            span: Span {
-                                source: File(
-                                    "$DIR/print_ty.rs",
-                                ),
-                                start: 85,
-                                end: 91,
-                            },
+                            span: $DIR/print_ty.rs:4:32 - 4:38,
                         },
                         generics: SynGenericArgs {
                             args: [
@@ -131,13 +125,7 @@ Path(
                     AstPathSegment {
                         ident: Ident {
                             name: "Option",
-                            span: Span {
-                                source: File(
-                                    "$DIR/print_ty.rs",
-                                ),
-                                start: 165,
-                                end: 171,
-                            },
+                            span: $DIR/print_ty.rs:5:32 - 5:38,
                         },
                         generics: SynGenericArgs {
                             args: [
@@ -242,13 +230,7 @@ Path(
                     AstPathSegment {
                         ident: Ident {
                             name: "Option",
-                            span: Span {
-                                source: File(
-                                    "$DIR/print_ty.rs",
-                                ),
-                                start: 245,
-                                end: 251,
-                            },
+                            span: $DIR/print_ty.rs:6:32 - 6:38,
                         },
                         generics: SynGenericArgs {
                             args: [
@@ -334,13 +316,7 @@ Path(
                     AstPathSegment {
                         ident: Ident {
                             name: "Option",
-                            span: Span {
-                                source: File(
-                                    "$DIR/print_ty.rs",
-                                ),
-                                start: 312,
-                                end: 318,
-                            },
+                            span: $DIR/print_ty.rs:7:29 - 7:35,
                         },
                         generics: SynGenericArgs {
                             args: [
@@ -360,13 +336,7 @@ Path(
                                                             AstPathSegment {
                                                                 ident: Ident {
                                                                     name: "AllowSync",
-                                                                    span: Span {
-                                                                        source: File(
-                                                                            "$DIR/print_ty.rs",
-                                                                        ),
-                                                                        start: 319,
-                                                                        end: 328,
-                                                                    },
+                                                                    span: $DIR/print_ty.rs:7:36 - 7:45,
                                                                 },
                                                                 generics: SynGenericArgs {
                                                                     args: [
@@ -497,13 +467,7 @@ Path(
                     AstPathSegment {
                         ident: Ident {
                             name: "Option",
-                            span: Span {
-                                source: File(
-                                    "$DIR/print_ty.rs",
-                                ),
-                                start: 385,
-                                end: 391,
-                            },
+                            span: $DIR/print_ty.rs:8:28 - 8:34,
                         },
                         generics: SynGenericArgs {
                             args: [
@@ -523,13 +487,7 @@ Path(
                                                             AstPathSegment {
                                                                 ident: Ident {
                                                                     name: "AllowSync",
-                                                                    span: Span {
-                                                                        source: File(
-                                                                            "$DIR/print_ty.rs",
-                                                                        ),
-                                                                        start: 392,
-                                                                        end: 401,
-                                                                    },
+                                                                    span: $DIR/print_ty.rs:8:35 - 8:44,
                                                                 },
                                                                 generics: SynGenericArgs {
                                                                     args: [
@@ -663,13 +621,7 @@ Path(
                     AstPathSegment {
                         ident: Ident {
                             name: "Option",
-                            span: Span {
-                                source: File(
-                                    "$DIR/print_ty.rs",
-                                ),
-                                start: 476,
-                                end: 482,
-                            },
+                            span: $DIR/print_ty.rs:9:28 - 9:34,
                         },
                         generics: SynGenericArgs {
                             args: [
@@ -689,13 +641,7 @@ Path(
                                                             AstPathSegment {
                                                                 ident: Ident {
                                                                     name: "AllowSync",
-                                                                    span: Span {
-                                                                        source: File(
-                                                                            "$DIR/print_ty.rs",
-                                                                        ),
-                                                                        start: 488,
-                                                                        end: 497,
-                                                                    },
+                                                                    span: $DIR/print_ty.rs:10:5 - 10:14,
                                                                 },
                                                                 generics: SynGenericArgs {
                                                                     args: [
@@ -722,13 +668,7 @@ Path(
                                                                                                                 AstPathSegment {
                                                                                                                     ident: Ident {
                                                                                                                         name: "AliasTy",
-                                                                                                                        span: Span {
-                                                                                                                            source: File(
-                                                                                                                                "$DIR/print_ty.rs",
-                                                                                                                            ),
-                                                                                                                            start: 508,
-                                                                                                                            end: 515,
-                                                                                                                        },
+                                                                                                                        span: $DIR/print_ty.rs:11:9 - 11:16,
                                                                                                                     },
                                                                                                                     generics: SynGenericArgs {
                                                                                                                         args: [],
@@ -756,13 +696,7 @@ Path(
                                                                                                                 AstPathSegment {
                                                                                                                     ident: Ident {
                                                                                                                         name: "String",
-                                                                                                                        span: Span {
-                                                                                                                            source: File(
-                                                                                                                                "$DIR/print_ty.rs",
-                                                                                                                            ),
-                                                                                                                            start: 525,
-                                                                                                                            end: 531,
-                                                                                                                        },
+                                                                                                                        span: $DIR/print_ty.rs:12:9 - 12:15,
                                                                                                                     },
                                                                                                                     generics: SynGenericArgs {
                                                                                                                         args: [],
@@ -790,13 +724,7 @@ Path(
                                                                                                                 AstPathSegment {
                                                                                                                     ident: Ident {
                                                                                                                         name: "Option",
-                                                                                                                        span: Span {
-                                                                                                                            source: File(
-                                                                                                                                "$DIR/print_ty.rs",
-                                                                                                                            ),
-                                                                                                                            start: 541,
-                                                                                                                            end: 547,
-                                                                                                                        },
+                                                                                                                        span: $DIR/print_ty.rs:13:9 - 13:15,
                                                                                                                     },
                                                                                                                     generics: SynGenericArgs {
                                                                                                                         args: [
@@ -816,13 +744,7 @@ Path(
                                                                                                                                                         AstPathSegment {
                                                                                                                                                             ident: Ident {
                                                                                                                                                                 name: "String",
-                                                                                                                                                                span: Span {
-                                                                                                                                                                    source: File(
-                                                                                                                                                                        "$DIR/print_ty.rs",
-                                                                                                                                                                    ),
-                                                                                                                                                                    start: 548,
-                                                                                                                                                                    end: 554,
-                                                                                                                                                                },
+                                                                                                                                                                span: $DIR/print_ty.rs:13:16 - 13:22,
                                                                                                                                                             },
                                                                                                                                                             generics: SynGenericArgs {
                                                                                                                                                                 args: [],
@@ -863,13 +785,7 @@ Path(
                                                                                                                 AstPathSegment {
                                                                                                                     ident: Ident {
                                                                                                                         name: "Vec",
-                                                                                                                        span: Span {
-                                                                                                                            source: File(
-                                                                                                                                "$DIR/print_ty.rs",
-                                                                                                                            ),
-                                                                                                                            start: 565,
-                                                                                                                            end: 568,
-                                                                                                                        },
+                                                                                                                        span: $DIR/print_ty.rs:14:9 - 14:12,
                                                                                                                     },
                                                                                                                     generics: SynGenericArgs {
                                                                                                                         args: [
@@ -889,13 +805,7 @@ Path(
                                                                                                                                                         AstPathSegment {
                                                                                                                                                             ident: Ident {
                                                                                                                                                                 name: "UnionItem",
-                                                                                                                                                                span: Span {
-                                                                                                                                                                    source: File(
-                                                                                                                                                                        "$DIR/print_ty.rs",
-                                                                                                                                                                    ),
-                                                                                                                                                                    start: 569,
-                                                                                                                                                                    end: 578,
-                                                                                                                                                                },
+                                                                                                                                                                span: $DIR/print_ty.rs:14:13 - 14:22,
                                                                                                                                                             },
                                                                                                                                                             generics: SynGenericArgs {
                                                                                                                                                                 args: [],
@@ -936,13 +846,7 @@ Path(
                                                                                                                 AstPathSegment {
                                                                                                                     ident: Ident {
                                                                                                                         name: "Box",
-                                                                                                                        span: Span {
-                                                                                                                            source: File(
-                                                                                                                                "$DIR/print_ty.rs",
-                                                                                                                            ),
-                                                                                                                            start: 589,
-                                                                                                                            end: 592,
-                                                                                                                        },
+                                                                                                                        span: $DIR/print_ty.rs:15:9 - 15:12,
                                                                                                                     },
                                                                                                                     generics: SynGenericArgs {
                                                                                                                         args: [
@@ -997,13 +901,7 @@ Path(
                                                                                                                 AstPathSegment {
                                                                                                                     ident: Ident {
                                                                                                                         name: "Box",
-                                                                                                                        span: Span {
-                                                                                                                            source: File(
-                                                                                                                                "$DIR/print_ty.rs",
-                                                                                                                            ),
-                                                                                                                            start: 613,
-                                                                                                                            end: 616,
-                                                                                                                        },
+                                                                                                                        span: $DIR/print_ty.rs:16:9 - 16:12,
                                                                                                                     },
                                                                                                                     generics: SynGenericArgs {
                                                                                                                         args: [

--- a/marker_uilints/tests/uitest.rs
+++ b/marker_uilints/tests/uitest.rs
@@ -14,6 +14,7 @@ fn main() -> color_eyre::Result<()> {
         (r"ui//", "ui/"),
         (r"item//", "item/"),
         (r"expr//", "expr/"),
+        (r"sugar//", "sugar/"),
     ];
     for (pat, repl) in filters {
         config.stderr_filter(pat, repl);

--- a/marker_utils/src/visitor.rs
+++ b/marker_utils/src/visitor.rs
@@ -224,7 +224,7 @@ pub fn traverse_expr<'ast, B>(
             if let Some(start) = e.start() {
                 traverse_expr(cx, visitor, start)?;
             }
-            if let Some(end) = e.start() {
+            if let Some(end) = e.end() {
                 traverse_expr(cx, visitor, end)?;
             }
         },


### PR DESCRIPTION
Spans are a fundamental part of linting in Rust. The previous implementation of spans in Marker were hacked together, with me always adding something new when it was needed. This PR reworks spans from the ground up.

The implementation is inspired by rustc's [`Span`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_span/struct.Span.html) and connected data structures. 

While testing, I also found a few ICEs and mistakes, that were fixed as well. The short summary:
* Marker's `Span`s are now cool
* Marker has less errors and panics
* Changes are almost net negative

An awesome effect of this change is that the `Debug` format implementation of spans looks a lot better now, like this:
```
path/file.rs:17:6 - 17:7,
```

---

cc: rust-marker/marker#175