### PR TITLE
Automate the release process, produce pre-compiled binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         os: [ubuntu, windows, macos]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - run: cargo test --locked
@@ -48,21 +48,21 @@ jobs:
         os: [ubuntu, windows, macos]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - run: cargo clippy
+      - run: cargo clippy --all-features --all-targets --locked
       - run: cargo doc --no-deps
 
   rust-formatting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # We don't need any cache here, so use dtolnay action directly
       # The version of toolchain here should track the latest stable
       # version of Rust. The version of `cargo fmt` we use here doesn't
       # influence the version of Rust that is used when `cargo-marker` is built.
-      - uses: dtolnay/rust-toolchain@1.71.1
+      - uses: dtolnay/rust-toolchain@1.72.0
       - run: cargo fmt --check
 
   # This job ensures required packages can be built with a stable toolchain
@@ -75,7 +75,7 @@ jobs:
         os: [ubuntu, windows, macos]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: rm rust-toolchain.toml
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -100,7 +100,7 @@ jobs:
   rust-unused-dependencies:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: scripts/download/cargo-machete.sh
       - run: cargo-machete
 
@@ -108,7 +108,7 @@ jobs:
   toml:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: scripts/download/taplo.sh
       - run: taplo fmt --check
 
@@ -116,7 +116,7 @@ jobs:
   typos:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: scripts/download/typos.sh
       - run: typos
 
@@ -124,6 +124,14 @@ jobs:
   mdbook:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: scripts/download/mdbook.sh
       - run: mdbook build docs/book
