### PR TITLE
CI: Fix Marker Book Deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -36,7 +36,7 @@ jobs:
           mkdir deploy
           cp ./docs/index.html ./deploy/index.html
       - name: Build the book
-        run: mdbook build docs/book --dest-dir deploy/book
+        run: mdbook build docs/book --dest-dir ../../deploy/book
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2


### PR DESCRIPTION
Fix book deployment after switching to merge queues in rust-marker/marker#222