### PR TITLE
Add docs about installing the precompiled binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,30 @@ The following is an abbreviated guide. Check out [The Marker Book] for detailed 
 
 ### Installation
 
+#### Download pre-compiled binaries (recommended)
+
+We provide pre-compiled binaries for the mainstream platforms. See the list of available artifacts in our [Github Releases](https://github.com/rust-marker/marker/releases/latest).
+
+Select one of the installation scripts below according to your platform. The script will install the required Rust toolchain dependency on your machine, download the current version of `cargo-marker` CLI, and the internal driver.
+
+<!-- region replace-version stable -->
+
+**Linux or MacOS (Bash)**:
+```bash
+curl -fsSL https://raw.githubusercontent.com/rust-marker/marker/v0.2.1/scripts/release/install.sh | bash
+```
+
+**Windows (PowerShell)**:
+```ps1
+curl.exe -fsSL https://raw.githubusercontent.com/rust-marker/marker/v0.2.1/scripts/release/install.ps1 | powershell -command -
+```
+
+<!-- endregion replace-version stable -->
+
+The provided scripts are pinned to a specific version of `marker` to avoid sudden breakages especially if this script will be used on CI.
+
+If you are a windows user or your platform isn't supported yet by the pre-compiled binaries, then you should fall back to building from sources as described below.
+
 #### Build from sources
 
 ```sh

--- a/docs/book/src/usage/installation.md
+++ b/docs/book/src/usage/installation.md
@@ -11,6 +11,30 @@ The marker sub-command is provided by the *cargo_marker* crate. This crate requi
 [Cargo]: https://github.com/rust-lang/cargo/
 [rustup]: https://github.com/rust-lang/rustup/
 
+## Download pre-compiled binaries (recommended)
+
+We provide pre-compiled binaries for the mainstream platforms. See the list of available artifacts in our [Github Releases](https://github.com/rust-marker/marker/releases/latest).
+
+Select one of the installation scripts below according to your platform. The script will install the required Rust toolchain dependency on your machine, download the current version of `cargo-marker` CLI, and the internal driver.
+
+<!-- region replace-version stable -->
+
+**Linux or MacOS (Bash)**:
+```bash
+curl -fsSL https://raw.githubusercontent.com/rust-marker/marker/v0.2.1/scripts/release/install.sh | bash
+```
+
+**Windows (PowerShell)**:
+```ps1
+curl.exe -fsSL https://raw.githubusercontent.com/rust-marker/marker/v0.2.1/scripts/release/install.ps1 | powershell -command -
+```
+
+<!-- endregion replace-version stable -->
+
+The provided scripts are pinned to a specific version of `marker` to avoid sudden breakages especially if this script will be used on CI.
+
+If you are a windows user or your platform isn't supported yet by the pre-compiled binaries, then you should fall back to building from sources as described below.
+
 ## Build `cargo marker` plugin from sources
 
 Marker provides a new Cargo sub-command, that handles the driver installation, lint crate compilation, and checking process for you. To install it, simply use:

--- a/scripts/release/snapshot.diff
+++ b/scripts/release/snapshot.diff
@@ -61,6 +61,14 @@
  # endregion replace-version dev
 
 === README.md ===
+ ```bash
+-curl -fsSL https://raw.githubusercontent.com/rust-marker/marker/v<version>/scripts/release/install.sh | bash
++curl -fsSL https://raw.githubusercontent.com/rust-marker/marker/v0.1.0/scripts/release/install.sh | bash
+ ```
+ ```ps1
+-curl.exe -fsSL https://raw.githubusercontent.com/rust-marker/marker/v<version>/scripts/release/install.ps1 | powershell -command -
++curl.exe -fsSL https://raw.githubusercontent.com/rust-marker/marker/v0.1.0/scripts/release/install.ps1 | powershell -command -
+ ```
  # An external crate from a registry
 -marker_lints = "<version>"
 +marker_lints = "0.1.0"
@@ -88,6 +96,16 @@
 -        cli_example = display::cli(r#"cargo marker --lints "marker_lints = '<version>'""#),
 +        cli_example = display::cli(r#"cargo marker --lints "marker_lints = '0.1.0'""#),
          lints = "--lints".blue(),
+
+=== docs/book/src/usage/installation.md ===
+ ```bash
+-curl -fsSL https://raw.githubusercontent.com/rust-marker/marker/v<version>/scripts/release/install.sh | bash
++curl -fsSL https://raw.githubusercontent.com/rust-marker/marker/v0.1.0/scripts/release/install.sh | bash
+ ```
+ ```ps1
+-curl.exe -fsSL https://raw.githubusercontent.com/rust-marker/marker/v<version>/scripts/release/install.ps1 | powershell -command -
++curl.exe -fsSL https://raw.githubusercontent.com/rust-marker/marker/v0.1.0/scripts/release/install.ps1 | powershell -command -
+ ```
 
 === docs/book/src/usage/lint-crate-declaration.md ===
  # An external crate from a registry


### PR DESCRIPTION
I decided to reduce the `curl` line with the short option names and removed `--retry 5 --retry-connrefused` because there are no short options for those. This makes the installation script a pure one-liner.