### PR TITLE
API: Reduce parameters for `AstContext::emit_lint` and add docs

### DIFF
--- a/marker_adapter/src/context.rs
+++ b/marker_adapter/src/context.rs
@@ -9,7 +9,7 @@ use marker_api::{
         TyDefId,
     },
     context::DriverCallbacks,
-    diagnostic::{Diagnostic, EmissionNode},
+    diagnostic::{Diagnostic, EmissionNodeId},
     ffi::{self, FfiOption},
     lint::{Level, Lint},
 };
@@ -59,7 +59,7 @@ impl<'ast> DriverContextWrapper<'ast> {
 
 // False positive because `EmissionNode` are non-exhaustive
 #[allow(improper_ctypes_definitions)]
-extern "C" fn lint_level_at<'ast>(data: &'ast (), lint: &'static Lint, node: EmissionNode) -> Level {
+extern "C" fn lint_level_at<'ast>(data: &'ast (), lint: &'static Lint, node: EmissionNodeId) -> Level {
     unsafe { as_driver_cx(data) }.lint_level_at(lint, node)
 }
 
@@ -129,7 +129,7 @@ unsafe fn as_driver_cx<'ast>(data: &'ast ()) -> &'ast dyn DriverContext<'ast> {
 }
 
 pub trait DriverContext<'ast> {
-    fn lint_level_at(&'ast self, lint: &'static Lint, node: EmissionNode) -> Level;
+    fn lint_level_at(&'ast self, lint: &'static Lint, node: EmissionNodeId) -> Level;
     fn emit_diag(&'ast self, diag: &Diagnostic<'_, 'ast>);
 
     fn item(&'ast self, api_id: ItemId) -> Option<ItemKind<'ast>>;

--- a/marker_adapter/src/context.rs
+++ b/marker_adapter/src/context.rs
@@ -2,16 +2,12 @@
 #![allow(clippy::needless_lifetimes)]
 
 use marker_api::{
-    ast::{
-        item::{Body, ItemKind},
-        ty::SemTyKind,
-        BodyId, ExpnId, ExpnInfo, ExprId, FileInfo, FilePos, ItemId, Span, SpanId, SpanPos, SpanSource, SymbolId,
-        TyDefId,
-    },
+    ast::{ty::SemTyKind, ExpnId, ExpnInfo, ExprId, FileInfo, FilePos, SpanId, SpanPos, SpanSource, SymbolId},
     context::DriverCallbacks,
-    diagnostic::{Diagnostic, EmissionNodeId},
+    diagnostic::Diagnostic,
     ffi::{self, FfiOption},
     lint::{Level, Lint},
+    prelude::*,
 };
 
 /// ### Safety
@@ -59,7 +55,7 @@ impl<'ast> DriverContextWrapper<'ast> {
 
 // False positive because `EmissionNode` are non-exhaustive
 #[allow(improper_ctypes_definitions)]
-extern "C" fn lint_level_at<'ast>(data: &'ast (), lint: &'static Lint, node: EmissionNodeId) -> Level {
+extern "C" fn lint_level_at<'ast>(data: &'ast (), lint: &'static Lint, node: NodeId) -> Level {
     unsafe { as_driver_cx(data) }.lint_level_at(lint, node)
 }
 
@@ -129,7 +125,7 @@ unsafe fn as_driver_cx<'ast>(data: &'ast ()) -> &'ast dyn DriverContext<'ast> {
 }
 
 pub trait DriverContext<'ast> {
-    fn lint_level_at(&'ast self, lint: &'static Lint, node: EmissionNodeId) -> Level;
+    fn lint_level_at(&'ast self, lint: &'static Lint, node: NodeId) -> Level;
     fn emit_diag(&'ast self, diag: &Diagnostic<'_, 'ast>);
 
     fn item(&'ast self, api_id: ItemId) -> Option<ItemKind<'ast>>;

--- a/marker_api/src/ast/expr/lit_expr.rs
+++ b/marker_api/src/ast/expr/lit_expr.rs
@@ -62,7 +62,7 @@ impl<'ast> CharLitExpr<'ast> {
 /// can be hardware-dependent. For exact value checks, it might be better to check
 /// the written float literal by getting the code snipped from the expression span.
 /// See:
-/// * [`ExprData::span()`](`super::ExprData::span`)
+/// * [`HasSpan::span()`](`super::HasSpan::span`)
 /// * [`Span::snippet()`](`crate::ast::Span::snippet`)
 ///
 /// All integer literals are unsigned, negative numbers have a unary negation

--- a/marker_api/src/ast/item/adt_item.rs
+++ b/marker_api/src/ast/item/adt_item.rs
@@ -1,6 +1,7 @@
 use crate::ast::expr::ConstExpr;
 use crate::ast::generic::SynGenericParams;
 use crate::ast::ty::SynTyKind;
+use crate::ast::HasSpan;
 use crate::ast::{FieldId, Span, SpanId, SymbolId, VariantId};
 use crate::context::with_cx;
 use crate::ffi::{FfiOption, FfiSlice};
@@ -159,19 +160,20 @@ impl<'ast> EnumVariant<'ast> {
         }
     }
 
-    /// The [`Span`] of the entire item. This span should be used for general item related
-    /// diagnostics.
-    pub fn span(&self) -> &Span<'ast> {
-        with_cx(self, |cx| cx.span(self.span))
-    }
-
     /// The discriminant of this variant, if one has been defined
     pub fn discriminant(&self) -> Option<&ConstExpr<'ast>> {
         self.discriminant.get()
     }
 }
 
