### PR TITLE
Reorganize the CLI to a consistent module structure 

### DIFF
--- a/cargo-marker/src/backend/lints/fetch.rs
+++ b/cargo-marker/src/backend/lints/fetch.rs
@@ -16,7 +16,7 @@ use crate::observability::prelude::*;
 use crate::{backend::Config, config::LintDependencyEntry};
 use camino::{Utf8Path, Utf8PathBuf};
 use cargo_metadata::Metadata;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// This function fetches and locates all lint crates specified in the given
 /// configuration.
@@ -39,7 +39,7 @@ fn setup_dummy_crate(config: &Config) -> Result<Utf8PathBuf> {
     /// A small hack, to have the lints namespaced under the `[dependencies]` section
     #[derive(serde::Serialize)]
     struct DepNamespace<'a> {
-        dependencies: &'a HashMap<String, LintDependencyEntry>,
+        dependencies: &'a BTreeMap<String, LintDependencyEntry>,
     }
 
     // Manifest

--- a/cargo-marker/src/cli.rs
+++ b/cargo-marker/src/cli.rs
@@ -1,8 +1,10 @@
-use crate::config::{Config, LintDependency};
+mod check;
+mod setup;
+mod test_setup;
+
+use crate::config::Config;
 use crate::error::prelude::*;
-use camino::Utf8Path;
-use clap::{Args, Parser, Subcommand};
-use std::collections::HashMap;
+use clap::{Parser, Subcommand};
 
 /// Marker's CLI interface
 ///
@@ -11,7 +13,7 @@ use std::collections::HashMap;
 #[derive(Parser, Debug)]
 #[command(name = "cargo")]
 #[command(author, version, about)]
