### PR TITLE
Add windows installation script

### DIFF
--- a/scripts/release/install.ps1
+++ b/scripts/release/install.ps1
@@ -1,0 +1,165 @@
+# This script downloads the `cargo-marker` and the `marker_rustc_driver`
+# binaries from the GitHub release assets. It also sets up the required
+# Rust toolchain that the `marker_rustc_driver` depends on.
+#
+# This script must be self-contained! Nothing here should use anything from
+# the marker repository, because users are expected to run this script on
+# their machines where they don't have the marker repository cloned.
+#
+# It's possible to run this script on Linux if you have PowerShell installed there.
+# An important caveat is that you'll likely install the latest PowerShell 7.0 on linux,
+# but on real Windows 10/11 the version of PowerShell is quite old (5.1), so don't
+# try to use any new features.
+
+$ErrorActionPreference = "Stop"
+
+# This script isn't meant to be run from `master`, but if it is, then
+# it will install the latest version be it a stable version or a pre-release.
+# region replace-version unstable
+$version = "0.2.1"
+# endregion replace-version unstable
+
+$toolchain = "nightly-2023-08-24"
+
+function With-Log {
+    Write-Output "> $($args -join ' ')"
+
+    $cmd = $args[0]
+    $rest = $args[1..$args.Length]
+
+    & $cmd @rest
+}
+
+function Extract-TarGz {
+    param (
+        [string]$bin,
+        [string]$dest
+    )
+    $file_stem = "${bin}-${host_triple}"
+
+    With-Log cd $temp_dir
+
+    Check-Sha256Sum $file_stem "tar.gz"
+
+    With-Log tar --extract --file (Join-Path $temp_dir "$file_stem.tar.gz") --directory $dest
+}
+
+# There isn't mktemp on Windows, so we have to reinvent the wheel.
+function New-TemporaryDirectory {
+    $parent = [System.IO.Path]::GetTempPath()
+    [string] $name = [System.Guid]::NewGuid()
+    New-Item -ItemType Directory -Path (Join-Path $parent $name)
+}
+
+# There isn't sha256sum on Windows, so we have to reinvent the wheel.
+function Check-Sha256Sum {
+    param (
+        [string]$file_stem,
+        [string]$extension
+    )
+
+    $file = "$file_stem.$extension"
+
+    $actual = Get-FileHash -Algorithm SHA256 -Path $file
+    $expected = Get-Content "$file_stem.sha256"
+
+    foreach ($line in $expected) {
+        $line -match '(\S+)\s*\*?(.*)'
+        $expected_hash = $Matches[1]
+        $expected_file = $Matches[2]
+
+        if ($expected_file -ne $file) {
+            continue
+        }
+
+        if ($actual.Hash -eq $expected_hash) {
+            Write-Output "${file}: OK"
+            return
+        }
+
+        throw "Checksum verification failed for $file. Expected: $expected_hash, actual: $actual"
+    }
+
+    throw "No checksum found for $file"
+}
+
+# This script can run on unix too if you have PowerShell installed there.
+# The only difference is that on Windows's old PowerShell 5 there is an alias
+# `curl` for `Invoke-WebRequest`, and if you want to use the real curl, then
+# you have to use `curl.exe`. That's a really perplexing design decision. Why
+# would you alias `Invoke-WebRequest` to `curl` when it's not a real drop-in
+# replacement for curl? Anyway.. PowerShell 7 removed that alias.
+# More details here: https://stackoverflow.com/a/75867014
+#
+# Btw. this condition is written specically so that it can run on PowerShell 5,
+# In PowerShell 7 there are automatic variables `$IsWindows`, `$IsMacOS`, `$IsLinux`.
+$exe = if ([System.Environment]::OSVersion.Platform -eq "Win32NT") {
+    ".exe"
+} else {
+    ""
+}
+
+With-Log rustup install --profile minimal --no-self-update $toolchain
+
+$host_triple = (
+    rustc +$toolchain --version --verbose `
+    | Select-String -Pattern "host: (.*)" `
+    | ForEach-Object { $_.Matches.Groups[1].Value }
+)
+
+$current_dir = (Get-Location).Path
+$temp_dir = New-TemporaryDirectory
+
+try {
+    $files = "{cargo-marker,marker_rustc_driver}-$host_triple.{tar.gz,sha256}"
+
+    # Curl is available by default on windows, yay!
+    # https://curl.se/windows/microsoft.html
+    #
+    # Download all files using a single TCP connection with HTTP2 multiplexing
+    With-Log curl$exe `
+        --location `
+        --silent `
+        --fail `
+        --show-error `
+        --retry 5 `
+        --retry-connrefused `
+        --remote-name `
+        --output-dir $temp_dir `
+        "https://github.com/rust-marker/marker/releases/download/v$version/$files"
+
+    # There is a null coalescing operator in PowerShell 7, but that version
+    # is too cutting edge for now.
+    $cargo_home = if ($env:CARGO_HOME) {
+        $env:CARGO_HOME
+    } else {
+        Join-Path $HOME ".cargo"
+    }
+
+    Extract-TarGz "cargo-marker" (Join-Path $cargo_home "bin")
+
+    $sysroot = (rustc +$toolchain --print sysroot)
+    Extract-TarGz "marker_rustc_driver" (Join-Path $sysroot "bin")
+} finally {
+    Write-Output "Removing the temp directory $temp_dir"
+
+    # Go back to the original directory before removing the temp directory
+    # otherwise it will fail because the temporary directory is in use.
+    cd $current_dir
+
+    Remove-Item -Force -Recurse $temp_dir
+}
+
+# You, my friend will be surprised. But the workability of this entire
+# script depends on the presence of this comment. I'm not joking. If you remove
+# this comment the script won't work. The try block higher won't be executed.
+# That's the stupidest thing I've ever seen in my life, really.
+#
+# The reason is that if you pipe this script to a PowerShell interpreter, then
+# that interpreter will not execute a multiline expression (which try block is)
+# unless that expression is followed by two blank lines.
+#
+# You can test this with `Get-Content .\scripts\release\install.ps1 | powershell -command -`
+#
+# That's crazy, but this bug has been not fixed since 2017 when it was reported:
+# https://github.com/PowerShell/PowerShell/issues/3223

--- a/scripts/release/install.ps1
+++ b/scripts/release/install.ps1
@@ -10,6 +10,10 @@
 # An important caveat is that you'll likely install the latest PowerShell 7.0 on linux,
 # but on real Windows 10/11 the version of PowerShell is quite old (5.1), so don't
 # try to use any new features.
+#
+# This script is specifically for windows, but has a similar structure to the
+# unix `install.sh` script. If you modify this script, please check if the modifications
+# should also apply to the unix one.
 
 $ErrorActionPreference = "Stop"
 

--- a/scripts/release/install.sh
+++ b/scripts/release/install.sh
@@ -66,6 +66,6 @@ function extract_archive {
     with_log tar --extract --file "$temp_dir/$file_stem.tar.gz" --directory "$dest"
 }
 
-extract_archive cargo-marker "${CARGO_HOME-$HOME/.cargo/bin}"
+extract_archive cargo-marker "${CARGO_HOME-$HOME/.cargo}/bin"
 
 extract_archive marker_rustc_driver "$(rustc +$toolchain --print sysroot)/bin"

--- a/scripts/release/install.sh
+++ b/scripts/release/install.sh
@@ -6,6 +6,10 @@
 # This script must be self-contained! Nothing here should use anything from
 # the marker repository, because users are expected to run this script on
 # their machines where they don't have the marker repository cloned.
+#
+# This script is specifically for unix, but has a similar structure to the
+# windows `install.ps1` script. If you modify this script, please check if the modifications
+# should also apply to the windows one.
 
 set -Eeuo pipefail
 

--- a/scripts/release/set-version.sh
+++ b/scripts/release/set-version.sh
@@ -48,6 +48,7 @@ files=($(\
         -o -name "*.md" \
         -o -name "*.toml" \
         -o -name "*.sh" \
+        -o -name "*.ps1" \
         \)\
 ))
 

--- a/scripts/release/snapshot.diff
+++ b/scripts/release/snapshot.diff
@@ -135,6 +135,12 @@
 +marker_lints = "0.1.0"
  ```
 
+=== scripts/release/install.ps1 ===
+ # region replace-version unstable
+-$version = "<version>"
++$version = "0.1.0"
+ # endregion replace-version unstable
+
 === scripts/release/install.sh ===
  # region replace-version unstable
 -version=<version>

--- a/scripts/update-toolchain.sh
+++ b/scripts/update-toolchain.sh
@@ -14,4 +14,5 @@ sed -i "s/nightly-2023-08-24/$1/g" \
     ./scripts/update-toolchain.sh \
     ./cargo-marker/src/backend/driver.rs \
     ./cargo-marker/README.md \
-    ./install.sh
+    ./scripts/release/install.sh \
+    ./scripts/release/install.ps1


### PR DESCRIPTION
ChatGPT rules.However of course it made a ton of mistakes converting bash to powershell, and I of course I had to stare at powershell syntax with their poor error messages for some time. But, anyway, it's past that and the script works.

You can test it using a separate branch where I configured it to work with my fork.

```ps1
curl.exe --location --silent --fail --show-error --retry 5 --retry-connrefused `
    https://raw.githubusercontent.com/Veetaha/marker/feat/install-on-windows-test/scripts/release/install.ps1 | powershell -command -
```

This was inspired by the installation script in [deno](https://github.com/denoland/deno). Turns out both `curl.exe` and `tar.exe` are [available on windows by default](https://learn.microsoft.com/en-us/virtualization/community/team-blog/2017/20171219-tar-and-curl-come-to-windows), and deno also uses them for its installation script.

There are some stupid caveats with using unicode symbols (I'm not even saying ansi colors) on windows. I didn't look into that, and just made the script monochrome and use `>` character for logging the executed commands.

---

I didn't update the docs here. I think I'll just make separate PR for that whicj will also include the commit with the docs for linux

---


Also fixed the behavior of `install.sh` when the `$CARGO_HOME` variable is set. Previously it was writing directly to it, but instead it has to write to a `$CARGO_HOME/bin` subdirectory.