-crate::diagnostic::impl_emission_node_for_node!(&EnumVariant<'ast>);
+impl<'ast> HasSpan<'ast> for EnumVariant<'ast> {
+    fn span(&self) -> &Span<'ast> {
+        with_cx(self, |cx| cx.span(self.span))
+    }
+}
+
+crate::ast::impl_identifiable_for!(EnumVariant<'ast>);
+impl<'ast> crate::private::Sealed for EnumVariant<'ast> {}
 
 #[cfg(feature = "driver-api")]
 impl<'ast> EnumVariant<'ast> {
@@ -312,16 +314,17 @@ impl<'ast> Field<'ast> {
         self.ty
     }
 
-    /// The [`Span`] of the entire item. This span should be used for general item related
-    /// diagnostics.
-    pub fn span(&self) -> &Span<'ast> {
-        with_cx(self, |cx| cx.span(self.span))
-    }
-
     // FIXME(xFrednet): Add `fn attrs() -> ??? {}`, see rust-marker/marker#51
 }
 
-crate::diagnostic::impl_emission_node_for_node!(&Field<'ast>);
+impl<'ast> HasSpan<'ast> for Field<'ast> {
+    fn span(&self) -> &Span<'ast> {
+        with_cx(self, |cx| cx.span(self.span))
+    }
+}
+
+crate::ast::impl_identifiable_for!(Field<'ast>);
+impl<'ast> crate::private::Sealed for Field<'ast> {}
 
 #[cfg(feature = "driver-api")]
 impl<'ast> Field<'ast> {

--- a/marker_api/src/ast/item/adt_item.rs
+++ b/marker_api/src/ast/item/adt_item.rs
@@ -171,6 +171,8 @@ impl<'ast> EnumVariant<'ast> {
     }
 }
 
+crate::diagnostic::impl_emission_node_for_node!(&EnumVariant<'ast>);
+
 #[cfg(feature = "driver-api")]
 impl<'ast> EnumVariant<'ast> {
     pub fn new(
@@ -318,6 +320,8 @@ impl<'ast> Field<'ast> {
 
     // FIXME(xFrednet): Add `fn attrs() -> ??? {}`, see rust-marker/marker#51
 }
+
+crate::diagnostic::impl_emission_node_for_node!(&Field<'ast>);
 
 #[cfg(feature = "driver-api")]
 impl<'ast> Field<'ast> {

--- a/marker_api/src/ast/stmt.rs
+++ b/marker_api/src/ast/stmt.rs
@@ -51,6 +51,9 @@ impl<'ast> StmtKind<'ast> {
     pub fn attrs(&self) {}
 }
 
+crate::diagnostic::impl_emission_node_for_node!(StmtKind<'ast>);
+crate::diagnostic::impl_emission_node_for_node!(&StmtKind<'ast>);
+
 #[repr(C)]
 #[derive(Debug)]
 #[cfg_attr(feature = "driver-api", visibility::make(pub))]
@@ -128,6 +131,7 @@ impl<'ast> LetStmt<'ast> {
 }
 
 impl_stmt_data!(LetStmt<'ast>, Let);
+crate::diagnostic::impl_emission_node_for_node!(LetStmt<'ast>);
 
 #[repr(C)]
 #[derive(Debug)]
@@ -144,6 +148,7 @@ impl<'ast> ExprStmt<'ast> {
 }
 
 impl_stmt_data!(ExprStmt<'ast>, Expr);
+crate::diagnostic::impl_emission_node_for_node!(ExprStmt<'ast>);
 
 #[repr(C)]
 #[derive(Debug)]
@@ -160,3 +165,4 @@ impl<'ast> ItemStmt<'ast> {
 }
 
 impl_stmt_data!(ItemStmt<'ast>, Item);
+crate::diagnostic::impl_emission_node_for_node!(ItemStmt<'ast>);

--- a/marker_api/src/lib.rs
+++ b/marker_api/src/lib.rs
@@ -46,6 +46,8 @@ pub(crate) mod private {
     ///
     /// See: [Sealed traits](https://rust-lang.github.io/api-guidelines/future-proofing.html)
     pub trait Sealed {}
+
+    impl<N: Sealed> Sealed for &N {}
 }
 
 /// This struct blocks the construction of enum variants, similar to the `#[non_exhaustive]`

--- a/marker_api/src/prelude.rs
+++ b/marker_api/src/prelude.rs
@@ -2,12 +2,13 @@
 //! when working with Marker. Simply add `use marker_api::prelude::*;` to your
 //! file, to import them all.
 
-// AST Traits:
+// Traits:
 pub use crate::ast::expr::ExprData;
 pub use crate::ast::item::ItemData;
 pub use crate::ast::pat::PatData;
 pub use crate::ast::stmt::StmtData;
 pub use crate::ast::ty::SynTyData;
+pub use crate::diagnostic::EmissionNode;
 
 // Common types
 pub use crate::ast::expr::ExprKind;

--- a/marker_api/src/prelude.rs
+++ b/marker_api/src/prelude.rs
@@ -8,7 +8,12 @@ pub use crate::ast::item::ItemData;
 pub use crate::ast::pat::PatData;
 pub use crate::ast::stmt::StmtData;
 pub use crate::ast::ty::SynTyData;
+pub use crate::ast::HasNodeId;
+pub use crate::ast::HasSpan;
 pub use crate::diagnostic::EmissionNode;
+
+// IDs
+pub use crate::ast::{BodyId, ExprId, FieldId, GenericId, ItemId, NodeId, StmtId, TyDefId, VarId, VariantId};
 
 // Common types
 pub use crate::ast::expr::ExprKind;

--- a/marker_lints/src/lib.rs
+++ b/marker_lints/src/lib.rs
@@ -50,7 +50,6 @@ fn check_msg<'ast>(cx: &AstContext<'ast>, msg_expr: ExprKind<'ast>) {
             DIAG_MSG_UPPERCASE_START,
             msg_expr,
             "this message starts with an uppercase character",
-            |_| {},
         );
     }
 }

--- a/marker_lints/src/lib.rs
+++ b/marker_lints/src/lib.rs
@@ -48,9 +48,8 @@ fn check_msg<'ast>(cx: &AstContext<'ast>, msg_expr: ExprKind<'ast>) {
     {
         cx.emit_lint(
             DIAG_MSG_UPPERCASE_START,
-            msg_expr.id(),
+            msg_expr,
             "this message starts with an uppercase character",
-            msg_expr.span(),
             |_| {},
         );
     }

--- a/marker_lints/src/lib.rs
+++ b/marker_lints/src/lib.rs
@@ -7,7 +7,7 @@ use marker_api::{
     LintPass, LintPassInfo, LintPassInfoBuilder,
 };
 
-marker_api::declare_lint!(
+marker_api::declare_lint! {
     /// ### What it does
     /// Diagnostic messages should start with lower case letter according to
     /// [rustc's dev guide].
@@ -15,7 +15,7 @@ marker_api::declare_lint!(
     /// [rustc's dev guide]: <https://rustc-dev-guide.rust-lang.org/diagnostics.html#diagnostic-output-style-guide>
     DIAG_MSG_UPPERCASE_START,
     Warn,
-);
+}
 
 #[derive(Debug, Default)]
 struct MarkerLintsLintPass;

--- a/marker_lints/tests/ui/diag_msg_uppercase_start.rs
+++ b/marker_lints/tests/ui/diag_msg_uppercase_start.rs
@@ -9,17 +9,17 @@ marker_api::declare_lint!(
 );
 
 pub fn accept_message<'ast>(cx: &AstContext<'ast>, expr: ExprKind<'ast>) {
-    cx.emit_lint(DUMMY, expr.id(), "x <-- this is cool", expr.span(), |_| {});
-    cx.emit_lint(DUMMY, expr.id(), "=^.^= <-- Interesting, but valid", expr.span(), |_| {});
-    cx.emit_lint(DUMMY, expr.id(), "", expr.span(), |_| {});
+    cx.emit_lint(DUMMY, expr, "x <-- this is cool", |_| {});
+    cx.emit_lint(DUMMY, expr, "=^.^= <-- Interesting, but valid", |_| {});
+    cx.emit_lint(DUMMY, expr, "", |_| {});
     
     let variable = "";
-    cx.emit_lint(DUMMY, expr.id(), variable, expr.span(), |_| {});
+    cx.emit_lint(DUMMY, expr, variable, |_| {});
 }
 
 pub fn warn_about_message<'ast>(cx: &AstContext<'ast>, expr: ExprKind<'ast>) {
-    cx.emit_lint(DUMMY, expr.id(), "X <-- starting with upper case", expr.span(), |_| {});
-    cx.emit_lint(DUMMY, expr.id(), "Hey <-- starting with upper case", expr.span(), |_| {});
+    cx.emit_lint(DUMMY, expr, "X <-- starting with upper case", |_| {});
+    cx.emit_lint(DUMMY, expr, "Hey <-- starting with upper case", |_| {});
 }
 
 fn main() {}

--- a/marker_lints/tests/ui/diag_msg_uppercase_start.rs
+++ b/marker_lints/tests/ui/diag_msg_uppercase_start.rs
@@ -9,17 +9,17 @@ marker_api::declare_lint!(
 );
 
 pub fn accept_message<'ast>(cx: &AstContext<'ast>, expr: ExprKind<'ast>) {
-    cx.emit_lint(DUMMY, expr, "x <-- this is cool", |_| {});
-    cx.emit_lint(DUMMY, expr, "=^.^= <-- Interesting, but valid", |_| {});
-    cx.emit_lint(DUMMY, expr, "", |_| {});
-    
+    cx.emit_lint(DUMMY, expr, "x <-- this is cool");
+    cx.emit_lint(DUMMY, expr, "=^.^= <-- Interesting, but valid");
+    cx.emit_lint(DUMMY, expr, "");
+
     let variable = "";
-    cx.emit_lint(DUMMY, expr, variable, |_| {});
+    cx.emit_lint(DUMMY, expr, variable);
 }
 
 pub fn warn_about_message<'ast>(cx: &AstContext<'ast>, expr: ExprKind<'ast>) {
-    cx.emit_lint(DUMMY, expr, "X <-- starting with upper case", |_| {});
-    cx.emit_lint(DUMMY, expr, "Hey <-- starting with upper case", |_| {});
+    cx.emit_lint(DUMMY, expr, "X <-- starting with upper case");
+    cx.emit_lint(DUMMY, expr, "Hey <-- starting with upper case");
 }
 
 fn main() {}

--- a/marker_lints/tests/ui/diag_msg_uppercase_start.rs
+++ b/marker_lints/tests/ui/diag_msg_uppercase_start.rs
@@ -2,11 +2,11 @@ extern crate marker_api;
 
 use marker_api::{ast::expr::ExprKind, context::AstContext};
 
-marker_api::declare_lint!(
+marker_api::declare_lint!{
     /// Dummy
     DUMMY,
     Warn,
-);
+}
 
 pub fn accept_message<'ast>(cx: &AstContext<'ast>, expr: ExprKind<'ast>) {
     cx.emit_lint(DUMMY, expr, "x <-- this is cool");

--- a/marker_lints/tests/ui/diag_msg_uppercase_start.stderr
+++ b/marker_lints/tests/ui/diag_msg_uppercase_start.stderr
@@ -1,16 +1,16 @@
 warning: this message starts with an uppercase character
-  --> $DIR/diag_msg_uppercase_start.rs:21:36
+  --> $DIR/diag_msg_uppercase_start.rs:21:31
    |
-21 |     cx.emit_lint(DUMMY, expr.id(), "X <-- starting with upper case", expr.span(), |_| {});
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+21 |     cx.emit_lint(DUMMY, expr, "X <-- starting with upper case", |_| {});
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(marker::diag_msg_uppercase_start)]` on by default
 
 warning: this message starts with an uppercase character
-  --> $DIR/diag_msg_uppercase_start.rs:22:36
+  --> $DIR/diag_msg_uppercase_start.rs:22:31
    |
-22 |     cx.emit_lint(DUMMY, expr.id(), "Hey <-- starting with upper case", expr.span(), |_| {});
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+22 |     cx.emit_lint(DUMMY, expr, "Hey <-- starting with upper case", |_| {});
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: 2 warnings emitted
 

--- a/marker_lints/tests/ui/diag_msg_uppercase_start.stderr
+++ b/marker_lints/tests/ui/diag_msg_uppercase_start.stderr
@@ -1,7 +1,7 @@
 warning: this message starts with an uppercase character
   --> $DIR/diag_msg_uppercase_start.rs:21:31
    |
-21 |     cx.emit_lint(DUMMY, expr, "X <-- starting with upper case", |_| {});
+21 |     cx.emit_lint(DUMMY, expr, "X <-- starting with upper case");
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(marker::diag_msg_uppercase_start)]` on by default
@@ -9,7 +9,7 @@ warning: this message starts with an uppercase character
 warning: this message starts with an uppercase character
   --> $DIR/diag_msg_uppercase_start.rs:22:31
    |
-22 |     cx.emit_lint(DUMMY, expr, "Hey <-- starting with upper case", |_| {});
+22 |     cx.emit_lint(DUMMY, expr, "Hey <-- starting with upper case");
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: 2 warnings emitted

--- a/marker_rustc_driver/src/context.rs
+++ b/marker_rustc_driver/src/context.rs
@@ -7,7 +7,7 @@ use marker_api::{
         BodyId, ExprId, ItemId, Span, SpanId, SymbolId, TyDefId,
     },
     context::AstContext,
-    diagnostic::{Diagnostic, EmissionNode},
+    diagnostic::{Diagnostic, EmissionNodeId},
     lint::{Level, Lint},
 };
 use rustc_hash::FxHashMap;
@@ -74,7 +74,7 @@ impl<'ast, 'tcx> RustcContext<'ast, 'tcx> {
 }
 
 impl<'ast, 'tcx: 'ast> DriverContext<'ast> for RustcContext<'ast, 'tcx> {
-    fn lint_level_at(&'ast self, api_lint: &'static Lint, node: EmissionNode) -> Level {
+    fn lint_level_at(&'ast self, api_lint: &'static Lint, node: EmissionNodeId) -> Level {
         if let Some(id) = self.rustc_converter.try_to_hir_id_from_emission_node(node) {
             let lint = self.rustc_converter.to_lint(api_lint);
             let level = self.rustc_cx.lint_level_at_node(lint, id).0;

--- a/marker_rustc_driver/src/context.rs
+++ b/marker_rustc_driver/src/context.rs
@@ -2,13 +2,10 @@ use std::cell::{OnceCell, RefCell};
 
 use marker_adapter::context::{DriverContext, DriverContextWrapper};
 use marker_api::{
-    ast::{
-        item::{Body, ItemKind},
-        BodyId, ExprId, ItemId, Span, SpanId, SymbolId, TyDefId,
-    },
-    context::AstContext,
-    diagnostic::{Diagnostic, EmissionNodeId},
+    ast::{SpanId, SymbolId},
+    diagnostic::Diagnostic,
     lint::{Level, Lint},
+    prelude::*,
 };
 use rustc_hash::FxHashMap;
 use rustc_hir as hir;
@@ -74,7 +71,7 @@ impl<'ast, 'tcx> RustcContext<'ast, 'tcx> {
 }
 
 impl<'ast, 'tcx: 'ast> DriverContext<'ast> for RustcContext<'ast, 'tcx> {
-    fn lint_level_at(&'ast self, api_lint: &'static Lint, node: EmissionNodeId) -> Level {
+    fn lint_level_at(&'ast self, api_lint: &'static Lint, node: NodeId) -> Level {
         if let Some(id) = self.rustc_converter.try_to_hir_id_from_emission_node(node) {
             let lint = self.rustc_converter.to_lint(api_lint);
             let level = self.rustc_cx.lint_level_at_node(lint, id).0;

--- a/marker_rustc_driver/src/conversion/rustc/common.rs
+++ b/marker_rustc_driver/src/conversion/rustc/common.rs
@@ -1,12 +1,10 @@
 use std::mem::{size_of, transmute};
 
 use marker_api::{
-    ast::{
-        BodyId, CrateId, ExpnId, ExprId, FieldId, GenericId, ItemId, Span, SpanId, SpanPos, SpanSrcId, StmtId,
-        SymbolId, TyDefId, VarId, VariantId,
-    },
-    diagnostic::{Applicability, EmissionNodeId},
+    ast::{CrateId, ExpnId, SpanId, SpanPos, SpanSrcId, SymbolId},
+    diagnostic::Applicability,
     lint::Level,
+    prelude::*,
 };
 use rustc_hir as hir;
 
@@ -130,13 +128,14 @@ impl<'ast, 'tcx> RustcConverter<'ast, 'tcx> {
     }
 
     #[must_use]
-    pub fn try_to_hir_id_from_emission_node(&self, node: EmissionNodeId) -> Option<hir::HirId> {
+    pub fn try_to_hir_id_from_emission_node(&self, node: NodeId) -> Option<hir::HirId> {
         let def_id = match node {
-            EmissionNodeId::Expr(id) => return Some(self.to_hir_id(id)),
-            EmissionNodeId::Item(id) => self.to_def_id(id),
-            EmissionNodeId::Stmt(id) => return Some(self.to_hir_id(id)),
-            EmissionNodeId::Field(id) => return Some(self.to_hir_id(id)),
-            EmissionNodeId::Variant(id) => self.to_def_id(id),
+            NodeId::Expr(id) => return Some(self.to_hir_id(id)),
+            NodeId::Item(id) => self.to_def_id(id),
+            NodeId::Stmt(id) => return Some(self.to_hir_id(id)),
+            NodeId::Body(id) => return Some(self.to_body_id(id).hir_id),
+            NodeId::Field(id) => return Some(self.to_hir_id(id)),
+            NodeId::Variant(id) => self.to_def_id(id),
             _ => unreachable!(),
         };
 

--- a/marker_rustc_driver/src/conversion/rustc/common.rs
+++ b/marker_rustc_driver/src/conversion/rustc/common.rs
@@ -5,7 +5,7 @@ use marker_api::{
         BodyId, CrateId, ExpnId, ExprId, FieldId, GenericId, ItemId, Span, SpanId, SpanPos, SpanSrcId, StmtId,
         SymbolId, TyDefId, VarId, VariantId,
     },
-    diagnostic::{Applicability, EmissionNode},
+    diagnostic::{Applicability, EmissionNodeId},
     lint::Level,
 };
 use rustc_hir as hir;
@@ -130,13 +130,13 @@ impl<'ast, 'tcx> RustcConverter<'ast, 'tcx> {
     }
 
     #[must_use]
-    pub fn try_to_hir_id_from_emission_node(&self, node: EmissionNode) -> Option<hir::HirId> {
+    pub fn try_to_hir_id_from_emission_node(&self, node: EmissionNodeId) -> Option<hir::HirId> {
         let def_id = match node {
-            EmissionNode::Expr(id) => return Some(self.to_hir_id(id)),
-            EmissionNode::Item(id) => self.to_def_id(id),
-            EmissionNode::Stmt(id) => return Some(self.to_hir_id(id)),
-            EmissionNode::Field(id) => return Some(self.to_hir_id(id)),
-            EmissionNode::Variant(id) => self.to_def_id(id),
+            EmissionNodeId::Expr(id) => return Some(self.to_hir_id(id)),
+            EmissionNodeId::Item(id) => self.to_def_id(id),
+            EmissionNodeId::Stmt(id) => return Some(self.to_hir_id(id)),
+            EmissionNodeId::Field(id) => return Some(self.to_hir_id(id)),
+            EmissionNodeId::Variant(id) => self.to_def_id(id),
             _ => unreachable!(),
         };
 

--- a/marker_uilints/src/lib.rs
+++ b/marker_uilints/src/lib.rs
@@ -119,7 +119,7 @@ impl LintPass for TestLintPass {
             Some(name) if name.starts_with("PrintMe") || name.starts_with("PRINT_ME") || name.starts_with("print_me")
         ) {
             cx.emit_lint(TEST_LINT, item, "printing item").decorate(|diag| {
-                diag.set_main_span(item.ident().unwrap().span());
+                diag.span(item.ident().unwrap().span());
                 diag.note(format!("{item:#?}"));
             });
         }
@@ -131,7 +131,7 @@ impl LintPass for TestLintPass {
             ) {
                 cx.emit_lint(TEST_LINT, item, "printing item with body")
                     .decorate(|diag| {
-                        diag.set_main_span(item.ident().unwrap().span());
+                        diag.span(item.ident().unwrap().span());
                         diag.note(format!("Item: {item:#?}"));
                         diag.note(format!("Body: {:#?}", cx.body(func.body_id().unwrap())));
                     });
@@ -210,7 +210,7 @@ fn check_static_item<'ast>(cx: &'ast AstContext<'ast>, item: &'ast StaticItem<'a
         let name = name.name();
         if name.starts_with("PRINT_TYPE") {
             cx.emit_lint(TEST_LINT, item, "printing type for").decorate(|diag| {
-                diag.set_main_span(item.ty().span());
+                diag.span(item.ty().span());
             });
             eprintln!("{:#?}\n\n", item.ty());
         } else if name.starts_with("FIND_ITEM") {

--- a/marker_uilints/src/utils.rs
+++ b/marker_uilints/src/utils.rs
@@ -20,9 +20,9 @@ pub fn check_item<'ast>(cx: &'ast AstContext<'ast>, item: ItemKind<'ast>) {
             TEST_CONTAINS_RETURN,
             item,
             format!("testing `contains_return` -> {res}"),
-            |diag| {
-                diag.set_main_span(ident.span());
-            },
-        );
+        )
+        .decorate(|diag| {
+            diag.set_main_span(ident.span());
+        });
     }
 }

--- a/marker_uilints/src/utils.rs
+++ b/marker_uilints/src/utils.rs
@@ -22,7 +22,7 @@ pub fn check_item<'ast>(cx: &'ast AstContext<'ast>, item: ItemKind<'ast>) {
             format!("testing `contains_return` -> {res}"),
         )
         .decorate(|diag| {
-            diag.set_main_span(ident.span());
+            diag.span(ident.span());
         });
     }
 }

--- a/marker_uilints/src/utils.rs
+++ b/marker_uilints/src/utils.rs
@@ -18,10 +18,11 @@ pub fn check_item<'ast>(cx: &'ast AstContext<'ast>, item: ItemKind<'ast>) {
 
         cx.emit_lint(
             TEST_CONTAINS_RETURN,
-            item.id(),
+            item,
             format!("testing `contains_return` -> {res}"),
-            ident.span(),
-            |_| {},
+            |diag| {
+                diag.set_main_span(ident.span());
+            },
         );
     }
 }


### PR DESCRIPTION
This came up in the discussion of rust-marker/marker#189. I believe the previous design was the correct technical implementation, I agree that it's quite verbose and potentially confusing to new users. Now we have a bunch of documentation, how `AstContext::emit_lint` should be used, and it only takes three parameters for a minimal lint emission. :tada: 

@Veetaha would you mind providing feedback on this PR? Since this came up in the discussion from rust-marker/marker#189