### PR TITLE
Bump nightly -> 2023-08-24

### DIFF
--- a/cargo-marker/README.md
+++ b/cargo-marker/README.md
@@ -19,7 +19,7 @@
 * **Simple CLI**: *cargo_marker* does all the heavy lifting for you, making custom code analysis, as simple as a single console command.
 * **Seamless Integration**: *cargo_marker* reuses Rust's existing infrastructure for linting, running Marker as part of your workflow is close to the effort needed for its sibling *[Clippy]*.
 * **Automatic Lint-Crate Compilation**: *cargo_marker* automatically fetches and builds specified lint crates, streamlining the process of incorporating additional linting rules into your project.
-* **User-Friendly Setup**: *cargo_marker* can automatically set up the driver and toolchain, allowing you to focus on writing quality code. (This version will setup rustc's driver for `nightly-2023-07-13`)
+* **User-Friendly Setup**: *cargo_marker* can automatically set up the driver and toolchain, allowing you to focus on writing quality code. (This version will setup rustc's driver for `nightly-2023-08-24`)
 
 ## Usage
 

--- a/cargo-marker/src/backend/driver.rs
+++ b/cargo-marker/src/backend/driver.rs
@@ -14,7 +14,7 @@ pub const MARKER_DRIVER_BIN_NAME: &str = "marker_rustc_driver.exe";
 /// This is the driver version and toolchain, that is used by the setup command
 /// to install the driver.
 pub static DEFAULT_DRIVER_INFO: Lazy<DriverVersionInfo> = Lazy::new(|| DriverVersionInfo {
-    toolchain: "nightly-2023-07-13".to_string(),
+    toolchain: "nightly-2023-08-24".to_string(),
     version: "0.3.0-dev".to_string(),
     api_version: "0.3.0-dev".to_string(),
 });

--- a/marker_rustc_driver/README.md
+++ b/marker_rustc_driver/README.md
@@ -17,7 +17,7 @@ The rustc driver for [Marker], an experimental linting interface for Rust. This 
 
 ## Toolchain
 
-The driver is linked to a specific nightly rust toolchain. The crate will be updated about every six weeks with a new release of Rust. This version of the driver has been developed for: `nightly-2023-07-13`
+The driver is linked to a specific nightly rust toolchain. The crate will be updated about every six weeks with a new release of Rust. This version of the driver has been developed for: `nightly-2023-08-24`
 
 ## Contributing
 

--- a/marker_rustc_driver/src/context.rs
+++ b/marker_rustc_driver/src/context.rs
@@ -195,7 +195,7 @@ impl<'ast, 'tcx: 'ast> DriverContext<'ast> for RustcContext<'ast, 'tcx> {
                         | hir::def::DefKind::Union
                         | hir::def::DefKind::Enum
                         | hir::def::DefKind::Trait
-                        | hir::def::DefKind::TyAlias
+                        | hir::def::DefKind::TyAlias { .. }
                 )
             })
             .map(|def_id| self.marker_converter.to_ty_def_id(def_id))

--- a/marker_rustc_driver/src/conversion/marker/common.rs
+++ b/marker_rustc_driver/src/conversion/marker/common.rs
@@ -356,7 +356,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                 id,
             ) => AstPathTarget::Generic(self.to_generic_id(*id)),
             hir::def::Res::Def(
-                hir::def::DefKind::TyAlias
+                hir::def::DefKind::TyAlias { .. }
                 | hir::def::DefKind::Fn
                 | hir::def::DefKind::Enum
                 | hir::def::DefKind::Struct

--- a/marker_rustc_driver/src/conversion/marker/expr.rs
+++ b/marker_rustc_driver/src/conversion/marker/expr.rs
@@ -190,7 +190,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                     }))
                 },
             },
