### PR TITLE
Chore: Use `workspace.package` and `workspace.dependencies` and bump version to `v0.2.0-dev`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "cargo_marker"
-version = "0.1.1"
+version = "0.2.0-dev"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -463,7 +463,7 @@ checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "marker_adapter"
-version = "0.1.1"
+version = "0.2.0-dev"
 dependencies = [
  "libloading",
  "marker_api",
@@ -473,14 +473,14 @@ dependencies = [
 
 [[package]]
 name = "marker_api"
-version = "0.1.1"
+version = "0.2.0-dev"
 dependencies = [
  "visibility",
 ]
 
 [[package]]
 name = "marker_lints"
-version = "0.1.1"
+version = "0.2.0-dev"
 dependencies = [
  "marker_api",
  "marker_uitest",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "marker_rustc_driver"
-version = "0.1.1"
+version = "0.2.0-dev"
 dependencies = [
  "bumpalo",
  "marker_adapter",
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "marker_uilints"
-version = "0.1.1"
+version = "0.2.0-dev"
 dependencies = [
  "marker_api",
  "marker_uitest",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "marker_uitest"
-version = "0.1.1"
+version = "0.2.0-dev"
 dependencies = [
  "semver",
  "tempfile",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "marker_utils"
-version = "0.1.1"
+version = "0.2.0-dev"
 dependencies = [
  "marker_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,34 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+edition    = "2021"
+keywords   = ["marker", "lint"]
+license    = "MIT OR Apache-2.0"
+repository = "https://github.com/rust-marker/marker"
+version    = "0.1.1"
+
+[workspace.dependencies]
+marker_adapter = { path = "./marker_adapter", version = "0.1.1" }
+marker_api     = { path = "./marker_api", version = "0.1.1" }
+marker_uitest  = { path = "./marker_uitest", features = ["dev-build"] }
+marker_utils   = { path = "./marker_utils", version = "0.1.1" }
+
+bumpalo          = "3.12"
+camino           = { version = "1.1", features = ["serde1"] }
+cargo_metadata   = "0.15.4"
+clap             = { version = "4.0", features = ["string", "derive"] }
+libloading       = "0.8.0"
+once_cell        = "1.17.0"
+rustc_tools_util = "0.3"
+semver           = "1.0"
+serde            = { version = "1.0", features = ["derive"] }
+serde_json       = "1.0"
+tempfile         = "3.6.0"
+thiserror        = "1.0.44"
+toml             = "0.7"
+ui_test          = "0.11.7"
+visibility       = "0.0.1"
+
 [workspace.metadata.marker.lints]
 marker_lints = { path = "./marker_lints" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,13 @@ edition    = "2021"
 keywords   = ["marker", "lint"]
 license    = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-marker/marker"
-version    = "0.1.1"
+version    = "0.2.0-dev"
 
 [workspace.dependencies]
-marker_adapter = { path = "./marker_adapter", version = "0.1.1" }
-marker_api     = { path = "./marker_api", version = "0.1.1" }
+marker_adapter = { path = "./marker_adapter", version = "0.2.0-dev" }
+marker_api     = { path = "./marker_api", version = "0.2.0-dev" }
 marker_uitest  = { path = "./marker_uitest", features = ["dev-build"] }
-marker_utils   = { path = "./marker_utils", version = "0.1.1" }
+marker_utils   = { path = "./marker_utils", version = "0.2.0-dev" }
 
 bumpalo          = "3.12"
 camino           = { version = "1.1", features = ["serde1"] }

--- a/cargo-marker/Cargo.toml
+++ b/cargo-marker/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
-name    = "cargo_marker"
-version = "0.1.1"
+name = "cargo_marker"
 
 categories  = ["development-tools::cargo-plugins"]
 description = "Marker's CLI interface to automatically compile and run lint crates"
-edition     = "2021"
 keywords    = ["marker", "linting", "cli", "cargo", "cargo-subcommand"]
-license     = "MIT OR Apache-2.0"
-repository  = "https://github.com/rust-marker/marker"
+
+edition    = { workspace = true }
+license    = { workspace = true }
+repository = { workspace = true }
+version    = { workspace = true }
 
 # Crate names in Rust are fun. I reserved `cargo_marker` as a crate name. However,
 # Cargo requires it's subcommands to use a dash like `cargo-marker`. Unable to
@@ -17,10 +18,10 @@ name = "cargo-marker"
 path = "src/main.rs"
 
 [dependencies]
-camino         = { version = "1.1", features = ["serde1"] }
-cargo_metadata = "0.15.4"
-clap           = { version = "4.0", features = ["string", "derive"] }
-once_cell      = "1.17.0"
-serde          = { version = "1.0", features = ["derive"] }
-serde_json     = "1.0"
-toml           = "0.7"
+camino         = { workspace = true }
+cargo_metadata = { workspace = true }
+clap           = { workspace = true }
+once_cell      = { workspace = true }
+serde          = { workspace = true }
+serde_json     = { workspace = true }
+toml           = { workspace = true }

--- a/cargo-marker/src/backend/driver.rs
+++ b/cargo-marker/src/backend/driver.rs
@@ -15,8 +15,8 @@ pub const MARKER_DRIVER_BIN_NAME: &str = "marker_rustc_driver.exe";
 /// to install the driver.
 pub static DEFAULT_DRIVER_INFO: Lazy<DriverVersionInfo> = Lazy::new(|| DriverVersionInfo {
     toolchain: "nightly-2023-07-13".to_string(),
-    version: "0.1.1".to_string(),
-    api_version: "0.1.1".to_string(),
+    version: "0.2.0-dev".to_string(),
+    api_version: "0.2.0-dev".to_string(),
 });
 
 /// The version info of one specific driver

--- a/marker_adapter/Cargo.toml
+++ b/marker_adapter/Cargo.toml
@@ -1,18 +1,19 @@
 [package]
-name    = "marker_adapter"
-version = "0.1.1"
+name = "marker_adapter"
 
 description = "Marker's adapter for common functions shared among lint drivers"
-edition     = "2021"
 keywords    = ["marker"]
-license     = "MIT OR Apache-2.0"
-repository  = "https://github.com/rust-marker/marker"
+
+edition    = { workspace = true }
+license    = { workspace = true }
+repository = { workspace = true }
+version    = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-marker_api   = { path = "../marker_api", version = "0.1.1", features = ["driver-api"] }
-marker_utils = { path = "../marker_utils", version = "0.1.1" }
+marker_api   = { workspace = true, features = ["driver-api"] }
+marker_utils = { workspace = true }
 
-libloading = "0.8.0"
-thiserror  = "1.0.44"
+libloading = { workspace = true }
+thiserror  = { workspace = true }

--- a/marker_api/Cargo.toml
+++ b/marker_api/Cargo.toml
@@ -1,18 +1,19 @@
 [package]
-name    = "marker_api"
-version = "0.1.1"
+name = "marker_api"
 
 categories  = ["development-tools"]
 description = "Marker's API, designed for stability and usability"
-edition     = "2021"
-keywords    = ["marker", "linting"]
-license     = "MIT OR Apache-2.0"
-repository  = "https://github.com/rust-marker/marker"
+
+edition    = { workspace = true }
+keywords   = { workspace = true }
+license    = { workspace = true }
+repository = { workspace = true }
+version    = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-visibility = "0.0.1"
+visibility = { workspace = true }
 
 [features]
 # Some items should only be used by the driver implementing the functionality,

--- a/marker_lints/Cargo.toml
+++ b/marker_lints/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
-name    = "marker_lints"
-version = "0.1.1"
+name = "marker_lints"
 
 description = "Lints for the marker_api and marker_utils crate"
-edition     = "2021"
-keywords    = ["marker", "lint"]
-license     = "MIT OR Apache-2.0"
-repository  = "https://github.com/rust-marker/marker"
+
+edition    = { workspace = true }
+keywords   = { workspace = true }
+license    = { workspace = true }
+repository = { workspace = true }
+version    = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,10 +15,10 @@ repository  = "https://github.com/rust-marker/marker"
 crate-type = ["cdylib"]
 
 [dependencies]
-marker_api = { path = "../marker_api", version = "0.1.1" }
+marker_api = { workspace = true }
 
 [dev-dependencies]
-marker_uitest = { path = "../marker_uitest", features = ["dev-build"] }
+marker_uitest = { workspace = true }
 
 [[test]]
 harness = false

--- a/marker_rustc_driver/Cargo.toml
+++ b/marker_rustc_driver/Cargo.toml
@@ -1,25 +1,26 @@
 [package]
-name    = "marker_rustc_driver"
-version = "0.1.1"
+name = "marker_rustc_driver"
 
 build       = "build.rs"
 description = "Marker's lint driver for rustc"
-edition     = "2021"
-keywords    = ["marker", "linting"]
-license     = "MIT OR Apache-2.0"
-repository  = "https://github.com/rust-marker/marker"
+
+edition    = { workspace = true }
+keywords   = { workspace = true }
+license    = { workspace = true }
+repository = { workspace = true }
+version    = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-marker_adapter = { path = "../marker_adapter", version = "0.1.1" }
-marker_api     = { path = "../marker_api", version = "0.1.1", features = ["driver-api"] }
+marker_adapter = { workspace = true }
+marker_api     = { workspace = true, features = ["driver-api"] }
 
-bumpalo          = "3.12"
-rustc_tools_util = "0.3"
+bumpalo          = { workspace = true }
+rustc_tools_util = { workspace = true }
 
 [build-dependencies]
-rustc_tools_util = "0.3"
+rustc_tools_util = { workspace = true }
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/marker_uilints/Cargo.toml
+++ b/marker_uilints/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
-name    = "marker_uilints"
-version = "0.1.1"
+name = "marker_uilints"
 
-edition = "2021"
-license = "MIT OR Apache-2.0"
 publish = false
+
+edition    = { workspace = true }
+license    = { workspace = true }
+repository = { workspace = true }
+version    = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -12,10 +14,10 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-marker_api = { path = "../marker_api", version = "0.1.1" }
+marker_api = { workspace = true }
 
 [dev-dependencies]
-marker_uitest = { path = "../marker_uitest", features = ["dev-build"] }
+marker_uitest = { workspace = true }
 
 [[test]]
 harness = false

--- a/marker_uitest/Cargo.toml
+++ b/marker_uitest/Cargo.toml
@@ -1,19 +1,20 @@
 [package]
-name    = "marker_uitest"
-version = "0.1.1"
+name = "marker_uitest"
 
 description = "A thin wrapper around the ui_test crate for Marker"
-edition     = "2021"
-keywords    = ["marker", "linting"]
-license     = "MIT OR Apache-2.0"
-repository  = "https://github.com/rust-marker/marker"
+
+edition    = { workspace = true }
+keywords   = { workspace = true }
+license    = { workspace = true }
+repository = { workspace = true }
+version    = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-semver   = "1.0"
-tempfile = "3.6.0"
-ui_test  = "0.11.7"
+semver   = { workspace = true }
+tempfile = { workspace = true }
+ui_test  = { workspace = true }
 
 [features]
 default = []

--- a/marker_utils/Cargo.toml
+++ b/marker_utils/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
-name    = "marker_utils"
-version = "0.1.1"
+name = "marker_utils"
 
 categories  = ["development-tools"]
 description = "Marker's standard library for creating lints"
-edition     = "2021"
-keywords    = ["marker", "linting"]
-license     = "MIT OR Apache-2.0"
-repository  = "https://github.com/rust-marker/marker"
+
+edition    = { workspace = true }
+keywords   = { workspace = true }
+license    = { workspace = true }
+repository = { workspace = true }
+version    = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-marker_api = { path = "../marker_api", version = "0.1.1" }
+marker_api = { workspace = true }


### PR DESCRIPTION
I hope this is the correct usage of `workspace` information. I've bumped the version in the manifest, but left the version in the documentation as `0.1.1`, since I believe that new comers will first look at the repository and should therefore see the last released version and not the name of the new one. I'll maybe write a script at some point, to automatically update all versions. Declaring the version on the workspace level is already a major improvement :)

---

Closes: rust-marker/marker#226