+
+  bash-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Check that the release automation works as expected
+      - run: scripts/release/test.sh

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'rust-marker/marker'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: ./scripts/download/mdbook.sh
       - name: Setup deploy directory
         run: |

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,187 @@
+# This workflow is subscribed only to the `tag` events, and it assumes that
+# the version bumps were already done in the `release` workflow.
+# See the docs/internal/release.md for more details.
+
+name: release-on-tag
+on:
+  push:
+    tags: ['v*']
+
+defaults:
+  run:
+    shell: bash
+
+# Contrary to intuition, "contents" covers not only the repository commits
+# but also GitHub releases.
+permissions:
+  contents: write
+
+# It's technically possible to run several releases in parallel if they are
+# a regular release and a hotfix from a different branch, but let's try not
+# to do that for our own sanity (🦶🔫).
+concurrency:
+  group: ${{ github.workflow }}/${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/create-gh-release-action@v1
+        with:
+          changelog: CHANGELOG.md
+          token: ${{ github.token }}
+
+  build:
+    needs: [github-release]
+    # GitHub doesn't let you split the `${{ }}` syntax into multiple lines 🤦.
+    # Anyway, let's return to the topic... The reason why we pin the specific
+    # versions of OSes is described in the docs under `docs/internal/release.md`
+    runs-on: ${{ contains(matrix.target, 'windows') && 'windows-2019' || contains(matrix.target, 'darwin') && 'macos-11' || 'ubuntu-20.04' }}
+
+    strategy:
+      # If it happens so that some binaries fail to build, then we can have a
+      # release anyway, but just without those binaries that failed to build.
+      # A build failure, of course would be a very rare event and would be bad,
+      # but it won't be the end of the world. We can rerun the CI job to try again
+      # if it was something flaky. GitHub allows rerunning only the failed jobs.
+      #
+      # If the failure was something deterministic and specific to the platform,
+      # then a new hotfix patch should be created for this.
+      fail-fast: false
+      matrix:
+        include:
+          - { bin: cargo-marker, target: x86_64-pc-windows-msvc }
+          - { bin: cargo-marker, target: x86_64-apple-darwin }
+          - { bin: cargo-marker, target: x86_64-unknown-linux-gnu }
+          - { bin: cargo-marker, target: x86_64-unknown-linux-musl }
+
+          # Who could know that cross-compiling for ARM on windows and macos "just works"?!
+          # I hope one day it will just work for Linux too, but that's really surprising to
+          # see how windows and macos beat linux in this regard 👀.
+          #
+          # We use `cargo-zigbuild` instead of the default `cross` build tool because the latter
+          # is more heavyweight as it depends on `docker`, but `cargo-zigbuild` doesn't.
+          - { bin: cargo-marker, target: aarch64-pc-windows-msvc }
+          - { bin: cargo-marker, target: aarch64-apple-darwin }
+          - { bin: cargo-marker, target: aarch64-unknown-linux-gnu,  build_tool: cargo-zigbuild }
+          - { bin: cargo-marker, target: aarch64-unknown-linux-musl, build_tool: cargo-zigbuild }
+
+          # Unfortunatelly, the driver depends on the dynamic libraries `rustc_driver` and `LLVM`.
+          # It means we can't have a static `musl` binary for it. It also significantly complicates
+          # the build for the ARM targets, so in this matrix we have only x86_64 targets. The ARM
+          # build is handled in a separate job.
+          - { bin: marker_rustc_driver, target: x86_64-pc-windows-msvc }
+          - { bin: marker_rustc_driver, target: x86_64-apple-darwin }
+          - { bin: marker_rustc_driver, target: x86_64-unknown-linux-gnu }
+    env:
+      MARKER_ALLOW_DRIVER_BUILD: 1
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          # Release is a rare event. We don't need any caching for it,
+          # and even if we did use the cache it would already be evicted
+          # at the time we run the next release because GitHub clears the
+          # cache after 7 days of inactivity.
+          cache: false
+          target: ${{ matrix.target }}
+
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: ${{ matrix.bin }}
+          target: ${{ matrix.target }}
+          token: ${{ github.token }}
+          checksum: sha256
+          tar: all
+          zip: all
+          build_tool: ${{ matrix.build_tool || 'cargo' }}
+
+  # This job is the result of desperation. Unfortunatelly we can't easily cross-compile
+  # the driver for ARM targets, because we need to have the `rustc_private` DLLs to
+  # be compiled for ARM, but their proc macros need to be compiled for the host x86_64
+  # architecture. However, this isn't the case today, and those proc macros are distributed
+  # pre-compiled only for the architecture of the target machine by `rustup`.
+  #
+  # So this job uses docker + QEMU to emulate an ARM machine and build the driver there.
+  # This, however, is a very slow process, and it's not possible to use this approach
+  # to build the driver for windows and macos that easily. I have high confidence it's
+  # possible to hack something for windows, but given the Apple's closed ecosystem...
+  #
+  # I don't think it's reasonably possible to compile for macos ARM. They really want
+  # you to buy their hardware. There is a gossip that GitHub will provide Apple M1 managed
+  # runners somewhere in the observable future, but until that happens the only option
+  # to compile for macos on ARM is to buy an Apple M1 machine and make a self-hosted runner,
+  # but that is ridiculously expensive.
+  # https://github.com/actions/runner/issues/805#issuecomment-1438149537
+  #
+  # See also the discussion in zulip:
+  # https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Cross-compile.20with.20rustc_private
+  build-driver-on-arm:
+    needs: [github-release]
+    runs-on: ubuntu-20.04
+    env:
+      artifact: marker_rustc_driver-aarch64-unknown-linux-gnu
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Concatenate dependent bash files. Unfortunately, the install script
+      # runs without the repository mounted, so we have to do this to not
+      # use anything from the repo.
+      - run: |
+          cat <<EOF >> $GITHUB_ENV
+          install_script<<DELIM
+            rust_version=$(sed -n 's/^channel = "\(.*\)"/\1/p' rust-toolchain.toml)
+            $(cat scripts/lib.sh scripts/release/qemu-install.sh)
+          DELIM
+          EOF
+
+      - uses: uraimo/run-on-arch-action@v2
+        with:
+          arch: aarch64
+          distro: ubuntu20.04
+          dockerRunArgs: --volume .:/artifacts
+          setup: mkdir -p artifacts
+          install: ${{ env.install_script }}
+          env: |
+            MARKER_ALLOW_DRIVER_BUILD: 1
+
+          # Produce a binary artifact and place it in the mounted volume
+          run: |
+            export PATH="/root/.cargo/bin:$PATH"
+            cargo build -p marker_rustc_driver --release
+            cp target/release/marker_rustc_driver /artifacts/${{ env.artifact }}
+
+      - run: ./scripts/release/upload.sh ${{ github.ref_name }} ${{ env.artifact }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  # Publish the crates to crates.io
+  crates-io:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with: { cache: false }
+      - run: ./scripts/download/cargo-release.sh
+
+      # For extra security we set the env variable with the token only
+      # for the steps that require them.
+      #
+      # There are two `cargo release` invocations here. One without the
+      # `cargo_marker` package, and one with it.
+      #
+      # Keep in mind that `cargo-marker` may install `marker_rustc_driver`
+      # from crates.io via `cargo install`.
+      #
+      # That being said, we will be extra safe if `cargo_marker` is published
+      # after `marker_rustc_driver`.
+      - run: cargo release publish --exclude cargo_marker --execute --no-confirm --no-verify --allow-branch '*'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      - run: cargo release publish --package cargo_marker --execute --no-confirm --no-verify --allow-branch '*'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -135,7 +135,7 @@ jobs:
           cat <<EOF >> $GITHUB_ENV
           install_script<<DELIM
             rust_version=$(sed -n 's/^channel = "\(.*\)"/\1/p' rust-toolchain.toml)
-            $(cat scripts/lib.sh scripts/release/qemu-install.sh)
+            $(cat scripts/lib.sh scripts/release/qemu-setup.sh)
           DELIM
           EOF
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+# This workflow must be triggered manually. It is intended to be an entrypoint for
+# the whole release process. See the docs/internal/release.md for more details.
+
+name: release
+on:
+  workflow_dispatch:
+
+# It's technically possible to run several releases in parallel if they are
+# a regular release and a hotfix from a different branch, but let's try not
+# to do that for our own sanity (🦶🔫).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Unfortunatelly, we can't use the default `github.token` in this workflow.
+          # By design, GitHub doesn't trigger workflows on pushes to tags created by
+          # the `github.token` to prevent infinite loops.
+          # https://github.com/orgs/community/discussions/27028
+          token: ${{ secrets.RELEASE_GITHUB_PAT }}
+
+      - name: Resolve the release version
+        run: echo "release_version=$(scripts/release/get-version-from-changelog.sh)" >> $GITHUB_ENV
+      - name: Resolve the next dev version
+        run: echo "next_dev_version=$(scripts/release/get-next-dev-version.sh ${{ env.release_version }})" >> $GITHUB_ENV
+
+      # To be able to create a commit we need some committer identity.
+      - run: |
+          git config user.name "rust-marker-ci"
+          git config user.email "rust.marker.ci@gmail.com"
+
+      # Create a release commit and tag
+      - run: scripts/release/set-version.sh ${{ env.release_version }}
+          --commit "🚀 Release v${{ env.release_version }}"
+
+      - run: git tag v${{ env.release_version }}
+
+      # Create a next dev version commit
+      - run: scripts/release/set-version.sh ${{ env.next_dev_version }}
+          --commit "🚧 Development v${{ env.next_dev_version }}"
+
+      # Push the branch and the new tag to the remote
+      - run: git push --atomic origin ${{ github.ref_name }} v${{ env.release_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The following components are considered to be internal and they are excluded fro
 
 - `marker_rustc_driver`
 - `marker_adapter`
+- `marker_error`
 
 ## [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,106 @@
+[Unreleased]: https://github.com/rust-marker/marker/releases/tag/v0.2.1...HEAD
+[0.2.1]: https://github.com/rust-marker/marker/releases/tag/v0.2.1
+[0.1.1]: https://github.com/rust-marker/marker/releases/tag/v0.1.1
+
+
+# Changelog
+
+⚠️ Marker is in an early stage of development, so there are breaking changes on each `0.x` minor version. Our target is to stabilize all APIs before we reach a `1.0.0`.
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+This project adheres to a stricter subset of [Semantic Versioning](https://semver.org/spec/v2.0.0.html) as described in [cargo's crates versioning](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio):
+
+> This compatibility convention is different from SemVer in the way it treats versions before 1.0.0. While SemVer says there is no compatibility before 1.0.0, Cargo considers 0.x.y to be compatible with 0.x.z, where y ≥ z and x > 0.
+
+The following components are considered to be internal and they are excluded from the semver and API/ABI stability guarantees.
+
+- `marker_rustc_driver`
+- `marker_adapter`
+
+## [Unreleased]
+
+[#231]: https://github.com/rust-marker/marker/pull/231
+[#232]: https://github.com/rust-marker/marker/pull/232
+[#239]: https://github.com/rust-marker/marker/pull/239
+
+### Added
+- [#232]: Add scope config for visitors and `for_each_expr` to `marker_utils`
+- [#239]: GitHub releases now provide precompiled binaries of `cargo-marker` and `marker_rustc_driver`.
+- [#231]: Significantly improved error handling
+
+### Internal
+
+- [#239]: The release flow was automated. It's now a process of updating the `CHANGELOG.md` and doing several clicks to trigger the CI job.
+
+## [0.2.1] - 2023-08-24
+
+See the v0.2.0 milestone for a full list of all changes
+
+### Added
+- Support `.await` and `async` expressions
+- Started [The Marker Book](https://rust-marker.github.io/marker/book/)
+
+### Fixed
+
+- `cargo marker` now works with lower toolchain versions
+- Fixed errors due to drifts in the used toolchain
+- Fixed the question mark operator resugar
+- `Span`s now properly represent macro expansions
+
+### Changed
+- **BREAKING:** `FnItem<'ast>` and `ClosureExpr<'ast>` no longer implement `CallableData`
+- **BREAKING:** Some `Span` methods have been renamed
+
+
+## [0.1.1] - 2023-07-17
+
+[#174]: https://github.com/rust-marker/marker/issues/174
+
+Marker's first release intended for user testing.
+
+### Features
+This version is far from done, but it already includes most critical AST nodes required for linting. This is an incomplete list of supported elements:
+
+- Items
+- Generics
+- Statements
+- Expressions
+- Patterns
+- Types
+Marker should be able to handle all stable features, except `async` and `await` expressions. (See: [#174])
+
+### Installation
+You can install Marker with cargo, like this:
+
+```bash
+cargo install cargo_marker
+
+# Automatically setup the toolchain and driver
+cargo marker setup --auto-install-toolchain
+```
+
+To run Marker simply specify a lint crate in your `Cargo.toml` file, like this:
+
+```toml
+[workspace.metadata.marker.lints]
+marker_lints = "0.1.0"
+```
+
+And run:
+
+```
+cargo marker
+```
+
+This should give you the usual `Checking ...` output of Cargo.
+
+### Development
+You might want to check out Marker's [lint crate template](https://github.com/rust-marker/lint-crate-template) to test the API yourself.
+
+### Feedback
+This release is intended to collect feedback of any kind. If you encounter any bugs, have any thoughts or suggestions, please create an issue or reach out to me directly.
+
+Happy linting everyone! 🦀 🖊️ 🎉

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Marker
 
-Thank you for your interest in contributing to Marker. All contributions are appreciated! 
+Thank you for your interest in contributing to Marker. All contributions are appreciated!
 
 ## Table of Content
 
@@ -140,11 +140,14 @@ The current versions of Marker are intended for testing. All feedback is appreci
 The following is a small collection of ways you can test Marker right now:
 
 1. **Run Marker**
-    
+
     Simply run Marker on any Rust project you can find and report bugs or unexpected behavior. Once you've installed Marker, you can use the following command to run Marker with the `marker_lints` lint crate:
+
+<!-- region replace-version stable -->
     ```sh
     cargo marker --lints "marker_lints = '0.2.1'"
     ```
+<!-- endregion replace-version stable -->
 
     If you find any bugs or unexpected behavior, please [create an issue]. [rust-marker/marker#198] is a collection of all crates that were linted successfully. You can also add your own crates to the ever-growing list by commenting on the issue.
 
@@ -239,4 +242,3 @@ You can also contact me, @xFrednet, directly:
 ## Legal Notice
 
 Rust-marker is distributed under the terms of the MIT or Apache License (Version 2.0). All contributions fall under these licenses, and as such, it's expected that you authored 100% of the content you contribute and that you have the necessary rights to the content.
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,21 +23,21 @@ keywords   = ["marker", "lint"]
 license    = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-marker/marker"
 
-# region replace-version unstable
+# region replace-version dev
 version = "0.3.0-dev"
-# endregion replace-version unstable
+# endregion replace-version dev
 
 # The MSRV is applied to the public library crates published to crates.io
 rust-version = "1.66"
 
 [workspace.dependencies]
-# region replace-version unstable
+# region replace-version dev
 marker_adapter = { path = "./marker_adapter", version = "0.3.0-dev" }
 marker_api     = { path = "./marker_api", version = "0.3.0-dev" }
 marker_error   = { path = "./marker_error", version = "0.3.0-dev" }
 marker_uitest  = { path = "./marker_uitest", features = ["dev-build"] }
 marker_utils   = { path = "./marker_utils", version = "0.3.0-dev" }
-# endregion replace-version unstable
+# endregion replace-version dev
 
 bumpalo            = "3.12"
 camino             = { version = "1.1", features = ["serde1"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,19 +11,33 @@ members = [
 ]
 resolver = "2"
 
+[profile.release]
+codegen-units = 1
+lto           = true
+strip         = false
+
+
 [workspace.package]
 edition    = "2021"
 keywords   = ["marker", "lint"]
 license    = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-marker/marker"
-version    = "0.3.0-dev"
+
+# region replace-version unstable
+version = "0.3.0-dev"
+# endregion replace-version unstable
+
+# The MSRV is applied to the public library crates published to crates.io
+rust-version = "1.66"
 
 [workspace.dependencies]
+# region replace-version unstable
 marker_adapter = { path = "./marker_adapter", version = "0.3.0-dev" }
 marker_api     = { path = "./marker_api", version = "0.3.0-dev" }
 marker_error   = { path = "./marker_error", version = "0.3.0-dev" }
 marker_uitest  = { path = "./marker_uitest", features = ["dev-build"] }
 marker_utils   = { path = "./marker_utils", version = "0.3.0-dev" }
+# endregion replace-version unstable
 
 bumpalo            = "3.12"
 camino             = { version = "1.1", features = ["serde1"] }

--- a/README.md
+++ b/README.md
@@ -35,14 +35,33 @@ And more to come, see Marker's goals and limitations below.
 
 The following is an abbreviated guide. Check out [The Marker Book] for detailed instructions and additional information.
 
-[The Marker Book]: rust-marker.github.io/marker/book
+[The Marker Book]: https://rust-marker.github.io/marker/book
 
 ### Installation
+
+#### Download pre-compiled binaries (recommended)
+
+We provide pre-compiled binaries for the mainstream platforms. See the list of available artifacts in our [Github Releases](https://github.com/rust-marker/marker/releases/latest).
+
+Run the following bash script to install the required rust toolchain dependency on your machine and download the current version of `cargo-marker` CLI, and the internal driver.
+
+<!-- region replace-version stable -->
+```bash
+curl --location --silent --fail --show-error --retry 5 --retry-connrefused --retry-delay 30 \
+    https://raw.githubusercontent.com/rust-marker/marker/v0.2.1/install.sh | bash
+```
+<!-- endregion replace-version stable -->
+
+The provided scripts are pinned to a specific version of `marker` to avoid sudden breakages especially if this script will be used on CI.
+
+If you are a windows user or your platform isn't supported yet by the pre-compiled binaries, then you should fall back to building from sources as described below.
+
+#### Build from sources
 
 ```sh
 cargo install cargo_marker
 
-# Automatically setup the toolchain and driver
+# Automatically setup the toolchain and build driver from sources
 cargo marker setup --auto-install-toolchain
 ```
 
@@ -50,6 +69,7 @@ cargo marker setup --auto-install-toolchain
 
 Marker requires lint crates to be specified. The best way is to add them to the `Cargo.toml` file, like this:
 
+<!-- region replace-version stable -->
 ```toml
 [workspace.metadata.marker.lints]
 # A local crate as a path
@@ -59,12 +79,13 @@ marker_lints = { git = "https://github.com/rust-marker/marker" }
 # An external crate from a registry
 marker_lints = "0.2.1"
 ```
+<!-- endregion replace-version stable -->
 
 ### Making Your Own Lints
 
 You can create your own lint crates if you want, the [lint-crate-template] has all the basics for you to get started writing your own lints.
 
-[lint-crate-template]: https://github.com/rust-marker/lint-crate-template 
+[lint-crate-template]: https://github.com/rust-marker/lint-crate-template
 
 ### Running Marker
 

--- a/README.md
+++ b/README.md
@@ -39,23 +39,6 @@ The following is an abbreviated guide. Check out [The Marker Book] for detailed 
 
 ### Installation
 
-#### Download pre-compiled binaries (recommended)
-
-We provide pre-compiled binaries for the mainstream platforms. See the list of available artifacts in our [Github Releases](https://github.com/rust-marker/marker/releases/latest).
-
-On UNIX-like systems, you can run the following bash script. It will install the required rust toolchain dependency on your machine, download the current version of `cargo-marker` CLI, and the internal driver.
-
-<!-- region replace-version stable -->
-```bash
-curl --location --silent --fail --show-error --retry 5 --retry-connrefused \
-    https://raw.githubusercontent.com/rust-marker/marker/v0.2.1/scripts/release/install.sh | bash
-```
-<!-- endregion replace-version stable -->
-
-The provided scripts are pinned to a specific version of `marker` to avoid sudden breakages especially if this script will be used on CI.
-
-If you are a windows user or your platform isn't supported yet by the pre-compiled binaries, then you should fall back to building from sources as described below.
-
 #### Build from sources
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ The following is an abbreviated guide. Check out [The Marker Book] for detailed 
 
 We provide pre-compiled binaries for the mainstream platforms. See the list of available artifacts in our [Github Releases](https://github.com/rust-marker/marker/releases/latest).
 
-Run the following bash script to install the required rust toolchain dependency on your machine and download the current version of `cargo-marker` CLI, and the internal driver.
+On UNIX-like systems, you can run the following bash script. It will install the required rust toolchain dependency on your machine, download the current version of `cargo-marker` CLI, and the internal driver.
 
 <!-- region replace-version stable -->
 ```bash
-curl --location --silent --fail --show-error --retry 5 --retry-connrefused --retry-delay 30 \
-    https://raw.githubusercontent.com/rust-marker/marker/v0.2.1/install.sh | bash
+curl --location --silent --fail --show-error --retry 5 --retry-connrefused \
+    https://raw.githubusercontent.com/rust-marker/marker/v0.2.1/scripts/release/install.sh | bash
 ```
 <!-- endregion replace-version stable -->
 

--- a/cargo-marker/README.md
+++ b/cargo-marker/README.md
@@ -42,6 +42,7 @@ cargo marker setup --auto-install-toolchain
 
 Marker requires lint crates to be specified. The best way is to add them to the `Cargo.toml` file, like this:
 
+<!-- region replace-version stable -->
 ```toml
 [workspace.metadata.marker.lints]
 # A local crate as a path
@@ -51,6 +52,7 @@ marker_lints = { git = "https://github.com/rust-marker/marker" }
 # An external crate from a registry
 marker_lints = "0.2.1"
 ```
+<!-- endregion replace-version stable -->
 
 ### Running Marker
 
@@ -75,4 +77,3 @@ Copyright (c) 2022-2023 Rust-Marker
 Rust-marker is distributed under the terms of the MIT license or the Apache License (Version 2.0).
 
 See [LICENSE-APACHE](https://github.com/rust-marker/marker/blob/master/LICENSE-APACHE), [LICENSE-MIT](https://github.com/rust-marker/marker/blob/master/LICENSE-MIT).
-

--- a/cargo-marker/src/backend/driver.rs
+++ b/cargo-marker/src/backend/driver.rs
@@ -17,10 +17,10 @@ pub fn marker_driver_bin_name() -> String {
 pub(crate) fn default_driver_info() -> DriverVersionInfo {
     DriverVersionInfo {
         toolchain: "nightly-2023-08-24".to_string(),
-        // region replace-version unstable
+        // region replace-version dev
         version: "0.3.0-dev".to_string(),
         api_version: "0.3.0-dev".to_string(),
-        // endregion replace-version unstable
+        // endregion replace-version dev
     }
 }
 

--- a/cargo-marker/src/backend/driver.rs
+++ b/cargo-marker/src/backend/driver.rs
@@ -17,8 +17,10 @@ pub fn marker_driver_bin_name() -> String {
 pub(crate) fn default_driver_info() -> DriverVersionInfo {
     DriverVersionInfo {
         toolchain: "nightly-2023-08-24".to_string(),
+        // region replace-version unstable
         version: "0.3.0-dev".to_string(),
         api_version: "0.3.0-dev".to_string(),
+        // endregion replace-version unstable
     }
 }
 

--- a/cargo-marker/src/error.rs
+++ b/cargo-marker/src/error.rs
@@ -50,6 +50,7 @@ or:
     BuildDriver,
 }
 
+// region replace-version stable
 fn help_for_no_lints() -> String {
     format!(
         r#"The are two ways to specify lints.
@@ -71,10 +72,11 @@ marker_lints = { git = "https://github.com/rust-marker/marker" }
 # An external crate from a registry
 marker_lints = "0.2.1""#
         ),
-        cli_example = display::cli(r#"cargo marker --lints "marker_lints = '<version>'""#),
+        cli_example = display::cli(r#"cargo marker --lints "marker_lints = '0.2.1'""#),
         lints = "--lints".blue(),
     )
 }
+// endregion replace-version stable
 
 fn help_for_driver_not_found() -> String {
     format!(

--- a/cargo-marker/src/utils/utf8.rs
+++ b/cargo-marker/src/utils/utf8.rs
@@ -45,7 +45,7 @@ mod tests {
     use super::*;
     use expect_test::{expect, Expect};
 
-    fn assert_into_utf8<T>(actual: T, expect: Expect)
+    fn assert_into_utf8<T>(actual: T, expect: &Expect)
     where
         T: IntoUtf8,
         T::Output: Display,
@@ -60,14 +60,14 @@ mod tests {
 
     #[test]
     fn test_into_utf8_success() {
-        assert_into_utf8(vec![97, 98, 99u8], expect!["abc"]);
+        assert_into_utf8(vec![97, 98, 99u8], &expect!["abc"]);
     }
 
     #[test]
     fn test_into_utf8_fail() {
         assert_into_utf8(
             vec![97, 98, 255u8],
-            expect![[r#"
+            &expect![[r#"
                 Error: Failed to convert to UTF-8 encoded string (dumped it on the line bellow):
                 ---
                 ab�
@@ -77,6 +77,6 @@ mod tests {
 
     #[test]
     fn test_pathbuf_into_utf8_success() {
-        assert_into_utf8(PathBuf::from("/My/Custom/Path"), expect!["/My/Custom/Path"]);
+        assert_into_utf8(PathBuf::from("/My/Custom/Path"), &expect!["/My/Custom/Path"]);
     }
 }

--- a/docs/book/src/usage/installation.md
+++ b/docs/book/src/usage/installation.md
@@ -15,12 +15,12 @@ The marker sub-command is provided by the *cargo_marker* crate. This crate requi
 
 We provide pre-compiled binaries for the mainstream platforms. See the list of available artifacts in our [Github Releases](https://github.com/rust-marker/marker/releases/latest).
 
-Run the following bash script to install the required rust toolchain dependency on your machine and download the current version of `cargo-marker` CLI, and the internal driver.
+On UNIX-like systems, you can run the following bash script. It will install the required rust toolchain dependency on your machine, download the current version of `cargo-marker` CLI, and the internal driver.
 
 <!-- region replace-version stable -->
 ```bash
-curl --location --silent --fail --show-error --retry 5 --retry-connrefused --retry-delay 30 \
-    https://raw.githubusercontent.com/rust-marker/marker/v0.2.1/install.sh | bash
+curl --location --silent --fail --show-error --retry 5 --retry-connrefused \
+    https://raw.githubusercontent.com/rust-marker/marker/v0.2.1/scripts/release/install.sh | bash
 ```
 <!-- endregion replace-version stable -->
 

--- a/docs/book/src/usage/installation.md
+++ b/docs/book/src/usage/installation.md
@@ -11,23 +11,6 @@ The marker sub-command is provided by the *cargo_marker* crate. This crate requi
 [Cargo]: https://github.com/rust-lang/cargo/
 [rustup]: https://github.com/rust-lang/rustup/
 
-## Download pre-compiled binaries (recommended)
-
-We provide pre-compiled binaries for the mainstream platforms. See the list of available artifacts in our [Github Releases](https://github.com/rust-marker/marker/releases/latest).
-
-On UNIX-like systems, you can run the following bash script. It will install the required rust toolchain dependency on your machine, download the current version of `cargo-marker` CLI, and the internal driver.
-
-<!-- region replace-version stable -->
-```bash
-curl --location --silent --fail --show-error --retry 5 --retry-connrefused \
-    https://raw.githubusercontent.com/rust-marker/marker/v0.2.1/scripts/release/install.sh | bash
-```
-<!-- endregion replace-version stable -->
-
-The provided scripts are pinned to a specific version of `marker` to avoid sudden breakages especially if this script will be used on CI.
-
-If you are a windows user or your platform isn't supported yet by the pre-compiled binaries, then you should fall back to building from sources as described below.
-
 ## Build `cargo marker` plugin from sources
 
 Marker provides a new Cargo sub-command, that handles the driver installation, lint crate compilation, and checking process for you. To install it, simply use:

--- a/docs/book/src/usage/installation.md
+++ b/docs/book/src/usage/installation.md
@@ -11,7 +11,24 @@ The marker sub-command is provided by the *cargo_marker* crate. This crate requi
 [Cargo]: https://github.com/rust-lang/cargo/
 [rustup]: https://github.com/rust-lang/rustup/
 
-## Cargo Marker Command
+## Download pre-compiled binaries (recommended)
+
+We provide pre-compiled binaries for the mainstream platforms. See the list of available artifacts in our [Github Releases](https://github.com/rust-marker/marker/releases/latest).
+
+Run the following bash script to install the required rust toolchain dependency on your machine and download the current version of `cargo-marker` CLI, and the internal driver.
+
+<!-- region replace-version stable -->
+```bash
+curl --location --silent --fail --show-error --retry 5 --retry-connrefused --retry-delay 30 \
+    https://raw.githubusercontent.com/rust-marker/marker/v0.2.1/install.sh | bash
+```
+<!-- endregion replace-version stable -->
+
+The provided scripts are pinned to a specific version of `marker` to avoid sudden breakages especially if this script will be used on CI.
+
+If you are a windows user or your platform isn't supported yet by the pre-compiled binaries, then you should fall back to building from sources as described below.
+
+## Build `cargo marker` plugin from sources
 
 Marker provides a new Cargo sub-command, that handles the driver installation, lint crate compilation, and checking process for you. To install it, simply use:
 

--- a/docs/book/src/usage/lint-crate-declaration.md
+++ b/docs/book/src/usage/lint-crate-declaration.md
@@ -8,6 +8,7 @@ Marker in itself, is a linting interface. The actual code analysis is implemente
 
 The main way to declare lint crates, is to add them to the `Cargo.toml` file under the `[workspace.metadata.marker.lints]` section. There they can be defined like a normal dependency, with a version, git repository, or path. This is a short example of the three methods:
 
+<!-- region replace-version stable -->
 ```toml
 [workspace.metadata.marker.lints]
 # An external crate from a registry
@@ -19,6 +20,7 @@ marker_lints = { git = "https://github.com/rust-marker/marker" }
 # A local crate as a path
 marker_lints = { path = './marker_lints' }
 ```
+<!-- endregion replace-version stable -->
 
 ## Declaration as arguments
 
@@ -26,6 +28,7 @@ Lints can also be declared as arguments to the `cargo marker` command. Marker wi
 
 A lint crate can be specified with the `--lints` option. The string is expected to have the same format, that would be used in the `Cargo.toml` file. Here is an example for the same lint crates specified above:
 
+<!-- region replace-version stable -->
 ```sh
 # An external crate from a registry
 cargo marker --lint "marker_lints = '0.2.1'"
@@ -36,3 +39,4 @@ cargo marker --lint "marker_lints = { git = 'https://github.com/rust-marker/mark
 # A local crate as a path
 cargo marker --lint "marker_lints = { path = './marker_lints' }"
 ```
+<!-- endregion replace-version stable -->

--- a/docs/internal/release.md
+++ b/docs/internal/release.md
@@ -1,0 +1,111 @@
+This document describes the release processes and artifacts in `marker`.
+
+# Artifacts
+
+As a result of the engineering effort invested into `marker` we get the following items. Each of them comprises the public API of this project.
+
+## Source packages in `crates.io`
+
+There are library packages published to crates.io such as `marker_api`, `marker_uitest`. They are intended to be statically linked to the users' lint crates.
+
+There are binary packages published to crates.io such as `cargo_marker`, `marker_rustc_driver`. They are intended to be used only in exceptional cases to let users build binaries from source. For example, if `marker` lacks support for some platform where users want to utilize it, then they may leverage `cargo install` to compile `marker`'s component binaries from source. However, 99% of the time users will want to download a precompiled binary.
+
+## Pre-compiled binaries published in a GitHub release
+
+These are the archived binaries such as `cargo-marker-x86_64-unknown-linux-gnu.tar.gz`. These binaries cover as much platforms as possible meaning different combinations of OS (`windows`, `linux`, `macos`), arch (`x86_64`, `aarch64`), libc implementations (`gnu`, `musl`) and their different versions.
+
+Let's review what artifacts there are for a single platform. Take this list as an example.
+
+- `cargo-marker-aarch64-unknown-linux-gnu.tar.gz`
+- `cargo-marker-aarch64-unknown-linux-gnu.zip`
+- `cargo-marker-aarch64-unknown-linux-gnu.sha256`
+
+The `tar.gz` and `zip` archives contain a single `cargo-marker` binary file in them. It doesn't matter what archive the user downloads. They have the choice to select either of them. It is usually common to have only `tar.gz` format for `unix`-like systems, and `zip` for `windows`, but we provide both for the reason described below.
+
+For the cross-platform code it is much more convenient when the same archive format is available for every platform consistently. This means, for example, `cargo-marker` may depend only on the `zip` crate exclusively and expect that `zip` of the  `marker_rustc_driver` is always available for download on all platforms.
+
+> Here is a case of [`terraform`'s](https://developer.hashicorp.com/terraform/downloads) binaries. They are distributed in `zip` for all platforms.
+
+GitHub is very generous with the releases storage limits. They are [almost unlimited](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#storage-and-bandwidth-quotas). They difinitely want your project to be open-source 😉.
+
+The `sha256` sum is a small file that users may optionally download together with the archive itself to verify the integrity of the archive. It serves as a signature of the artifact to make sure it was downloaded as expected bit-by-bit with what was published effectively detecting corruptions during the download and making it harder to forge the artifact for the malicious actor.
+
+```bash
+file_stem=cargo-marker-x86_64-unknown-linux-gnu
+
+# Download two files using one TCP connection with HTTP2 multiplexing
+curl -LO "https://github.com/rust-marker/marker/releases/download/v0.3.0/$file_stem.{tar.gz,sha256}"
+
+# `--ignore-missing` because the `sha256` file also includes the checksum for `zip` archive
+# but users don't need both the `tar.gz` and `zip`. They will chose only one of them.
+# This will fail if the checksum of the downloaded file differs from what's specified in `.sha256`
+sha256sum --ignore-missing --check $file_stem.sha256
+```
+
+## Operating system versions coverage
+
+We want to cover not only the mainstream operating systems, but also some reasonable range of their versions. For example, for `ubuntu` we want our binaries to work on the current LTS version of `ubuntu` and also on the version of `ubuntu` that precedes it. At the time of this writing the latest LTS version of `ubuntu` is `22.04`, and the previous one is `20.04`, while the LTS version of ubuntu before that one is `18.04` and it already reached the "end of standard support" date, and so far practically noone uses it.
+
+The platforms that we use for builds are pinned to specific OS versions. It gives us confidence that our binaries will run on these platforms or more modern ones. Operating systems are usually backward-compatible, but they are not forward-compatible.
+
+It means, you can't compile a binary on `ubuntu-22.04` and run it on `ubuntu-20.04` because the GLIBC that the binary will require will be too high for `ubuntu-20.04`. The version of GLIBC installed on `ubuntu-20.04` is `2.29`, and the version of GLIBC installed on `ubuntu-22.04` is `2.34`. This is based on the experience of the problem that appeared in [nushell](https://github.com/nushell/nushell/issues/7282) project.
+
+> The story of `nushell` was the following.
+>
+> They used `ubuntu-latest` to build their pre-compiled binaries. At that moment `ubuntu-latest` was aliased to `20.04` and the whole world was sitting on this version of `ubuntu` and everything was fine.
+>
+> But then some day `ubuntu-22.04` became generally available on GitHub runners and `ubuntu-latest` was changed to point to this new version of `ubuntu`. When the new release of `nushell` was created they built it on `ubuntu-latest` a.k.a. `ubuntu-22.04` at that point in time.
+>
+> The whole world was still sitting on `ubuntu-20.04` and lazily migrating to `ubuntu-22.04` so, consequently, there were multiple users who wanted to upgrade `nushell` but they were still sitting on `ubuntu-20.04`. The binaries from the new `nushell` release were not working for them due to the higher GLIBC requirement.
+
+You can check for yourself the GLIBC version requirement of your binary with the following command.
+
+```bash
+objdump -T ./path/to/binary | grep -Eo 'GLIBC_[^)]+' | sort -V | tail -1
+```
+
+### Universal `musl` binaries
+
+The binaries with `musl` in their name don't depend on GLIBC. They are statically linked meaning they have no dynamic library dependencies. This way they support a wide range of `linux` distributions meaning that you may expect them to run almost on any `linux` distro of any version.
+
+This comes at a cost, though. The `musl` implementation of `libc` isn't complete, and it may have bugs, performance degradations compared to GLIBC, etc. However, it generally covers everything you may ever need if you aren't doing something unusual.
+
+# Regular release
+
+The regular release means a planned event when the maintainer of `marker` publishes the new version of the artifacts to the users. It may happen at any time when such a decision is made, which usually means on some consistent schedule.
+
+The release process is semi-automated, and thus requires the human involvement.
+
+The maintainer has to decide what the next release semver version number will be and prepare the `CHANGELOG.md` file with the description of the new release. The description should follow a consistent structure [like this](https://keepachangelog.com/en/1.0.0/).
+
+The new versions are always prepended to the top of the changelog file. The numbered version at the top is always considered to be the latest release of `marker`. Before invoking the release automation a human must make sure that a new entry with the new version number was created in the `CHANGELOG.md` file.
+
+## `release` workflow
+
+Once the `CHANGELOG.md` is ready in `master` the maintainer can trigger the CI `release` workflow from GitHub "Actions" web page. That workflow contains no input variables to set the version. It fully relies on the `CHANGELOG.md` as an input for that.
+
+The `release` CI workflow then checks out the `master` branch (assuming "Use workflow from" input wasn't changed from its default), parses the current release version from the `CHANGELOG.md` file and updates `Cargo.toml`, `Cargo.lock` and various `.rs` and `.md` files with the new version. It uses simple regex patterns with `sed` to edit the files. This logic may break, and thus there is a test on regular CI that makes sure it stays stable.
+
+The release commit is then assigned a `v{semver}` git tag. After that the workflow sets the next version for the new development cycle with the incremented release version and the `-dev` suffix, and creates a new commit with that. No additional tag at this point is created.
+
+## `release-on-tag` workflow
+
+The other CI workflow called `release-on-tag` triggers on the new `v{semver}` git tag in the repository. It does the following.
+
+1. It creates a new GitHub release associated with the new tag. The description of the GitHub release will contain a copy of the section corresponding to the new version from the `CHANGELOG.md`.
+2. It builds the pre-compiled binaries for multiple platforms and uploads them to the new GitHub release.
+3. It publishes the new version of packages to `crates.io`.
+
+Once this workflow finishes successfully, the release process may be considered complete.
+
+# Hotfix backport release
+
+There may be a case that a new critical bug was revealed in the released version of `marker` artifacts. It is most likely that bugs come from the new version of code, so you'll probably want to fix the bug in the current version of code present in `master`, increment the patch version and release it. The release flow in this case is identical to the [regular release](#regular-release) with the specificity that the maintainer is expected to make a patch bump in the changelog.
+
+A more elaborate case is when the bug was fixed in the latest version of `marker` but there still are users who sit on the previous incompatible version of `marker`, and upgrading to the latest one for them may take too much effort and time, but they desperately need a fix today.
+
+For this case you need to check out the older version of `marker` in a new git branch. Use the git tags to find the proper commit for that. Make the fix in your branch and call it `hotfix/X.Y.Z`, for example. The format of the branch name doesn't matter, but let's use this one just for consistency.
+
+Push the branch to the upstream `marker` repository. You don't want to merge that branch into `master`, because master is already far ahead of that branch and contains the fix in the new code. You just need to create it in the upstream so that the CI workflows in that repo can use it.
+
+Add a new entry with the new patch to the `CHANGELOG.md` file in that branch just like during the regular release. Now trigger the `release` CI workflow, but specify your custom hotfix branch in the "Use workflow from" input selector. Once that is done you should also cherry-pick the commit that updated the `CHANGELOG.md` into the `master` branch for the history. This backported fix should still appear at the top of the changelog file, but, of course the next release's version should still be the increment of the previous version within the semver compatibility range set for the current development cycle.

--- a/docs/internal/release.md
+++ b/docs/internal/release.md
@@ -28,19 +28,11 @@ For the cross-platform code it is much more convenient when the same archive for
 
 GitHub is very generous with the releases storage limits. They are [almost unlimited](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#storage-and-bandwidth-quotas). They difinitely want your project to be open-source 😉.
 
-The `sha256` sum is a small file that users may optionally download together with the archive itself to verify the integrity of the archive. It serves as a signature of the artifact to make sure it was downloaded as expected bit-by-bit with what was published effectively detecting corruptions during the download and making it harder to forge the artifact for the malicious actor.
+The `sha256` sum is a small file that users may optionally download together with the archive itself to verify the integrity of the archive. It serves as a signature of the artifact to make sure it was downloaded as expected bit-by-bit with what was published effectively detecting corruptions during the download and making it harder to forge artifacts for malicious actors.
 
-```bash
-file_stem=cargo-marker-x86_64-unknown-linux-gnu
-
-# Download two files using one TCP connection with HTTP2 multiplexing
-curl -LO "https://github.com/rust-marker/marker/releases/download/v0.3.0/$file_stem.{tar.gz,sha256}"
-
-# `--ignore-missing` because the `sha256` file also includes the checksum for `zip` archive
-# but users don't need both the `tar.gz` and `zip`. They will chose only one of them.
-# This will fail if the checksum of the downloaded file differs from what's specified in `.sha256`
-sha256sum --ignore-missing --check $file_stem.sha256
-```
+<!-- region replace-version stable -->
+This [`install.sh`](https://raw.githubusercontent.com/rust-marker/marker/v0.2.1/scripts/release/install.sh) script, can be used to automatically download and verify Marker's binaries.
+<!-- endregion replace-version stable -->
 
 ## Operating system versions coverage
 
@@ -79,6 +71,8 @@ The release process is semi-automated, and thus requires the human involvement.
 The maintainer has to decide what the next release semver version number will be and prepare the `CHANGELOG.md` file with the description of the new release. The description should follow a consistent structure [like this](https://keepachangelog.com/en/1.0.0/).
 
 The new versions are always prepended to the top of the changelog file. The numbered version at the top is always considered to be the latest release of `marker`. Before invoking the release automation a human must make sure that a new entry with the new version number was created in the `CHANGELOG.md` file.
+
+This flow also allows for pre-releases. These are the ones that contain a `-suffix` in their name e.g. `1.0.0-rc` or even `1.0.0-rc.2` etc. You just need to prepend an entry with this version to the changelog.
 
 ## `release` workflow
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# This script downloads the `cargo-marker` and the `marker_rustc_driver`
+# binaries from the GitHub release assets. It also sets up the required
+# Rust toolchain that the `marker_rustc_driver` depends on.
+#
+# This script must be self-contained! Nothing here should use anything from
+# the marker repository, because users are expected to run this script on
+# their machines where they don't have the marker repository cloned.
+
+set -Eeuo pipefail
+
+# There isn't a release of the `dev`, version, however the released version
+# of marker will replace this version with the actual one.
+# region replace-version unstable
+version=0.3.0-dev
+# endregion replace-version unstable
+
+toolchain=nightly-2023-08-24
+
+function with_log {
+    echo -e "\033[32;1m❱\033[0m $@" >&2
+    "$@"
+}
+
+with_log rustup install --profile minimal --no-self-update $toolchain
+
+host_triple=$(\
+    rustc +$toolchain --version --verbose \
+    | grep --only-matching --perl-regexp 'host: \K.*' \
+)
+
+trap cleanup SIGINT SIGTERM ERR EXIT
+
+temp_dir=$(mktemp -d)
+
+function cleanup {
+    # Unset the trap to prevent an infinite loop
+    trap - SIGINT SIGTERM ERR EXIT
+
+    with_log rm -rf "$temp_dir"
+}
+
+files="{cargo-marker,marker_rustc_driver}-$host_triple.{tar.gz,sha256}"
+
+# Download all files using a single TCP connection with HTTP2 multiplexing
+with_log curl \
+    --location \
+    --silent \
+    --fail \
+    --show-error \
+    --retry 5 \
+    --retry-connrefused \
+    --retry-delay 30 \
+    --remote-name \
+    --output-dir "$temp_dir" \
+    "https://github.com/rust-marker/marker/releases/download/v$version/$files"
+
+function extract_archive {
+    local bin="$1"
+    local dest="$2"
+    local file_stem="$bin-$host_triple"
+
+    # `--ignore-missing` because the `sha256` file also includes the checksum for `zip` archive,
+    # but we only download the `tar.gz` one.
+    (with_log cd $temp_dir && with_log sha256sum --ignore-missing --check "$file_stem".sha256)
+
+    with_log tar --extract --file "$temp_dir/$file_stem.tar.gz" --directory "$dest"
+}
+
+extract_archive cargo-marker "${CARGO_HOME-$HOME/.cargo/bin}"
+
+extract_archive marker_rustc_driver "$(rustc +$toolchain --print sysroot)/bin"

--- a/marker_adapter/Cargo.toml
+++ b/marker_adapter/Cargo.toml
@@ -9,8 +9,6 @@ license    = { workspace = true }
 repository = { workspace = true }
 version    = { workspace = true }
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 marker_api   = { workspace = true, features = ["driver-api"] }
 marker_error = { workspace = true }

--- a/marker_api/Cargo.toml
+++ b/marker_api/Cargo.toml
@@ -4,13 +4,12 @@ name = "marker_api"
 categories  = ["development-tools"]
 description = "Marker's API, designed for stability and usability"
 
-edition    = { workspace = true }
-keywords   = { workspace = true }
-license    = { workspace = true }
-repository = { workspace = true }
-version    = { workspace = true }
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition      = { workspace = true }
+keywords     = { workspace = true }
+license      = { workspace = true }
+repository   = { workspace = true }
+rust-version = { workspace = true }
+version      = { workspace = true }
 
 [dependencies]
 typed-builder = { workspace = true, optional = true }

--- a/marker_api/README.md
+++ b/marker_api/README.md
@@ -40,14 +40,16 @@ The simplest way to get started, is to use Marker's [lint crate template], which
 
 To get started, create a new Rust crate that compiles to a library (`cargo init --lib`). Afterwards, edit the `Cargo.toml` to compile the crate to a dynamic library and include `marker_api` as a dependency. You can simply add the following to your `Cargo.toml` file:
 
+<!-- region replace-version stable -->
 ```toml
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-marker_api = "<version>"
-marker_utils = "<version>"
+marker_api = "0.2.1"
+marker_utils = "0.2.1"
 ```
+<!-- endregion replace-version stable -->
 
 #### src/lib.rs
 

--- a/marker_api/src/ast/expr.rs
+++ b/marker_api/src/ast/expr.rs
@@ -371,7 +371,7 @@ mod test {
     use expect_test::{expect, Expect};
 
     #[track_caller]
-    fn assert_size_of<T>(expected: Expect) {
+    fn assert_size_of<T>(expected: &Expect) {
         let actual = std::mem::size_of::<T>();
         expected.assert_eq(&actual.to_string());
     }
@@ -380,37 +380,37 @@ mod test {
     fn expr_struct_size() {
         // These sizes are allowed to change, this is just a check to have a
         // general overview and to prevent accidental changes
-        assert_size_of::<IntLitExpr<'_>>(expect!["40"]);
-        assert_size_of::<FloatLitExpr<'_>>(expect!["32"]);
-        assert_size_of::<StrLitExpr<'_>>(expect!["48"]);
-        assert_size_of::<CharLitExpr<'_>>(expect!["24"]);
-        assert_size_of::<BoolLitExpr<'_>>(expect!["24"]);
-        assert_size_of::<BlockExpr<'_>>(expect!["96"]);
-        assert_size_of::<ClosureExpr<'_>>(expect!["72"]);
-        assert_size_of::<UnaryOpExpr<'_>>(expect!["40"]);
-        assert_size_of::<RefExpr<'_>>(expect!["40"]);
-        assert_size_of::<BinaryOpExpr<'_>>(expect!["56"]);
-        assert_size_of::<TryExpr<'_>>(expect!["32"]);
-        assert_size_of::<AssignExpr<'_>>(expect!["56"]);
-        assert_size_of::<AsExpr<'_>>(expect!["48"]);
-        assert_size_of::<PathExpr<'_>>(expect!["96"]);
-        assert_size_of::<CallExpr<'_>>(expect!["48"]);
-        assert_size_of::<MethodExpr<'_>>(expect!["80"]);
-        assert_size_of::<ArrayExpr<'_>>(expect!["56"]);
-        assert_size_of::<TupleExpr<'_>>(expect!["32"]);
-        assert_size_of::<CtorExpr<'_>>(expect!["136"]);
-        assert_size_of::<RangeExpr<'_>>(expect!["72"]);
-        assert_size_of::<IndexExpr<'_>>(expect!["48"]);
-        assert_size_of::<FieldExpr<'_>>(expect!["48"]);
-        assert_size_of::<IfExpr<'_>>(expect!["72"]);
-        assert_size_of::<LetExpr<'_>>(expect!["48"]);
-        assert_size_of::<MatchExpr<'_>>(expect!["48"]);
-        assert_size_of::<BreakExpr<'_>>(expect!["72"]);
-        assert_size_of::<ReturnExpr<'_>>(expect!["40"]);
-        assert_size_of::<ContinueExpr<'_>>(expect!["48"]);
-        assert_size_of::<ForExpr<'_>>(expect!["88"]);
-        assert_size_of::<LoopExpr<'_>>(expect!["56"]);
-        assert_size_of::<WhileExpr<'_>>(expect!["72"]);
-        assert_size_of::<UnstableExpr<'_>>(expect!["24"]);
+        assert_size_of::<IntLitExpr<'_>>(&expect!["40"]);
+        assert_size_of::<FloatLitExpr<'_>>(&expect!["32"]);
+        assert_size_of::<StrLitExpr<'_>>(&expect!["48"]);
+        assert_size_of::<CharLitExpr<'_>>(&expect!["24"]);
+        assert_size_of::<BoolLitExpr<'_>>(&expect!["24"]);
+        assert_size_of::<BlockExpr<'_>>(&expect!["96"]);
+        assert_size_of::<ClosureExpr<'_>>(&expect!["72"]);
+        assert_size_of::<UnaryOpExpr<'_>>(&expect!["40"]);
+        assert_size_of::<RefExpr<'_>>(&expect!["40"]);
+        assert_size_of::<BinaryOpExpr<'_>>(&expect!["56"]);
+        assert_size_of::<TryExpr<'_>>(&expect!["32"]);
+        assert_size_of::<AssignExpr<'_>>(&expect!["56"]);
+        assert_size_of::<AsExpr<'_>>(&expect!["48"]);
+        assert_size_of::<PathExpr<'_>>(&expect!["96"]);
+        assert_size_of::<CallExpr<'_>>(&expect!["48"]);
+        assert_size_of::<MethodExpr<'_>>(&expect!["80"]);
+        assert_size_of::<ArrayExpr<'_>>(&expect!["56"]);
+        assert_size_of::<TupleExpr<'_>>(&expect!["32"]);
+        assert_size_of::<CtorExpr<'_>>(&expect!["136"]);
+        assert_size_of::<RangeExpr<'_>>(&expect!["72"]);
+        assert_size_of::<IndexExpr<'_>>(&expect!["48"]);
+        assert_size_of::<FieldExpr<'_>>(&expect!["48"]);
+        assert_size_of::<IfExpr<'_>>(&expect!["72"]);
+        assert_size_of::<LetExpr<'_>>(&expect!["48"]);
+        assert_size_of::<MatchExpr<'_>>(&expect!["48"]);
+        assert_size_of::<BreakExpr<'_>>(&expect!["72"]);
+        assert_size_of::<ReturnExpr<'_>>(&expect!["40"]);
+        assert_size_of::<ContinueExpr<'_>>(&expect!["48"]);
+        assert_size_of::<ForExpr<'_>>(&expect!["88"]);
+        assert_size_of::<LoopExpr<'_>>(&expect!["56"]);
+        assert_size_of::<WhileExpr<'_>>(&expect!["72"]);
+        assert_size_of::<UnstableExpr<'_>>(&expect!["24"]);
     }
 }

--- a/marker_lints/Cargo.toml
+++ b/marker_lints/Cargo.toml
@@ -9,8 +9,6 @@ license    = { workspace = true }
 repository = { workspace = true }
 version    = { workspace = true }
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [lib]
 crate-type = ["cdylib"]
 

--- a/marker_lints/README.md
+++ b/marker_lints/README.md
@@ -25,10 +25,12 @@ This crate currently provides the following lints:
 
 To use `marker_lints` in your project, simply add it to your `Cargo.toml` under the `[workspace.metadata.marker.lints]` section. [cargo_marker] will then automatically fetch the crate and include is when running `cargo marker`.
 
+<!-- region replace-version stable -->
 ```toml
 [workspace.metadata.marker.lints]
 marker_lints = "0.2.1"
 ```
+<!-- endregion replace-version stable -->
 
 If you want to develop something with Marker, you might want to check out the [lint crate template] which already contains everything you need to get started.
 

--- a/marker_rustc_driver/Cargo.toml
+++ b/marker_rustc_driver/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "marker_rustc_driver"
 
-build       = "build.rs"
 description = "Marker's lint driver for rustc"
 
 edition    = { workspace = true }
@@ -9,8 +8,6 @@ keywords   = { workspace = true }
 license    = { workspace = true }
 repository = { workspace = true }
 version    = { workspace = true }
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 marker_adapter = { workspace = true }

--- a/marker_uilints/Cargo.toml
+++ b/marker_uilints/Cargo.toml
@@ -8,8 +8,6 @@ license    = { workspace = true }
 repository = { workspace = true }
 version    = { workspace = true }
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [lib]
 crate-type = ["cdylib"]
 

--- a/marker_uitest/Cargo.toml
+++ b/marker_uitest/Cargo.toml
@@ -3,13 +3,12 @@ name = "marker_uitest"
 
 description = "A thin wrapper around the ui_test crate for Marker"
 
-edition    = { workspace = true }
-keywords   = { workspace = true }
-license    = { workspace = true }
-repository = { workspace = true }
-version    = { workspace = true }
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition      = { workspace = true }
+keywords     = { workspace = true }
+license      = { workspace = true }
+repository   = { workspace = true }
+rust-version = { workspace = true }
+version      = { workspace = true }
 
 [dependencies]
 semver   = { workspace = true }

--- a/marker_uitest/README.md
+++ b/marker_uitest/README.md
@@ -28,14 +28,16 @@ For a full list of supported features and magic comments, please refer to the do
 
 First add `marker_utils` to the dev-dependencies of the lint crate, and specify that the ui-test doesn't require a test harness, like this:
 
+<!-- region replace-version stable -->
 ```toml
 [dev-dependencies]
-marker_uitest = "<version>"
+marker_uitest = "0.2.1"
 
 [[test]]
 name = "uitest"
 harness = false
 ```
+<!-- endregion replace-version stable -->
 
 ### Setup test file
 
@@ -47,7 +49,7 @@ use std::{env, path::Path};
 
 fn main() -> color_eyre::Result<()> {
     let mut config = marker_uitest::simple_ui_test_config!()?;
-    
+
     // Allows you to automatically update `.stderr` and `.stdout` files
     let bless = env::var_os("RUST_BLESS").is_some() || env::args().any(|arg| arg == "--bless");
     if bless {
@@ -79,4 +81,3 @@ Copyright (c) 2022-2023 Rust-Marker
 Rust-marker is distributed under the terms of the MIT license or the Apache License (Version 2.0).
 
 See [LICENSE-APACHE](https://github.com/rust-marker/marker/blob/master/LICENSE-APACHE), [LICENSE-MIT](https://github.com/rust-marker/marker/blob/master/LICENSE-MIT).
-

--- a/marker_utils/Cargo.toml
+++ b/marker_utils/Cargo.toml
@@ -4,13 +4,12 @@ name = "marker_utils"
 categories  = ["development-tools"]
 description = "Marker's standard library for creating lints"
 
-edition    = { workspace = true }
-keywords   = { workspace = true }
-license    = { workspace = true }
-repository = { workspace = true }
-version    = { workspace = true }
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition      = { workspace = true }
+keywords     = { workspace = true }
+license      = { workspace = true }
+repository   = { workspace = true }
+rust-version = { workspace = true }
+version      = { workspace = true }
 
 [dependencies]
 marker_api = { workspace = true }

--- a/marker_utils/README.md
+++ b/marker_utils/README.md
@@ -19,9 +19,10 @@ Marker utils aims to be the standard library for the development of lint crates 
 
 To get started, just include *marker_utils* as a dependency:
 
+<!-- region replace-version stable -->
 ```toml
 [dependencies]
-marker_api = "<version>"
+marker_api = "0.2.1"
 ```
 
 You can also add [marker_lints] as a lint crate, designed for this crate:
@@ -30,6 +31,7 @@ You can also add [marker_lints] as a lint crate, designed for this crate:
 [workspace.metadata.marker.lints]
 marker_lints = "0.2.1"
 ```
+<!-- endregion replace-version stable -->
 
 If you want to develop something with Marker, you might want to check out the [lint crate template] which already contains everything you need to get started.
 

--- a/scripts/download/cargo-machete.sh
+++ b/scripts/download/cargo-machete.sh
@@ -16,4 +16,4 @@ download_and_decompress \
     $base_url/$file_stem.tar.gz \
     --strip-components 1 $file_stem/cargo-machete
 
-with_log mv cargo-machete$exe ~/.cargo/bin
+move_to_path cargo-machete

--- a/scripts/download/cargo-release.sh
+++ b/scripts/download/cargo-release.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
+
+. $script_dir/lib.sh
+
+version=0.24.11
+
+base_url=https://github.com/crate-ci/cargo-release/releases/download/v$version
+
+file_stem=cargo-release-v$version-$triple_rust
+
+download_and_decompress $base_url/$file_stem.tar.gz ./cargo-release
+
+move_to_path cargo-release

--- a/scripts/download/lib.sh
+++ b/scripts/download/lib.sh
@@ -83,7 +83,6 @@ function curl_with_retry {
         --fail \
         --retry 5 \
         --retry-connrefused \
-        --retry-delay 30 \
         "$@"
 }
 

--- a/scripts/download/lib.sh
+++ b/scripts/download/lib.sh
@@ -77,10 +77,16 @@ function try_download_and_decompress {
 
 function curl_with_retry {
     with_log curl \
-        --silent \
         --location \
+        --silent \
+        --show-error \
+        --fail \
         --retry 5 \
         --retry-connrefused \
         --retry-delay 30 \
         "$@"
+}
+
+function move_to_path {
+    with_log mv "$1" $HOME/.cargo/bin
 }

--- a/scripts/download/mdbook.sh
+++ b/scripts/download/mdbook.sh
@@ -12,7 +12,7 @@ base_url=https://github.com/rust-lang/mdBook/releases/download/$version
 file_stem=mdbook-$version-$triple_rust
 download_and_decompress $base_url/$file_stem.tar.gz
 
-with_log mv mdbook$exe ~/.cargo/bin
+move_to_path mdbook
 
 # mdbook-toc
 version=0.14.1
@@ -20,4 +20,4 @@ base_url=https://github.com/badboy/mdbook-toc/releases/download/$version
 file_stem=mdbook-toc-$version-$triple_rust
 download_and_decompress $base_url/$file_stem.tar.gz
 
-with_log mv mdbook-toc$exe ~/.cargo/bin
+move_to_path mdbook-toc

--- a/scripts/download/taplo.sh
+++ b/scripts/download/taplo.sh
@@ -14,5 +14,6 @@ file_stem=taplo-$os-$arch_rust
 
 download_and_decompress $base_url/$file_stem.gz
 
-with_log chmod +x $file_stem$exe
-with_log mv $file_stem$exe ~/.cargo/bin/taplo$exe
+mv $file_stem taplo
+with_log chmod +x taplo
+move_to_path taplo

--- a/scripts/download/typos.sh
+++ b/scripts/download/typos.sh
@@ -20,4 +20,4 @@ file_stem=typos-$version-x86_64-unknown-linux-musl
 
 download_and_decompress $base_url/$file_stem.tar.gz ./typos
 
-with_log mv typos$exe ~/.cargo/bin
+move_to_path typos

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -132,3 +132,8 @@ function end_group {
         >&$global_stdout echo "::endgroup::"
     fi
 }
+
+function die {
+    >&2 echo -e "\033[31;1m❗️ Error\n$@\033[0m"
+    exit 1
+}

--- a/scripts/release/get-next-dev-version.sh
+++ b/scripts/release/get-next-dev-version.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+version="$1"
+
+IFS='.' read -r major minor patch <<< "$version"
+
+((minor++))
+
+echo "$major.$minor.0-dev"

--- a/scripts/release/get-version-from-changelog.sh
+++ b/scripts/release/get-version-from-changelog.sh
@@ -5,5 +5,5 @@ set -euo pipefail
 # Parse the first numbered version from the changelog.
 # This lives in a file separate from CI scripts so that it could be tested locally.
 
-grep --perl-regexp --only-matching '## \[\K\d+\.\d+\.\d+(-\w+)?' CHANGELOG.md \
+grep --perl-regexp --only-matching '## \[\K\d+\.\d+\.\d+(-([^\]]+))?' CHANGELOG.md \
     | head --lines 1

--- a/scripts/release/get-version-from-changelog.sh
+++ b/scripts/release/get-version-from-changelog.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Parse the first numbered version from the changelog.
+# This lives in a file separate from CI scripts so that it could be tested locally.
+
+grep --perl-regexp --only-matching '## \[\K\d+\.\d+\.\d+(-\w+)?' CHANGELOG.md \
+    | head --lines 1

--- a/scripts/release/install.sh
+++ b/scripts/release/install.sh
@@ -9,10 +9,10 @@
 
 set -Eeuo pipefail
 
-# There isn't a release of the `dev`, version, however the released version
-# of marker will replace this version with the actual one.
+# This script isn't meant to be run from `master`, but if it is, then
+# it will install the latest version be it a stable version or a pre-release.
 # region replace-version unstable
-version=0.3.0-dev
+version=0.2.1
 # endregion replace-version unstable
 
 toolchain=nightly-2023-08-24
@@ -50,7 +50,6 @@ with_log curl \
     --show-error \
     --retry 5 \
     --retry-connrefused \
-    --retry-delay 30 \
     --remote-name \
     --output-dir "$temp_dir" \
     "https://github.com/rust-marker/marker/releases/download/v$version/$files"

--- a/scripts/release/qemu-install.sh
+++ b/scripts/release/qemu-install.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# This script is intended to be run inside of a QEMU VM used for building
+# the `marker_rustc_driver` binary for ARM targets. We use a bare ubuntu
+# image in this environment which doesn't have anything installed for building
+# a Rust project, so we install all the essential build tools here.
+
+set -euo pipefail
+
+function apt-get-install {
+    with_backoff apt-get update -y
+    with_backoff apt-get install -y --no-install-recommends --no-install-suggests "$@"
+}
+
+apt-get-install \
+    build-essential \
+    ca-certificates \
+    curl
+
+function curl_with_retry {
+    with_log curl \
+        --location \
+        --silent \
+        --show-error \
+        --fail \
+        --retry 5 \
+        --retry-connrefused \
+        --retry-delay 30 \
+        "$@"
+}
+
+start_group "Installing Rust toolchain $rust_version"
+curl_with_retry \
+    --proto '=https' \
+    --tlsv1.2 \
+    -sSf https://sh.rustup.rs \
+    | with_log sh -s -- \
+        -y \
+        --default-toolchain $rust_version \
+        --no-modify-path \
+        --component rust-src rustc-dev llvm-tools
+end_group

--- a/scripts/release/qemu-setup.sh
+++ b/scripts/release/qemu-setup.sh
@@ -24,7 +24,6 @@ function curl_with_retry {
         --fail \
         --retry 5 \
         --retry-connrefused \
-        --retry-delay 30 \
         "$@"
 }
 

--- a/scripts/release/set-version.sh
+++ b/scripts/release/set-version.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
+
+. $script_dir/../lib.sh
+
+new_version="$1"
+shift
+
+commit=""
+
+while [[ $# -gt 0 ]]
+do
+    case $1 in
+        --commit)
+            commit="$2"
+            shift
+            shift
+            ;;
+        *)
+            die "Unknown option: $1"
+            ;;
+    esac
+done
+
+function replace {
+    local file="$1"
+    local region="replace-version"
+
+    if (( $# == 2 )); then
+        region="$region $2"
+    fi
+
+    comment_begin="(#|\/\/|<!--)"
+    comment_end="( -->)?$"
+
+    with_log sed --regexp-extended --in-place --file - "$file" <<EOF
+        /$comment_begin region $region$comment_end/,/$comment_begin endregion $region$comment_end/ \
+        s/[0-9]+\.[0-9]+\.[0-9]+(-[0-9a-zA-Z.]+)?/$new_version/
+EOF
+}
+
+files=($(\
+    find . -type f \
+        \( -name "*.rs" \
+        -o -name "*.md" \
+        -o -name "*.toml" \
+        -o -name "*.sh" \
+        \)\
+))
+
+for file in "${files[@]}"
+do
+    replace "$file" unstable
+    if [[ "$new_version" != *-* ]]; then
+        replace "$file" stable
+    fi
+done
+
+# We need any version of cargo executable to update the `Cargo.lock` file.
+# Github runners have `cargo` installed by default, but because this repo
+# contains a `rust-toolchain.toml` file the bare `cargo` command will try
+# to install the toolchain specified in this file. We don't need that, so
+# we use `cargo +stable` to force the use of the stable toolchain that should
+# be installed by default.
+with_log cargo +stable update --workspace
+
+if [[ $commit != "" ]]; then
+    with_log git commit --all --message "$commit"
+fi

--- a/scripts/release/set-version.sh
+++ b/scripts/release/set-version.sh
@@ -53,7 +53,16 @@ files=($(\
 
 for file in "${files[@]}"
 do
-    replace "$file" unstable
+    # Dev means all kinds of versions including stable `x.y.z`, unstable `x.y.z-suffix`
+    # and dev `x.y.z-dev`. Yes, we treat `-dev` as a special one that we never release.
+    replace "$file" dev
+
+    # Unstable means all kinds of versions including unstable `x.y.z-suffix`, but excluding `x.y.z-dev`
+    if [[ "$new_version" != *-dev ]]; then
+        replace "$file" unstable
+    fi
+
+    # Only suffixless `x.y.z` versions are replaced in stable mode
     if [[ "$new_version" != *-* ]]; then
         replace "$file" stable
     fi

--- a/scripts/release/snapshot.diff
+++ b/scripts/release/snapshot.diff
@@ -61,10 +61,6 @@
  # endregion replace-version dev
 
 === README.md ===
- curl --location --silent --fail --show-error --retry 5 --retry-connrefused \
--    https://raw.githubusercontent.com/rust-marker/marker/v<version>/scripts/release/install.sh | bash
-+    https://raw.githubusercontent.com/rust-marker/marker/v0.1.0/scripts/release/install.sh | bash
- ```
  # An external crate from a registry
 -marker_lints = "<version>"
 +marker_lints = "0.1.0"
@@ -92,12 +88,6 @@
 -        cli_example = display::cli(r#"cargo marker --lints "marker_lints = '<version>'""#),
 +        cli_example = display::cli(r#"cargo marker --lints "marker_lints = '0.1.0'""#),
          lints = "--lints".blue(),
-
-=== docs/book/src/usage/installation.md ===
- curl --location --silent --fail --show-error --retry 5 --retry-connrefused \
--    https://raw.githubusercontent.com/rust-marker/marker/v<version>/scripts/release/install.sh | bash
-+    https://raw.githubusercontent.com/rust-marker/marker/v0.1.0/scripts/release/install.sh | bash
- ```
 
 === docs/book/src/usage/lint-crate-declaration.md ===
  # An external crate from a registry

--- a/scripts/release/snapshot.diff
+++ b/scripts/release/snapshot.diff
@@ -44,11 +44,11 @@
  dependencies = [
 
 === Cargo.toml ===
- # region replace-version unstable
+ # region replace-version dev
 -version = "<version>-dev"
 +version = "0.1.0"
- # endregion replace-version unstable
- # region replace-version unstable
+ # endregion replace-version dev
+ # region replace-version dev
 -marker_adapter = { path = "./marker_adapter", version = "<version>-dev" }
 -marker_api     = { path = "./marker_api", version = "<version>-dev" }
 -marker_error   = { path = "./marker_error", version = "<version>-dev" }
@@ -58,12 +58,12 @@
  marker_uitest  = { path = "./marker_uitest", features = ["dev-build"] }
 -marker_utils   = { path = "./marker_utils", version = "<version>-dev" }
 +marker_utils   = { path = "./marker_utils", version = "0.1.0" }
- # endregion replace-version unstable
+ # endregion replace-version dev
 
 === README.md ===
- curl --location --silent --fail --show-error --retry 5 --retry-connrefused --retry-delay 30 \
--    https://raw.githubusercontent.com/rust-marker/marker/v<version>/install.sh | bash
-+    https://raw.githubusercontent.com/rust-marker/marker/v0.1.0/install.sh | bash
+ curl --location --silent --fail --show-error --retry 5 --retry-connrefused \
+-    https://raw.githubusercontent.com/rust-marker/marker/v<version>/scripts/release/install.sh | bash
++    https://raw.githubusercontent.com/rust-marker/marker/v0.1.0/scripts/release/install.sh | bash
  ```
  # An external crate from a registry
 -marker_lints = "<version>"
@@ -77,12 +77,12 @@
  ```
 
 === cargo-marker/src/backend/driver.rs ===
-         // region replace-version unstable
+         // region replace-version dev
 -        version: "<version>-dev".to_string(),
 -        api_version: "<version>-dev".to_string(),
 +        version: "0.1.0".to_string(),
 +        api_version: "0.1.0".to_string(),
-         // endregion replace-version unstable
+         // endregion replace-version dev
 
 === cargo-marker/src/error.rs ===
  # An external crate from a registry
@@ -94,9 +94,9 @@
          lints = "--lints".blue(),
 
 === docs/book/src/usage/installation.md ===
- curl --location --silent --fail --show-error --retry 5 --retry-connrefused --retry-delay 30 \
--    https://raw.githubusercontent.com/rust-marker/marker/v<version>/install.sh | bash
-+    https://raw.githubusercontent.com/rust-marker/marker/v0.1.0/install.sh | bash
+ curl --location --silent --fail --show-error --retry 5 --retry-connrefused \
+-    https://raw.githubusercontent.com/rust-marker/marker/v<version>/scripts/release/install.sh | bash
++    https://raw.githubusercontent.com/rust-marker/marker/v0.1.0/scripts/release/install.sh | bash
  ```
 
 === docs/book/src/usage/lint-crate-declaration.md ===
@@ -109,11 +109,11 @@
 +cargo marker --lint "marker_lints = '0.1.0'"
  
 
-=== install.sh ===
- # region replace-version unstable
--version=<version>-dev
-+version=0.1.0
- # endregion replace-version unstable
+=== docs/internal/release.md ===
+ <!-- region replace-version stable -->
+-This [`install.sh`](https://raw.githubusercontent.com/rust-marker/marker/v<version>/scripts/release/install.sh) script, can be used to automatically download and verify Marker's binaries.
++This [`install.sh`](https://raw.githubusercontent.com/rust-marker/marker/v0.1.0/scripts/release/install.sh) script, can be used to automatically download and verify Marker's binaries.
+ <!-- endregion replace-version stable -->
 
 === marker_api/README.md ===
  [dependencies]
@@ -144,3 +144,9 @@
 -marker_lints = "<version>"
 +marker_lints = "0.1.0"
  ```
+
+=== scripts/release/install.sh ===
+ # region replace-version unstable
+-version=<version>
++version=0.1.0
+ # endregion replace-version unstable

--- a/scripts/release/snapshot.diff
+++ b/scripts/release/snapshot.diff
@@ -1,0 +1,146 @@
+
+=== CONTRIBUTING.md ===
+     ```sh
+-    cargo marker --lints "marker_lints = '<version>'"
++    cargo marker --lints "marker_lints = '0.1.0'"
+     ```
+
+=== Cargo.lock ===
+ name = "cargo_marker"
+-version = "<version>-dev"
++version = "0.1.0"
+ dependencies = [
+ name = "marker_adapter"
+-version = "<version>-dev"
++version = "0.1.0"
+ dependencies = [
+ name = "marker_api"
+-version = "<version>-dev"
++version = "0.1.0"
+ dependencies = [
+ name = "marker_error"
+-version = "<version>-dev"
++version = "0.1.0"
+ dependencies = [
+ name = "marker_lints"
+-version = "<version>-dev"
++version = "0.1.0"
+ dependencies = [
+ name = "marker_rustc_driver"
+-version = "<version>-dev"
++version = "0.1.0"
+ dependencies = [
+ name = "marker_uilints"
+-version = "<version>-dev"
++version = "0.1.0"
+ dependencies = [
+ name = "marker_uitest"
+-version = "<version>-dev"
++version = "0.1.0"
+ dependencies = [
+ name = "marker_utils"
+-version = "<version>-dev"
++version = "0.1.0"
+ dependencies = [
+
+=== Cargo.toml ===
+ # region replace-version unstable
+-version = "<version>-dev"
++version = "0.1.0"
+ # endregion replace-version unstable
+ # region replace-version unstable
+-marker_adapter = { path = "./marker_adapter", version = "<version>-dev" }
+-marker_api     = { path = "./marker_api", version = "<version>-dev" }
+-marker_error   = { path = "./marker_error", version = "<version>-dev" }
++marker_adapter = { path = "./marker_adapter", version = "0.1.0" }
++marker_api     = { path = "./marker_api", version = "0.1.0" }
++marker_error   = { path = "./marker_error", version = "0.1.0" }
+ marker_uitest  = { path = "./marker_uitest", features = ["dev-build"] }
+-marker_utils   = { path = "./marker_utils", version = "<version>-dev" }
++marker_utils   = { path = "./marker_utils", version = "0.1.0" }
+ # endregion replace-version unstable
+
+=== README.md ===
+ curl --location --silent --fail --show-error --retry 5 --retry-connrefused --retry-delay 30 \
+-    https://raw.githubusercontent.com/rust-marker/marker/v<version>/install.sh | bash
++    https://raw.githubusercontent.com/rust-marker/marker/v0.1.0/install.sh | bash
+ ```
+ # An external crate from a registry
+-marker_lints = "<version>"
++marker_lints = "0.1.0"
+ ```
+
+=== cargo-marker/README.md ===
+ # An external crate from a registry
+-marker_lints = "<version>"
++marker_lints = "0.1.0"
+ ```
+
+=== cargo-marker/src/backend/driver.rs ===
+         // region replace-version unstable
+-        version: "<version>-dev".to_string(),
+-        api_version: "<version>-dev".to_string(),
++        version: "0.1.0".to_string(),
++        api_version: "0.1.0".to_string(),
+         // endregion replace-version unstable
+
+=== cargo-marker/src/error.rs ===
+ # An external crate from a registry
+-marker_lints = "<version>""#
++marker_lints = "0.1.0""#
+         ),
+-        cli_example = display::cli(r#"cargo marker --lints "marker_lints = '<version>'""#),
++        cli_example = display::cli(r#"cargo marker --lints "marker_lints = '0.1.0'""#),
+         lints = "--lints".blue(),
+
+=== docs/book/src/usage/installation.md ===
+ curl --location --silent --fail --show-error --retry 5 --retry-connrefused --retry-delay 30 \
+-    https://raw.githubusercontent.com/rust-marker/marker/v<version>/install.sh | bash
++    https://raw.githubusercontent.com/rust-marker/marker/v0.1.0/install.sh | bash
+ ```
+
+=== docs/book/src/usage/lint-crate-declaration.md ===
+ # An external crate from a registry
+-marker_lints = "<version>"
++marker_lints = "0.1.0"
+ 
+ # An external crate from a registry
+-cargo marker --lint "marker_lints = '<version>'"
++cargo marker --lint "marker_lints = '0.1.0'"
+ 
+
+=== install.sh ===
+ # region replace-version unstable
+-version=<version>-dev
++version=0.1.0
+ # endregion replace-version unstable
+
+=== marker_api/README.md ===
+ [dependencies]
+-marker_api = "<version>"
+-marker_utils = "<version>"
++marker_api = "0.1.0"
++marker_utils = "0.1.0"
+ ```
+
+=== marker_lints/README.md ===
+ [workspace.metadata.marker.lints]
+-marker_lints = "<version>"
++marker_lints = "0.1.0"
+ ```
+
+=== marker_uitest/README.md ===
+ [dev-dependencies]
+-marker_uitest = "<version>"
++marker_uitest = "0.1.0"
+ 
+
+=== marker_utils/README.md ===
+ [dependencies]
+-marker_api = "<version>"
++marker_api = "0.1.0"
+ ```
+ [workspace.metadata.marker.lints]
+-marker_lints = "<version>"
++marker_lints = "0.1.0"
+ ```

--- a/scripts/release/test.sh
+++ b/scripts/release/test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# This script is used to test the release automation script that sets the
+# new version number in the project files. It does so by copying the repo
+# into a temp directory, staging all dirty files, running the script, and
+# comparing the diff to a snapshot of the expected diff.
+
+set -Eeuo pipefail
+
+script_dir=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
+
+. $script_dir/../lib.sh
+
+trap cleanup SIGINT SIGTERM ERR EXIT
+
+temp_dir=$(mktemp -d)
+
+function cleanup {
+    # Unset the trap to prevent an infinite loop
+    trap - SIGINT SIGTERM ERR EXIT
+
+    with_log rm -rf "$temp_dir"
+}
+
+with_log rsync --archive --exclude-from .gitignore . "$temp_dir"
+
+with_log pushd "$temp_dir"
+
+# Make sure any dirty files in the repo at this point don't influence the diff
+with_log git add --all
+
+./scripts/release/set-version.sh '0.1.0'
+
+snap=scripts/release/snapshot.diff
+
+# Make the git diff snapshot and sanitize it from the noise and variable parts
+actual=$(\
+    with_log git diff --unified=1 \
+    | grep --invert-match --perl-regexp '^(index)|(@@.*@@ )|(--- .*)|(\+\+\+ .*)' \
+    | sed 's/diff --git a\/\(.*\) b\/.*/\n=== \1 ===/' \
+    | sed 's/\(^-[^0-9]*\)[0-9]*\.[0-9]*\.[0-9]*\(.*\)/\1<version>\2/'
+)
+
+if [[ -v UPDATE_SNAP ]]; then
+    with_log popd
+    echo "$actual" > "$snap"
+    exit 0
+fi
+
+err=0
+
+echo "$actual" | git diff --no-index --exit-code "$snap" - || err=1
+
+if [[ $err == 0 ]]; then
+    exit 0
+fi
+
+die "$(cat <<EOF
+--------------------------------------------------------------------------
+The test snapshot is outdated, or the release automation script is broken.
+If the change in the snapshot is expected run the following to update it.
+UPDATE_SNAP=1 ./scripts/release/test.sh
+EOF
+)"

--- a/scripts/release/upload.sh
+++ b/scripts/release/upload.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+script_dir=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
+
+. $script_dir/../lib.sh
+
+tag="$1"
+file="$2"
+
+with_log tar --auto-compress --create --file "$file.tar.gz" "$file"
+with_log zip -r $file.zip $file
+
+with_log shasum -a 256 "$file.tar.gz" "$file.zip" > "$file.sha256"
+
+with_backoff gh release upload \
+    "$tag" \
+    "$file.tar.gz" \
+    "$file.zip" \
+    "$file.sha256" \
+    --clobber

--- a/scripts/update-toolchain.sh
+++ b/scripts/update-toolchain.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [[ $1 != nightly-????-??-?? ]]
+then
+    echo "Please enter a valid toolchain like \`nightly-2022-01-01\`"
+    exit 1
+fi
+
+sed -i "s/nightly-2023-08-24/$1/g" \
+    ./marker_rustc_driver/src/main.rs \
+    ./marker_rustc_driver/README.md \
+    ./rust-toolchain.toml \
+    ./.github/workflows/* \
+    ./scripts/update-toolchain.sh \
+    ./cargo-marker/src/backend/driver.rs \
+    ./cargo-marker/README.md \
+    ./install.sh

--- a/util/update-toolchain.sh
+++ b/util/update-toolchain.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-if [[ $1 == nightly-????-??-?? ]]
-then
-    sed -i "s/nightly-2023-08-24/$1/g" ./marker_rustc_driver/src/main.rs ./marker_rustc_driver/README.md ./rust-toolchain.toml ./.github/workflows/* ./util/update-toolchain.sh ./cargo-marker/src/backend/driver.rs ./cargo-marker/README.md
-else
-    echo "Please enter a valid toolchain like \`nightly-2022-01-01\`"
-fi;


### PR DESCRIPTION
Closes #193

This PR adds two new CI workflows `release` and `release-on-tag`.
The release process and artifacts are described in [`docs/internal/release.md`](https://github.com/Veetaha/marker/blob/feat/automate-releases/docs/internal/release.md) in this PR,
so I won't repeat it here.

You can see how it works in my fork. 
Here is an example `release` worklfow run ([link](https://github.com/Veetaha/marker/actions/runs/6137532417/job/16653466213)).
Here is an example `release-on-tag` workflow run ([link](https://github.com/Veetaha/marker/actions/runs/6137533185/job/16653467821)) (the `crates-io` job is failing becase I don't have access to publishing marker crates).

Here are the two generated commits ([link](https://github.com/Veetaha/marker/commits/master)):
![image](https://github.com/rust-marker/marker/assets/36276403/6cd0d225-8cb2-4670-9017-443169e2b6b2)

Here is the github release that it makes ([link](https://github.com/Veetaha/marker/releases)):
![image](https://github.com/rust-marker/marker/assets/36276403/0ef81ea1-2d9b-4761-a525-705241ba60dc)

The other change made in this PR is the addition of `package.rust_version`
property to `Cargo.toml` of the library crates `marker_api`, `marker_uitest`,
`marker_utils`.

I was thinking to refactor the layout of the crates in the repo to separate
the library crates that have a strict MSRV, and the pre-compiled crates that
depend on the pinned nightly toolchain version (https://github.com/rust-marker/marker/issues/193#issuecomment-1703792584),
but I decided not to do that for now. It's not a big deal, and I don't want to
extend this PR with even more changes for that.

The scope of this PR doesn't include the code changes in `cargo-marker` to
make it use the pre-compiled `marker_rustc_driver` from the GitHub release artifacts,
falling back to `cargo install` if that doesn't work. That should be implemented in
the scope of #238.

---

The automation also covers publishing crates to crates.io with `cargo-release`

As a result of this PR the following changes to `marker` infrastructure need to be done manually and only once.

The new `bash-test` CI job needs to be marked as required to pass in `master` branch protection rules in the repo settings.
This test validates that the edits that the workflow makes to the repo match the expected git diff snapshot.

The `set-version.sh` script does a bunch of regex replacements with `sed` in all `.md` files and in some `.rs` files to update the places where we mention the bare version numbers. For example the constants of marker API and driver versions in the `cargo-marker` code, and the references to `marker_lints/api/uitest = "x.y.z"` all over the documentation.

---
The new `RELEASE_PAT` secret needs to be created in the repository. This is required because the default `github.token` that the workflows get doesn't work for the tag-event-based flow. See [the comment here](https://github.com/Veetaha/marker/blob/ac0ffbfbcfb75a68cabf75033dd9e48cbf95b46c/.github/workflows/release.yml#L25-L29).

To create it follow this link: https://github.com/settings/personal-access-tokens/new.

Make a token with a really long expiration date (unless you are okay with having a shorter expiration duration and rotating the token manually on schedule). For the permissions allow access only to the marker repository and give it "read and write" for the repo contents.

<details>
<summary>Screenshots</summary>

![](https://github.com/toml-lang/toml/assets/36276403/88084992-3ac2-4592-b31d-1cf1de3d2afb)
![](https://github.com/toml-lang/toml/assets/36276403/23fb6808-0f16-4b25-a5db-96c961c61e2a)

</details>

Then add this as as a GitHub Actions secret in the repo settings.

<details>
<summary>Screenshot</summary>

![](https://github.com/toml-lang/toml/assets/36276403/a3d83391-8373-4b08-baa9-b25a391f09d9)

</details>

---

Generate a new crates.io API token by following this link: https://crates.io/settings/tokens.
The token needs permissions to `publish-update` and optionally to `publish-new`. Unless you are going to manually reserve the crate names, and not rely on the release CI to publish the first version of the crate you may not give it `publish-new` permission.

The same comment about the token expiration applies here as well. Unfortunatelly, there isn't an easy way to automate the rotation of the expired tokens, so you either have to do that manually which is secure but annoying, or you can set a really high expiration duration, which is convenient but unsecure.

You can also restrict the token with the crate name pattern like `marker_*`.

The token then needs to be set as a secret named `CRATES_IO_TOKEN` in the repository. On my screenshots above I didn't have that secret, and I actually didn't fully test the publishing of the crates to crates.io because I don't have access to `marker` crates on crates.io, and otherwise I wouldn't like to create junk crates just for testing that will be left on `crates.io` indefinitely. I expect there may be publishing failures on the first release that uses this automation because I didn't test this entirely, but hopefully, there won't be any, or they will be simple to fix.