-            hir::ExprKind::Index(operand, index) => {
+            hir::ExprKind::Index(operand, index, _) => {
                 ExprKind::Index(self.alloc(IndexExpr::new(data, self.to_expr(operand), self.to_expr(index))))
             },
             hir::ExprKind::Field(operand, field) => {
@@ -209,7 +209,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
             hir::ExprKind::Match(scrutinee, arms, hir::MatchSource::Normal | hir::MatchSource::FormatArgs) => {
                 ExprKind::Match(self.alloc(MatchExpr::new(data, self.to_expr(scrutinee), self.to_match_arms(arms))))
             },
-            hir::ExprKind::Match(_scrutinee, [_early_return, _continue], hir::MatchSource::TryDesugar) => {
+            hir::ExprKind::Match(_scrutinee, [_early_return, _continue], hir::MatchSource::TryDesugar(_)) => {
                 ExprKind::QuestionMark(self.alloc(self.to_try_expr_from_desugar(expr)))
             },
             hir::ExprKind::Match(_scrutinee, [_awaitee_arm], hir::MatchSource::AwaitDesugar) => {
@@ -553,7 +553,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     }
 
     fn to_try_expr_from_desugar(&self, try_desugar: &hir::Expr<'tcx>) -> QuestionMarkExpr<'ast> {
-        if let hir::ExprKind::Match(scrutinee, [_ret, _con], hir::MatchSource::TryDesugar) = try_desugar.kind {
+        if let hir::ExprKind::Match(scrutinee, [_ret, _con], hir::MatchSource::TryDesugar(_)) = try_desugar.kind {
             if let hir::ExprKind::Call(_try_path, [tested_expr]) = scrutinee.kind {
                 return QuestionMarkExpr::new(
                     CommonExprData::new(self.to_expr_id(try_desugar.hir_id), self.to_span_id(try_desugar.span)),

--- a/marker_rustc_driver/src/conversion/marker/generics.rs
+++ b/marker_rustc_driver/src/conversion/marker/generics.rs
@@ -74,7 +74,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
             let main = main.skip_binder();
 
             let mut generics: Vec<_> = main
-                .substs
+                .args
                 .iter()
                 .filter_map(|arg| self.to_sem_generic_arg_kind(arg))
                 .collect();

--- a/marker_rustc_driver/src/conversion/marker/pat.rs
+++ b/marker_rustc_driver/src/conversion/marker/pat.rs
@@ -126,7 +126,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                 let expr = self.to_expr(lit);
                 let lit_expr = expr
                     .try_into()
-                    .unwrap_or_else(|_| panic!("this should be a literal expression {lit:#?}"));
+                    .unwrap_or_else(|()| panic!("this should be a literal expression {lit:#?}"));
                 PatKind::Lit(lit_expr, CtorBlocker::new())
             },
             hir::PatKind::Range(start, end, kind) => PatKind::Range(self.alloc(RangePat::new(

--- a/marker_rustc_driver/src/conversion/marker/ty.rs
+++ b/marker_rustc_driver/src/conversion/marker/ty.rs
@@ -241,7 +241,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                     hir::def::DefKind::LifetimeParam
                     | hir::def::DefKind::TyParam
                     | hir::def::DefKind::ConstParam
-                    | hir::def::DefKind::TyAlias
+                    | hir::def::DefKind::TyAlias { .. }
                     | hir::def::DefKind::Enum
                     | hir::def::DefKind::Struct
                     | hir::def::DefKind::Union

--- a/marker_rustc_driver/src/main.rs
+++ b/marker_rustc_driver/src/main.rs
@@ -45,7 +45,7 @@ use rustc_session::EarlyErrorHandler;
 
 use crate::conversion::rustc::RustcConverter;
 
-const RUSTC_TOOLCHAIN_VERSION: &str = "nightly-2023-07-13";
+const RUSTC_TOOLCHAIN_VERSION: &str = "nightly-2023-08-24";
 
 struct DefaultCallbacks {
     env_vars: Vec<(&'static str, String)>,

--- a/marker_uilints/tests/ui/lint_ice_message.stderr
+++ b/marker_uilints/tests/ui/lint_ice_message.stderr
@@ -1,3 +1,4 @@
-thread '<unnamed>' panicked at 'free ice cream for everyone!!!', marker_uilints/src/lib.rs
+thread '<unnamed>' panicked at marker_uilints/src/lib.rs
+free ice cream for everyone!!!
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 fatal runtime error: Rust cannot catch foreign exceptions

--- a/marker_uilints/tests/ui/rustc_ice_message.stderr
+++ b/marker_uilints/tests/ui/rustc_ice_message.stderr
@@ -1,4 +1,5 @@
-thread 'rustc' panicked at 'this is your captain talking, we are about to ICE', marker_rustc_driver/src/conversion/marker/item.rs
+thread 'rustc' panicked at marker_rustc_driver/src/conversion/marker/item.rs
+this is your captain talking, we are about to ICE
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 error: the compiler unexpectedly panicked. this is a bug.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-07-13"
+channel = "nightly-2023-08-24"
 components = [
   "cargo",
   "clippy",

--- a/util/update-toolchain.sh
+++ b/util/update-toolchain.sh
@@ -2,7 +2,7 @@
 
 if [[ $1 == nightly-????-??-?? ]]
 then
-    sed -i "s/nightly-2023-07-13/$1/g" ./marker_rustc_driver/src/main.rs ./marker_rustc_driver/README.md ./rust-toolchain ./.github/workflows/* ./util/update-toolchain.sh ./cargo-marker/src/backend/driver.rs ./cargo-marker/README.md
+    sed -i "s/nightly-2023-08-24/$1/g" ./marker_rustc_driver/src/main.rs ./marker_rustc_driver/README.md ./rust-toolchain.toml ./.github/workflows/* ./util/update-toolchain.sh ./cargo-marker/src/backend/driver.rs ./cargo-marker/README.md
 else
     echo "Please enter a valid toolchain like \`nightly-2022-01-01\`"
 fi;


### PR DESCRIPTION
Another showcase, why we need something like Marker. This PR migrates every lint crate that uses marker's public API to use `nightly-2024-08-24` :)

Closes: https://github.com/rust-marker/marker/issues/219