### PR TITLE
Type constraint for paths and IntoUtf8 trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "camino",
  "cargo_metadata 0.17.0",
  "clap",
+ "expect-test",
  "itertools",
  "marker_error",
  "miette",
@@ -327,6 +328,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "dissimilar"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86e3bdc80eee6e16b2b6b0f87fbc98c04bee3455e35174c0de1a125d0688c632"
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +364,16 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "expect-test"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d9eafeadd538e68fb28016364c9732d78e420b9ff8853fa5e4058861e9f8d3"
+dependencies = [
+ "dissimilar",
+ "once_cell",
 ]
 
 [[package]]
@@ -485,6 +502,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 name = "marker_adapter"
 version = "0.3.0-dev"
 dependencies = [
+ "camino",
  "libloading",
  "marker_api",
  "marker_error",
@@ -523,6 +541,7 @@ name = "marker_rustc_driver"
 version = "0.3.0-dev"
 dependencies = [
  "bumpalo",
+ "camino",
  "marker_adapter",
  "marker_api",
  "marker_error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ bumpalo            = "3.12"
 camino             = { version = "1.1", features = ["serde1"] }
 cargo_metadata     = "0.17"
 clap               = { version = "4.0", features = ["string", "derive"] }
+expect-test        = "1.4"
 itertools          = "0.11"
 libloading         = "0.8.0"
 miette             = { version = "5.9", features = ["fancy-no-backtrace"] }

--- a/cargo-marker/Cargo.toml
+++ b/cargo-marker/Cargo.toml
@@ -36,4 +36,4 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 yansi              = { workspace = true }
 
 [dev-dependencies]
-expect-test = "1.4"
+expect-test = { workspace = true }

--- a/cargo-marker/Cargo.toml
+++ b/cargo-marker/Cargo.toml
@@ -34,3 +34,6 @@ tracing            = { workspace = true }
 tracing-error      = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 yansi              = { workspace = true }
+
+[dev-dependencies]
+expect-test = "1.4"

--- a/cargo-marker/src/backend.rs
+++ b/cargo-marker/src/backend.rs
@@ -12,8 +12,9 @@ use crate::observability::prelude::*;
 use std::{
     collections::HashMap,
     ffi::{OsStr, OsString},
-    path::PathBuf,
 };
+
+use camino::Utf8PathBuf;
 
 pub mod cargo;
 pub mod driver;
@@ -31,7 +32,7 @@ pub struct Config {
     /// This should generally be used as a base path for everything. Notable
     /// exceptions can be the installation of a driver or the compilation of
     /// a lint for uitests.
-    pub marker_dir: PathBuf,
+    pub marker_dir: Utf8PathBuf,
     /// The list of lints.
     pub lints: HashMap<String, LintDependencyEntry>,
     /// Additional flags, which should be passed to rustc during the compilation
@@ -53,11 +54,11 @@ impl Config {
         })
     }
 
-    fn markers_target_dir(&self) -> PathBuf {
+    fn markers_target_dir(&self) -> Utf8PathBuf {
         self.marker_dir.join("target")
     }
 
-    fn lint_crate_dir(&self) -> PathBuf {
+    fn lint_crate_dir(&self) -> Utf8PathBuf {
         self.marker_dir.join("lints")
     }
 }

--- a/cargo-marker/src/backend/driver.rs
+++ b/cargo-marker/src/backend/driver.rs
@@ -2,8 +2,10 @@ use super::toolchain::{get_toolchain_folder, rustup_which, Toolchain};
 use crate::error::prelude::*;
 use crate::observability::display::print_stage;
 use crate::observability::prelude::*;
+use crate::utils::utf8::IntoUtf8;
 use crate::{utils::is_local_driver, Result};
-use std::{path::Path, process::Command};
+use camino::Utf8Path;
+use std::process::Command;
 use yansi::Paint;
 
 pub fn marker_driver_bin_name() -> String {
@@ -28,7 +30,7 @@ pub struct DriverVersionInfo {
 }
 
 impl DriverVersionInfo {
-    pub fn try_from_toolchain(toolchain: &Toolchain, manifest: &Path) -> Result<DriverVersionInfo> {
+    pub fn try_from_toolchain(toolchain: &Toolchain, manifest: &Utf8Path) -> Result<DriverVersionInfo> {
         // The driver has to be invoked via cargo, to ensure that the libraries
         // are correctly linked. Toolchains are truly fun...
         let output = toolchain
@@ -50,7 +52,7 @@ impl DriverVersionInfo {
             ));
         }
 
-        let info = String::from_utf8(output.stdout).context(|| "Failed to parse the driver metadata as UTF8")?;
+        let info = output.stdout.into_utf8()?;
 
         let fields = ["toolchain", "driver", "marker-api"];
 

--- a/cargo-marker/src/backend/lints.rs
+++ b/cargo-marker/src/backend/lints.rs
@@ -1,6 +1,6 @@
 use super::Config;
 use crate::error::prelude::*;
-use std::path::PathBuf;
+use camino::Utf8PathBuf;
 
 mod build;
 mod fetch;
@@ -14,7 +14,7 @@ pub struct LintCrateSource {
     /// that will be used to construct the dynamic library.
     name: String,
     /// The absolute path to the manifest of this lint crate
-    manifest: PathBuf,
+    manifest: Utf8PathBuf,
 }
 
 /// The information of a compiled lint crate.
@@ -23,7 +23,7 @@ pub struct LintCrate {
     /// The name of the crate
     pub name: String,
     /// The absolute path of the compiled crate, as a dynamic library.
-    pub file: PathBuf,
+    pub file: Utf8PathBuf,
 }
 
 /// This function fetches and builds all lints specified in the given [`Config`]

--- a/cargo-marker/src/backend/lints/build.rs
+++ b/cargo-marker/src/backend/lints/build.rs
@@ -2,8 +2,10 @@ use super::{LintCrate, LintCrateSource};
 use crate::backend::Config;
 use crate::error::prelude::*;
 use crate::observability::prelude::*;
+use crate::utils::utf8::IntoUtf8;
+use camino::Utf8Path;
 use itertools::Itertools;
-use std::{collections::HashSet, ffi::OsStr, path::Path};
+use std::{collections::HashSet, ffi::OsStr};
 use yansi::Paint;
 
 #[cfg(target_os = "linux")]
@@ -45,7 +47,7 @@ pub fn build_lints(sources: &[LintCrateSource], config: &Config) -> Result<Vec<L
 
     // Build lint crates and find the output of those builds
     let mut found_paths = HashSet::new();
-    let ending = OsStr::new(DYNAMIC_LIB_FILE_ENDING);
+    let ending = DYNAMIC_LIB_FILE_ENDING;
     let mut lints = Vec::with_capacity(sources.len());
 
     for lint_src in sources {
@@ -53,7 +55,7 @@ pub fn build_lints(sources: &[LintCrateSource], config: &Config) -> Result<Vec<L
         match std::fs::read_dir(&lints_dir) {
             Ok(dir) => {
                 for file in dir {
-                    let file = file.unwrap().path();
+                    let file = file.unwrap().path().into_utf8()?;
                     if file.extension() == Some(ending) && !found_paths.contains(&file) {
                         found_paths.insert(file.clone());
                         lints.push(LintCrate {
@@ -66,10 +68,7 @@ pub fn build_lints(sources: &[LintCrateSource], config: &Config) -> Result<Vec<L
             Err(err) => {
                 // This shouldn't really be a point of failure. In this case, I'm
                 // more interested in the HOW?
-                panic!(
-                    "unable to read lints dir after lint compilation: {} ({err:#?})",
-                    lints_dir.display()
-                );
+                panic!("unable to read lints dir after lint compilation: {lints_dir} ({err:#?})");
             },
         }
     }
@@ -82,7 +81,7 @@ pub fn build_lints(sources: &[LintCrateSource], config: &Config) -> Result<Vec<L
 ///
 /// This is an extra function to not call `delete_dir_all` and just accidentally delete
 /// the entire system.
-fn clear_lints_dir(lints_dir: &Path) -> Result {
+fn clear_lints_dir(lints_dir: &Utf8Path) -> Result {
     // Delete all files
     let dir = match std::fs::read_dir(lints_dir) {
         Ok(dir) => dir,
@@ -115,7 +114,7 @@ fn clear_lints_dir(lints_dir: &Path) -> Result {
     }
 
     // The dir should now be empty
-    std::fs::remove_dir(lints_dir).context(|| format!("Failed to remove lints directory {}", lints_dir.display()))
+    std::fs::remove_dir(lints_dir).context(|| format!("Failed to remove lints directory {lints_dir}"))
 }
 
 fn build_lint(lint_src: &LintCrateSource, config: &Config) -> Result {

--- a/cargo-marker/src/backend/toolchain.rs
+++ b/cargo-marker/src/backend/toolchain.rs
@@ -161,7 +161,7 @@ pub(crate) fn rustup_which(toolchain: &str, tool: &str) -> Result<Utf8PathBuf> {
     let string_path = output.stdout.into_utf8()?;
     let path = Utf8PathBuf::from(string_path.trim());
 
-    info!(%tool, %toolchain, path = %path, "Found the tool");
+    info!(%tool, %toolchain, %path, "Found the tool");
 
     Ok(path)
 }

--- a/cargo-marker/src/observability/display/cli.rs
+++ b/cargo-marker/src/observability/display/cli.rs
@@ -12,7 +12,7 @@ pub(crate) fn cli(cli: &str) -> String {
         .unwrap_or_else(|| {
             panic!(
                 "BUG: invalid CLI string; it is supposed to be a valid \
-                string from the trusted source, but got:---\n{cli}\n---"
+                string from the trusted source, but got:\n---\n{cli}\n---"
             )
         })
         .into_iter()

--- a/cargo-marker/src/utils.rs
+++ b/cargo-marker/src/utils.rs
@@ -1,3 +1,5 @@
+pub mod utf8;
+
 /// Use local dev build of driver nearby `cargo-marker` executable
 pub fn is_local_driver() -> bool {
     std::env::var("MARKER_NO_LOCAL_DRIVER").is_err() && cfg!(debug_assertions)

--- a/cargo-marker/src/utils/utf8.rs
+++ b/cargo-marker/src/utils/utf8.rs
@@ -1,0 +1,82 @@
+use crate::error::prelude::*;
+
+use camino::Utf8PathBuf;
+use std::path::PathBuf;
+
+/// Trait supports conversion `Vec<u8> -> String` and `PathBuf -> Utf8PathBuf`
+pub trait IntoUtf8 {
+    type Output;
+
+    fn into_utf8(self) -> Result<Self::Output>;
+}
+
+impl IntoUtf8 for Vec<u8> {
+    type Output = String;
+
+    fn into_utf8(self) -> Result<Self::Output> {
+        String::from_utf8(self).map_err(|err| {
+            Error::root(format!(
+                "Failed to convert to UTF-8 encoded string (dumped it on the line bellow):\n\
+                ---\n{}\n---",
+                String::from_utf8_lossy(err.as_bytes())
+            ))
+        })
+    }
+}
+
+impl IntoUtf8 for PathBuf {
+    type Output = Utf8PathBuf;
+
+    fn into_utf8(self) -> Result<Self::Output> {
+        Utf8PathBuf::try_from(self).map_err(|err| {
+            Error::root(format!(
+                "Failed to convert to UTF-8 encoded path (dumped it on the line bellow):\n\
+                ---\n{}\n---",
+                err.as_path().display()
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Display;
+
+    use super::*;
+    use expect_test::{expect, Expect};
+
+    fn assert_into_utf8<T>(actual: T, expect: Expect)
+    where
+        T: IntoUtf8,
+        T::Output: Display,
+    {
+        let actual = actual
+            .into_utf8()
+            .map(|ok| ok.to_string())
+            .unwrap_or_else(|err| format!("Error: {err}"));
+
+        expect.assert_eq(&actual);
+    }
+
+    #[test]
+    fn test_into_utf8_success() {
+        assert_into_utf8(vec![97, 98, 99u8], expect!["abc"]);
+    }
+
+    #[test]
+    fn test_into_utf8_fail() {
+        assert_into_utf8(
+            vec![97, 98, 255u8],
+            expect![[r#"
+                Error: Failed to convert to UTF-8 encoded string (dumped it on the line bellow):
+                ---
+                ab�
+                ---"#]],
+        );
+    }
+
+    #[test]
+    fn test_pathbuf_into_utf8_success() {
+        assert_into_utf8(PathBuf::from("/My/Custom/Path"), expect!["/My/Custom/Path"]);
+    }
+}

--- a/marker_adapter/Cargo.toml
+++ b/marker_adapter/Cargo.toml
@@ -16,6 +16,7 @@ marker_api   = { workspace = true, features = ["driver-api"] }
 marker_error = { workspace = true }
 marker_utils = { workspace = true }
 
+camino     = { workspace = true }
 libloading = { workspace = true }
 miette     = { workspace = true }
 thiserror  = { workspace = true }

--- a/marker_adapter/src/loader.rs
+++ b/marker_adapter/src/loader.rs
@@ -1,8 +1,8 @@
 use crate::error::prelude::*;
+use camino::Utf8PathBuf;
 use libloading::Library;
 use marker_api::{interface::LintCrateBindings, AstContext};
 use marker_api::{LintPass, LintPassInfo, MARKER_API_VERSION};
-use std::path::PathBuf;
 
 use super::LINT_CRATES_ENV;
 
@@ -12,7 +12,7 @@ pub struct LintCrateInfo {
     /// The name of the lint crate
     pub name: String,
     /// The absolute path of the compiled dynamic library, which can be loaded as a lint crate.
-    pub path: PathBuf,
+    pub path: Utf8PathBuf,
 }
 
 impl LintCrateInfo {
@@ -40,7 +40,7 @@ impl LintCrateInfo {
 
             lint_crates.push(LintCrateInfo {
                 name: name.to_string(),
-                path: PathBuf::from(path),
+                path: path.into(),
             });
         }
         Ok(Some(lint_crates))
@@ -189,7 +189,7 @@ unsafe fn get_symbol<T>(
             info.name,
             // String ignores the trailing nul byte
             String::from_utf8_lossy(symbol_with_nul),
-            info.path.display()
+            info.path
         )
     })
 }

--- a/marker_rustc_driver/Cargo.toml
+++ b/marker_rustc_driver/Cargo.toml
@@ -18,6 +18,7 @@ marker_api     = { workspace = true, features = ["driver-api"] }
 marker_error   = { workspace = true }
 
 bumpalo          = { workspace = true }
+camino           = { workspace = true }
 rustc_tools_util = { workspace = true }
 
 [build-dependencies]

--- a/marker_rustc_driver/src/main.rs
+++ b/marker_rustc_driver/src/main.rs
@@ -36,9 +36,9 @@ mod lint_pass;
 
 use std::env;
 use std::ops::Deref;
-use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use camino::{Utf8Path, Utf8PathBuf};
 use marker_adapter::{LintCrateInfo, LINT_CRATES_ENV};
 use marker_error::Context;
 use rustc_session::config::ErrorOutputType;
@@ -113,7 +113,7 @@ fn register_tracked_files(sess: &mut rustc_session::parse::ParseSess, lint_crate
 
     // Cargo sets the current directory, to the folder containing the `Cargo.toml`
     // file of the compiled crate. Therefore, we can use the relative path.
-    let cargo_file = Path::new("./Cargo.toml");
+    let cargo_file = Utf8Path::new("./Cargo.toml");
     if cargo_file.exists() {
         files.insert(Symbol::intern("./Cargo.toml"));
     }
@@ -121,14 +121,7 @@ fn register_tracked_files(sess: &mut rustc_session::parse::ParseSess, lint_crate
     // At this point, the lint crate paths should be absolute. Therefore, we
     // can just throw it in the `files` set.
     for lint_crate in lint_crates {
-        if let Some(name) = lint_crate.path.to_str() {
-            files.insert(Symbol::intern(name));
-        } else {
-            // The name is not a valid UTF-8 String. This is not ideal but at the
-            // same time not problematic enough to throw an error. It just means
-            // that the lint crate can't be tracked and the driver might reuse
-            // a cache if only that crate was changed.
-        }
+        files.insert(Symbol::intern(lint_crate.path.as_str()));
     }
 
     // Track the driver executable in debug builds
@@ -166,24 +159,10 @@ fn arg_value<'a, T: Deref<Target = str>>(
     None
 }
 
-#[test]
-fn test_arg_value() {
-    let args = &["--bar=bar", "--foobar", "123", "--foo"];
-
-    assert_eq!(arg_value(&[] as &[&str], "--foobar", |_| true), None);
-    assert_eq!(arg_value(args, "--bar", |_| false), None);
-    assert_eq!(arg_value(args, "--bar", |_| true), Some("bar"));
-    assert_eq!(arg_value(args, "--bar", |p| p == "bar"), Some("bar"));
-    assert_eq!(arg_value(args, "--bar", |p| p == "foo"), None);
-    assert_eq!(arg_value(args, "--foobar", |p| p == "foo"), None);
-    assert_eq!(arg_value(args, "--foobar", |p| p == "123"), Some("123"));
-    assert_eq!(arg_value(args, "--foo", |_| true), None);
-}
-
-fn toolchain_path(home: Option<String>, toolchain: Option<String>) -> Option<PathBuf> {
+fn toolchain_path(home: Option<String>, toolchain: Option<String>) -> Option<Utf8PathBuf> {
     home.and_then(|home| {
         toolchain.map(|toolchain| {
-            let mut path = PathBuf::from(home);
+            let mut path = Utf8PathBuf::from(home);
             path.push("toolchains");
             path.push(toolchain);
             path
@@ -292,7 +271,7 @@ fn try_main() -> Result<(), MainError> {
 
     // Setting RUSTC_WRAPPER causes Cargo to pass 'rustc' as the first argument.
     // We're invoking the compiler programmatically, so we'll ignore this.
-    let wrapper_mode = orig_args.get(1).map(Path::new).and_then(Path::file_stem) == Some("rustc".as_ref());
+    let wrapper_mode = orig_args.get(1).map(Utf8Path::new).and_then(Utf8Path::file_stem) == Some("rustc");
 
     if wrapper_mode {
         // we still want to be able to invoke rustc normally
@@ -353,8 +332,8 @@ fn try_main() -> Result<(), MainError> {
 ///    - `RUSTUP_HOME`, `MULTIRUST_HOME`, `RUSTUP_TOOLCHAIN`, `MULTIRUST_TOOLCHAIN`
 fn find_sys_root(sys_root_arg: Option<&str>) -> String {
     sys_root_arg
-        .map(PathBuf::from)
-        .or_else(|| std::env::var("SYSROOT").ok().map(PathBuf::from))
+        .map(Utf8PathBuf::from)
+        .or_else(|| std::env::var("SYSROOT").ok().map(Utf8PathBuf::from))
         .or_else(|| {
             let home = std::env::var("RUSTUP_HOME")
                 .or_else(|_| std::env::var("MULTIRUST_HOME"))
@@ -371,9 +350,9 @@ fn find_sys_root(sys_root_arg: Option<&str>) -> String {
                 .output()
                 .ok()
                 .and_then(|out| String::from_utf8(out.stdout).ok())
-                .map(|s| PathBuf::from(s.trim()))
+                .map(|s| Utf8PathBuf::from(s.trim()))
         })
-        .or_else(|| option_env!("SYSROOT").map(PathBuf::from))
+        .or_else(|| option_env!("SYSROOT").map(Utf8PathBuf::from))
         .or_else(|| {
             let home = option_env!("RUSTUP_HOME")
                 .or(option_env!("MULTIRUST_HOME"))
@@ -383,7 +362,7 @@ fn find_sys_root(sys_root_arg: Option<&str>) -> String {
                 .map(ToString::to_string);
             toolchain_path(home, toolchain)
         })
-        .map(|pb| pb.to_string_lossy().to_string())
+        .map(Utf8PathBuf::into_string)
         .expect("need to specify SYSROOT env var during marker compilation, or use rustup or multirust")
 }
 
@@ -402,4 +381,18 @@ impl From<rustc_span::ErrorGuaranteed> for MainError {
     fn from(err: rustc_span::ErrorGuaranteed) -> Self {
         Self::Rustc(err)
     }
+}
+
+#[test]
+fn test_arg_value() {
+    let args = &["--bar=bar", "--foobar", "123", "--foo"];
+
+    assert_eq!(arg_value(&[] as &[&str], "--foobar", |_| true), None);
+    assert_eq!(arg_value(args, "--bar", |_| false), None);
+    assert_eq!(arg_value(args, "--bar", |_| true), Some("bar"));
+    assert_eq!(arg_value(args, "--bar", |p| p == "bar"), Some("bar"));
+    assert_eq!(arg_value(args, "--bar", |p| p == "foo"), None);
+    assert_eq!(arg_value(args, "--foobar", |p| p == "foo"), None);
+    assert_eq!(arg_value(args, "--foobar", |p| p == "123"), Some("123"));
+    assert_eq!(arg_value(args, "--foo", |_| true), None);
 }

--- a/marker_rustc_driver/src/main.rs
+++ b/marker_rustc_driver/src/main.rs
@@ -383,16 +383,21 @@ impl From<rustc_span::ErrorGuaranteed> for MainError {
     }
 }
 
-#[test]
-fn test_arg_value() {
-    let args = &["--bar=bar", "--foobar", "123", "--foo"];
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    assert_eq!(arg_value(&[] as &[&str], "--foobar", |_| true), None);
-    assert_eq!(arg_value(args, "--bar", |_| false), None);
-    assert_eq!(arg_value(args, "--bar", |_| true), Some("bar"));
-    assert_eq!(arg_value(args, "--bar", |p| p == "bar"), Some("bar"));
-    assert_eq!(arg_value(args, "--bar", |p| p == "foo"), None);
-    assert_eq!(arg_value(args, "--foobar", |p| p == "foo"), None);
-    assert_eq!(arg_value(args, "--foobar", |p| p == "123"), Some("123"));
-    assert_eq!(arg_value(args, "--foo", |_| true), None);
+    #[test]
+    fn test_arg_value() {
+        let args = &["--bar=bar", "--foobar", "123", "--foo"];
+
+        assert_eq!(arg_value(&[] as &[&str], "--foobar", |_| true), None);
+        assert_eq!(arg_value(args, "--bar", |_| false), None);
+        assert_eq!(arg_value(args, "--bar", |_| true), Some("bar"));
+        assert_eq!(arg_value(args, "--bar", |p| p == "bar"), Some("bar"));
+        assert_eq!(arg_value(args, "--bar", |p| p == "foo"), None);
+        assert_eq!(arg_value(args, "--foobar", |p| p == "foo"), None);
+        assert_eq!(arg_value(args, "--foobar", |p| p == "123"), Some("123"));
+        assert_eq!(arg_value(args, "--foo", |_| true), None);
+    }
 }


### PR DESCRIPTION
## UTF-8 encoding trait `IntoUtf8`
Trait supports conversion `Vec<u8> -> String` and `PathBuf -> Utf8PathBuf`. 

## `Utf8Path`
Changing the path type to `Utf8Path` and `Utf8PathBuf` ensures that they have only UTF-8 encoding.
And also, they implement `Display`, which is also very convenient :)