-struct MarkerApp {
+struct CargoPlugin {
     #[clap(subcommand)]
     subcommand: MarkerSubcommand,
 }
@@ -24,76 +26,48 @@ enum MarkerSubcommand {
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
 #[command(override_usage = "cargo marker [OPTIONS] [COMMAND] -- <CARGO ARGS>")]
-pub struct MarkerCli {
+pub(crate) struct MarkerCli {
     #[command(subcommand)]
-    pub command: Option<CliCommand>,
+    pub(crate) command: Option<CliCommand>,
 
     /// Used as the arguments to run Marker, when no command was specified
     #[clap(flatten)]
-    pub check_args: CheckArgs,
+    pub(crate) check: check::CheckCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum CliCommand {
+    /// Run Marker on the current package
+    Check(check::CheckCommand),
+
+    /// Setup the rustc driver for Marker
+    Setup(setup::SetupCommand),
+
+    /// **UNSTABLE** Setup the specified lint crate for ui tests
+    #[command(hide = true)]
+    TestSetup(test_setup::TestSetupCommand),
 }
 
 impl MarkerCli {
     /// Prefer using this over the normal `parse` method, to split the arguments
-    pub fn parse_args() -> Self {
-        let MarkerSubcommand::Marker(cli) = MarkerApp::parse().subcommand;
+    pub(crate) fn parse_args() -> Self {
+        let MarkerSubcommand::Marker(cli) = CargoPlugin::parse().subcommand;
         cli
     }
-}
 
-#[derive(Subcommand, Debug)]
-pub enum CliCommand {
-    /// Run Marker on the current package
-    Check(CheckArgs),
-    /// Setup the rustc driver for Marker
-    Setup(SetupArgs),
-    /// **UNSTABLE** Setup the specified lint crate for ui tests
-    #[command(hide = true)]
-    TestSetup(CheckArgs),
-}
+    pub(crate) fn run(self) -> Result {
+        let manifest_path = crate::backend::cargo::Cargo::default().cargo_locate_project()?;
+        let config = Config::try_from_manifest(&manifest_path)?;
 
-#[derive(Args, Debug)]
-#[command(override_usage = "cargo marker check [OPTIONS] -- <CARGO ARGS>")]
-pub struct CheckArgs {
-    /// Specifies lint crates which should be used. (Lints in `Cargo.toml` will be ignored)
-    #[arg(short, long)]
-    pub lints: Vec<String>,
-    /// Forwards the current `RUSTFLAGS` value during driver and lint crate compilation
-    #[arg(long)]
-    pub forward_rust_flags: bool,
-
-    /// Arguments which will be forwarded to Cargo. See `cargo check --help`
-    #[clap(last = true)]
-    pub cargo_args: Vec<String>,
-}
-
-#[derive(Args, Debug)]
-pub struct SetupArgs {
-    /// Automatically installs the required toolchain using rustup
-    #[arg(long)]
-    pub auto_install_toolchain: bool,
-    /// Forwards the current `RUSTFLAGS` value during driver and lint crate compilation
-    #[arg(long)]
-    pub forward_rust_flags: bool,
-}
-
-pub fn collect_lint_deps(args: &CheckArgs) -> Result<Option<HashMap<String, LintDependency>>> {
-    if args.lints.is_empty() {
-        return Ok(None);
+        let Some(command) = self.command else {
+            return self.check.run(config);
+        };
+        match command {
+            CliCommand::Setup(cmd) => cmd.run(),
+            CliCommand::Check(cmd) => cmd.run(config),
+            CliCommand::TestSetup(cmd) => cmd.run(config),
+        }
     }
-
-    let mut virtual_manifest = "[workspace.metadata.marker.lints]\n".to_string();
-    for dep in &args.lints {
-        virtual_manifest.push_str(dep);
-        virtual_manifest.push('\n');
-    }
-
-    let path = Utf8Path::new(".");
-
-    let Config { lints } = Config::try_from_str(&virtual_manifest, path)?.unwrap_or_else(|| {
-        panic!("BUG: the config must definitely contain the marker metadata:\n---\n{virtual_manifest}\n---");
-    });
-    Ok(Some(lints))
 }
 
 #[cfg(test)]
@@ -112,16 +86,16 @@ mod tests {
 
         let cli = MarkerCli::parse_from(["cargo-marker"]);
         assert!(cli.command.is_none());
-        assert!(cli.check_args.cargo_args.is_empty());
+        assert!(cli.check.cargo_args.is_empty());
 
         let cli = MarkerCli::parse_from(["cargo-marker", "--", "ducks", "penguins"]);
         assert!(cli.command.is_none());
-        assert!(cli.check_args.cargo_args.len() == 2);
-        assert!(cli.check_args.cargo_args[0] == "ducks");
-        assert!(cli.check_args.cargo_args[1] == "penguins");
+        assert!(cli.check.cargo_args.len() == 2);
+        assert!(cli.check.cargo_args[0] == "ducks");
+        assert!(cli.check.cargo_args[1] == "penguins");
 
         let cli = MarkerCli::parse_from(["cargo-marker", "check", "--", "ducks", "penguins"]);
-        assert!(cli.check_args.cargo_args.is_empty());
+        assert!(cli.check.cargo_args.is_empty());
         if let Some(CliCommand::Check(check_args)) = cli.command {
             assert!(check_args.cargo_args.len() == 2);
             assert!(check_args.cargo_args[0] == "ducks");

--- a/cargo-marker/src/cli/check.rs
+++ b/cargo-marker/src/cli/check.rs
@@ -1,0 +1,102 @@
+use crate::config::{Config, LintDependency};
+use crate::error::prelude::*;
+use crate::{backend, utils};
+use camino::Utf8Path;
+use clap::Args;
+use std::collections::BTreeMap;
+
+#[derive(Args, Debug)]
+#[command(override_usage = "cargo marker check [OPTIONS] -- <CARGO ARGS>")]
+pub(crate) struct CheckCommand {
+    /// Specifies lint crates which should be used. (Lints in `Cargo.toml` will be ignored)
+    #[arg(short, long)]
+    pub(crate) lints: Vec<String>,
+
+    /// Forward the current `RUSTFLAGS` value during the lint crate compilation
+    #[arg(long)]
+    pub(crate) forward_rust_flags: bool,
+
+    /// Arguments which will be forwarded to Cargo. See `cargo check --help`
+    #[clap(last = true)]
+    pub(crate) cargo_args: Vec<String>,
+}
+
+impl CheckCommand {
+    pub(crate) fn run(self, config: Option<Config>) -> Result {
+        self.compile_lints(config)?.lint()
+    }
+
+    pub(crate) fn compile_lints(self, config: Option<Config>) -> Result<CompiledLints> {
+        // determine lints
+        let lints: BTreeMap<_, _> = self
+            .lints_from_cli()?
+            .or_else(|| config.map(|config| config.lints))
+            .into_iter()
+            .flatten()
+            .map(|(name, dep)| (name, dep.into_dep_entry()))
+            .collect();
+
+        // Validation
+        if lints.is_empty() {
+            return Err(Error::from_kind(ErrorKind::LintsNotFound));
+        }
+
+        // If this is a dev build, we want to rebuild the driver before checking
+        if utils::is_local_driver() {
+            backend::driver::install_driver(false, None)?;
+        }
+
+        // Configure backend
+        let toolchain = backend::toolchain::Toolchain::try_find_toolchain()?;
+        let backend_conf = backend::Config {
+            lints,
+            ..backend::Config::try_base_from(toolchain)?
+        };
+
+        // Prepare backend
+        let info = backend::prepare_check(&backend_conf)?;
+
+        Ok(CompiledLints {
+            backend_conf,
+            info,
+            cargo_args: self.cargo_args,
+        })
+    }
+
+    fn lints_from_cli(&self) -> Result<Option<BTreeMap<String, LintDependency>>> {
+        if self.lints.is_empty() {
+            return Ok(None);
+        }
+
+        let mut virtual_manifest = "[workspace.metadata.marker.lints]\n".to_string();
+        for dep in &self.lints {
+            virtual_manifest.push_str(dep);
+            virtual_manifest.push('\n');
+        }
+
+        let path = Utf8Path::new(".");
+
+        let Config { lints } = Config::try_from_str(&virtual_manifest, path)?.unwrap_or_else(|| {
+            panic!(
+                "BUG: the config must definitely contain the marker metadata:\
+                \n---\n{virtual_manifest}\n---"
+            );
+        });
+
+        Ok(Some(lints))
+    }
+}
+
+/// The result of discovering and compiling the lint libraries
+#[derive(Debug)]
+pub(crate) struct CompiledLints {
+    pub(crate) backend_conf: backend::Config,
+    pub(crate) info: backend::CheckInfo,
+    pub(crate) cargo_args: Vec<String>,
+}
+
+impl CompiledLints {
+    fn lint(self) -> Result {
+        backend::run_check(&self.backend_conf, self.info, &self.cargo_args)
+    }
+}

--- a/cargo-marker/src/cli/setup.rs
+++ b/cargo-marker/src/cli/setup.rs
@@ -1,0 +1,24 @@
+use crate::error::prelude::*;
+use clap::Args;
+
+#[derive(Args, Debug)]
+pub struct SetupCommand {
+    /// Automatically installs the required toolchain using rustup
+    #[arg(long)]
+    pub auto_install_toolchain: bool,
+
+    /// Forward the current `RUSTFLAGS` value during the driver compilation
+    #[arg(long)]
+    pub forward_rust_flags: bool,
+}
+
+impl SetupCommand {
+    pub(crate) fn run(self) -> Result {
+        let rustc_flags = self
+            .forward_rust_flags
+            .then(|| std::env::var("RUSTFLAGS").ok())
+            .flatten();
+
+        crate::backend::driver::install_driver(self.auto_install_toolchain, rustc_flags)
+    }
+}

--- a/cargo-marker/src/cli/test_setup.rs
+++ b/cargo-marker/src/cli/test_setup.rs
@@ -1,0 +1,31 @@
+use super::check::CheckCommand;
+use crate::backend::driver::DriverVersionInfo;
+use crate::config::Config;
+use crate::error::prelude::*;
+use clap::Args;
+
+#[derive(Args, Debug)]
+pub(crate) struct TestSetupCommand {
+    #[clap(flatten)]
+    check: CheckCommand,
+}
+
+impl TestSetupCommand {
+    pub(crate) fn run(self, config: Option<Config>) -> Result {
+        let lints = self.check.compile_lints(config)?;
+
+        for (name, value) in lints.info.env {
+            println!("env:{name}={value}");
+        }
+
+        let info = DriverVersionInfo::try_from_toolchain(
+            &lints.backend_conf.toolchain,
+            &lints.backend_conf.marker_dir.join("Cargo.toml"),
+        )?;
+
+        println!("info:toolchain={}", info.toolchain);
+        println!("info:marker-api={}", info.api_version);
+
+        Ok(())
+    }
+}

--- a/cargo-marker/src/config.rs
+++ b/cargo-marker/src/config.rs
@@ -9,7 +9,7 @@ use crate::error::prelude::*;
 use crate::observability::display;
 use camino::Utf8Path;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 use yansi::Paint;
 
 #[derive(Deserialize, Debug)]
@@ -35,7 +35,7 @@ struct WorkspaceMetadata {
 #[serde(deny_unknown_fields)]
 pub struct Config {
     /// A list of lints.
-    pub lints: HashMap<String, LintDependency>,
+    pub lints: BTreeMap<String, LintDependency>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -57,18 +57,18 @@ impl LintDependency {
         }
     }
 
-    pub fn to_dep_entry(&self) -> LintDependencyEntry {
+    pub fn into_dep_entry(self) -> LintDependencyEntry {
         match self {
             LintDependency::Simple(version) => LintDependencyEntry {
                 source: Source::Registry {
-                    version: version.clone(),
+                    version,
                     registry: None,
                 },
                 package: None,
                 default_features: None,
                 features: None,
             },
-            LintDependency::Full(entry) => entry.clone(),
+            LintDependency::Full(entry) => entry,
         }
     }
 }

--- a/cargo-marker/src/main.rs
+++ b/cargo-marker/src/main.rs
@@ -12,141 +12,18 @@ mod error;
 mod observability;
 mod utils;
 
+use cli::MarkerCli;
 use error::prelude::*;
-use std::{collections::HashMap, ffi::OsString};
-
-use crate::backend::driver::DriverVersionInfo;
-use backend::CheckInfo;
-use cli::{CheckArgs, CliCommand, MarkerCli};
-use config::Config;
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
     observability::init();
 
-    let Err(err) = try_main() else {
+    let Err(err) = MarkerCli::parse_args().run() else {
         return ExitCode::SUCCESS;
     };
 
     err.print();
 
     ExitCode::FAILURE
-}
-
-fn try_main() -> Result {
-    let cli = MarkerCli::parse_args();
-
-    let cargo = backend::cargo::Cargo::default();
-
-    let path = cargo.cargo_locate_project()?;
-    let config = Config::try_from_manifest(&path)?;
-
-    match &cli.command {
-        Some(CliCommand::Setup(args)) => {
-            let rustc_flags = args
-                .forward_rust_flags
-                .then(|| std::env::var("RUSTFLAGS").ok())
-                .flatten();
-
-            backend::driver::install_driver(args.auto_install_toolchain, rustc_flags)
-        },
-        Some(CliCommand::Check(args)) => run_check(args, config, CheckKind::Normal),
-        Some(CliCommand::TestSetup(args)) => run_check(args, config, CheckKind::TestSetup),
-        None => run_check(&cli.check_args, config, CheckKind::Normal),
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-enum CheckKind {
-    Normal,
-    TestSetup,
-}
-
-fn run_check(args: &CheckArgs, config: Option<Config>, kind: CheckKind) -> Result {
-    // determine lints
-    let lints: HashMap<_, _> = cli::collect_lint_deps(args)?
-        .or_else(|| config.map(|config| config.lints))
-        .into_iter()
-        .flatten()
-        .map(|(name, dep)| (name, dep.to_dep_entry()))
-        .collect();
-
-    // Validation
-    if lints.is_empty() {
-        return Err(Error::from_kind(ErrorKind::LintsNotFound));
-    }
-
-    // If this is a dev build, we want to rebuild the driver before checking
-    if utils::is_local_driver() {
-        backend::driver::install_driver(false, None)?;
-    }
-
-    // Configure backend
-    let toolchain = backend::toolchain::Toolchain::try_find_toolchain()?;
-    let backend_conf = backend::Config {
-        lints,
-        ..backend::Config::try_base_from(toolchain)?
-    };
-
-    // Prepare backend
-    let info = backend::prepare_check(&backend_conf)?;
-
-    // Run backend
-    match kind {
-        CheckKind::Normal => backend::run_check(&backend_conf, info, &args.cargo_args),
-        CheckKind::TestSetup => print_test_info(&backend_conf, &info),
-    }
-}
-
-fn print_test_info(config: &backend::Config, check: &CheckInfo) -> Result {
-    print_env(&check.env).unwrap();
-
-    let info = DriverVersionInfo::try_from_toolchain(&config.toolchain, &config.marker_dir.join("Cargo.toml"))?;
-    println!("info:toolchain={}", info.toolchain);
-    println!("info:marker-api={}", info.api_version);
-
-    Ok(())
-}
-
-#[allow(clippy::unnecessary_wraps)]
-fn print_env(env: &[(&'static str, OsString)]) -> std::io::Result<()> {
-    // Operating systems are fun... So, this function prints out the environment
-    // values to the standard output. For Unix systems, this requires `OsStr`
-    // objects, as file names are just bytes and don't need to be valid UTF-8.
-    // Windows, on the other hand, restricts file names, but uses UTF-16. The
-    // restriction only makes it slightly better, since windows `OsString` version
-    // doesn't have a `bytes()` method. Rust additionally has a restriction on the
-    // stdout of windows, that it has to be valid UTF-8, which means more conversion.
-    //
-    // This would be so much easier if everyone followed the "UTF-8 Everywhere Manifesto"
-
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
-    {
-        use std::io::Write;
-        use std::os::unix::prelude::OsStrExt;
-
-        // stdout is used directly, to print the `OsString`s without requiring
-        // them to be valid UTF-8
-        let mut lock = std::io::stdout().lock();
-        for (name, value) in env {
-            write!(lock, "env:")?;
-            lock.write_all(name.as_bytes())?;
-            write!(lock, "=")?;
-            lock.write_all(value.as_bytes())?;
-            writeln!(lock)?;
-        }
-    }
-
-    #[cfg(target_os = "windows")]
-    {
-        for (name, value) in env {
-            if let Some(value) = value.to_str() {
-                println!("env:{name}={value}");
-            } else {
-                unreachable!("Windows requires it's file path to be valid UTF-16 AFAIK");
-            }
-        }
-    }
-
-    Ok(())
 }


### PR DESCRIPTION
Every CLI command now lives in a separate module. This helps with readability because code is now categorized via module files. Previously it was hard to read it because everything was in one file.

Replaced some leftover `OsString` handling with just `String`.

Replaced `HashMap` with `BTreeMap` in several places to have stable sorting. Meaning, for example, if you run `cargo marker` several times lint crates will be compiled in the same order (instead of a random one). See also this [doc](https://elastio.notion.site/Prefer-BTreeMap-Set-6042af3bc69041348c07170722b45bd1?pvs=4) for additional reasoning.

Changed some `pub` types to `pub(crate)` since this is a binary crate nothing should actually be `pub` here.