### PR TITLE
Add a github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,3 +164,39 @@ jobs:
           --baseline-root './upstream'
           --default-features
           --release-type minor
+
+  # Check that the Github Action works
+  github-action-test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        # Make sure we cover all operating systems supported by Github Actions
+        os:
+          - windows-2019
+          - windows-2022
+          - ubuntu-20.04
+          - ubuntu-22.04
+          - macos-13
+          - macos-12
+          - macos-11
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # This action downloads the latest released version of `cargo-marker`,
+      # and installs it into `$PATH`.
+      #
+      # Because `marker_lints` in this repo depends on the next dev version of
+      # `marker_api` it won't be compatible with the latest released `marker_api`,
+      # so there is no sense in actually running `cargo marker check` here.
+      # Therefore we set `install-only` to skip running a command.
+      #
+      # At least this checks that our installation script works as expected.
+      - uses: ./
+        with:
+          install-only: true
+
+      # +stable is to force using the pre-installed `cargo` on the runner instead of
+      # what's specified in `rust-toolchain.toml`
+      - run: cargo +stable marker --version

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -3,9 +3,12 @@
 # See the docs/internal/release.md for more details.
 
 name: release-on-tag
+run-name: release-on-tag (${{ github.ref_name }})
 on:
   push:
-    tags: ['v*']
+    # Match only on specific tags. We don't want this workflow to be invoked when
+    # we put sliding `v{major}` and `v{major}.{minor}` tags on the same commit.
+    tags: ['v[0-9]+.[0-9]+.[0-9]+*']
 
 defaults:
   run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
         run: echo "release_version=$(scripts/release/get-version-from-changelog.sh)" >> $GITHUB_ENV
       - name: Resolve the next dev version
         run: echo "next_dev_version=$(scripts/release/get-next-dev-version.sh ${{ env.release_version }})" >> $GITHUB_ENV
+      - name: Resolve the git tags
+        run: echo "tags=$(scripts/release/get-git-tags.sh ${{ env.release_version }})" >> $GITHUB_ENV
+
 
       # To be able to create a commit we need some committer identity.
       - run: |
@@ -42,11 +45,21 @@ jobs:
       - run: scripts/release/set-version.sh ${{ env.release_version }}
           --commit "🚀 Release v${{ env.release_version }}"
 
-      - run: git tag v${{ env.release_version }}
+      - run: |
+          for tag in ${{ env.tags }}; do
+            git tag $tag
+          done
 
       # Create a next dev version commit
       - run: scripts/release/set-version.sh ${{ env.next_dev_version }}
           --commit "🚧 Development v${{ env.next_dev_version }}"
 
-      # Push the branch and the new tag to the remote
-      - run: git push --atomic origin ${{ github.ref_name }} v${{ env.release_version }}
+      # Push the changes to the remote
+      - run: git push origin ${{ github.ref_name }}
+
+      # We use `--force` because the tags that are pushed here will include the
+      # sliding `v{major}` and `v{major}.{minor}` tags, so we have to overwrite
+      # them with the new ones. To prevent force-pushing the master branch we
+      # do this push with --force in a separate step, so it's not fully atomic,
+      # but it's good enough.
+      - run: git push --force --atomic origin ${{ env.tags }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ See the [v0.3.0 milestone] for a full list of all changes.
 [#245]: https://github.com/rust-marker/marker/pull/245
 [#252]: https://github.com/rust-marker/marker/pull/252
 [#256]: https://github.com/rust-marker/marker/pull/256
+[#259]: https://github.com/rust-marker/marker/pull/259
 [#263]: https://github.com/rust-marker/marker/pull/263
 [#265]: https://github.com/rust-marker/marker/pull/265
 
@@ -43,6 +44,7 @@ See the [v0.3.0 milestone] for a full list of all changes.
 - [#232]: Add scope config for visitors and `for_each_expr` to `marker_utils`
 - [#239]: GitHub releases now provide precompiled binaries of `cargo-marker` and `marker_rustc_driver`.
 - [#252]: Marker now provides install scripts for linux, macos and windows
+- [#259]: Introduced a GitHub Action for installing and running Marker
 
 ### Breaking Changes
 - [#256]: Renamed `AstContext` -> `MarkerContext`

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,28 @@
+name: Rust Marker Linter
+description: GitHub Action to install and run the Marker linter for Rust 🦀
+branding:
+  icon: edit-3
+  color: white
+
+inputs:
+  install-only:
+    description: >
+      If set to `true` then the action will only install `cargo marker`,
+      and will skip running `cargo marker`. Use this if you want to run
+      something more complex than just `cargo marker`. If you think there
+      may be a frequent use case for running a different command then we will be
+      glad if you open a feature request issue for that to extend the action input
+      parameters.
+
+    default: 'false'
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - run: ${GITHUB_ACTION_PATH:?}/scripts/release/install.${{ runner.os == 'Windows' && 'ps1' || 'sh' }}
+      shell: bash
+
+    - run: cargo marker
+      if: ${{ inputs.install-only == 'false' }}
+      shell: bash

--- a/scripts/release/get-git-tags.sh
+++ b/scripts/release/get-git-tags.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+version="$1"
+
+IFS='.' read -r major minor patch <<< "$version"
+
+# We always put the full version tag even if this is a pre-release
+echo -n "v$version"
+
+# For suffixless stable release versions we also want to set the
+# sliding `v{major}` and `v{major}.{minor}` tags so that uses could
+# depend on `rust-marker/marker@v0.3` or `rust-marker/marker@v1`
+# version of the Github Action.
+if [[ "$version" != *-* ]]; then
+    echo -n " v$major v$major.$minor"
+fi

--- a/scripts/release/install.ps1
+++ b/scripts/release/install.ps1
@@ -1,3 +1,5 @@
+#!/usr/bin/env pwsh
+#
 # This script downloads the `cargo-marker` and the `marker_rustc_driver`
 # binaries from the GitHub release assets. It also sets up the required
 # Rust toolchain that the `marker_rustc_driver` depends on.
@@ -14,6 +16,30 @@
 # This script is specifically for windows, but has a similar structure to the
 # unix `install.sh` script. If you modify this script, please check if the modifications
 # should also apply to the unix one.
+#
+# General PowerShell notes:
+#
+# Since we have $ErrorActionPreference = "Stop" the script will stop at any `Write-Error`.
+# Yeah, writing an error log counts as an error. Who could expect that? Regardless of how
+# unintuitive it is we use `Write-Error` instead of `throw` because the error that is generated
+# this way is more readable, because it refers to the call site of the function where the error
+# was written and not to the `throw` statement itself in the code snippet that is output.
+#
+# Example error output with `throw` shows the `throw` statement itself, not the call site:
+# ```
+# Line |
+#   74 |          throw "Command $cmd failed with exit code $LASTEXITCODE"
+#      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#      | Command curl failed with exit code 22
+# ```
+# Example error output with `Write-Error` shows the call site of the function which is more useful:
+# ```
+# Line |
+#  174 |      Step curl$exe `
+#      |      ~~~~~~~~~~~~~~~
+#      | Command curl failed with exit code 22
+# ```
+
 
 $ErrorActionPreference = "Stop"
 
@@ -25,34 +51,68 @@ $version = "0.2.1"
 
 $toolchain = "nightly-2023-08-24"
 
-function With-Log {
-    Write-Output "> $($args -join ' ')"
-
+# Log the command, execute, and fail if its exit code is non-zero.
+# Surprisingly PowerShell can't do the exit code checks for us out of the box.
+function Step {
     $cmd = $args[0]
     $rest = $args[1..$args.Length]
 
+    # ASCII escape symbol
+    $e = [char]0x1b
+
+    # This is the unicode code of the symbol ❱.
+    # Yeah, this is how you do unicode in PowerShell, yay -_-
+    $run_symbol = [char]0x2771
+
+    Write-Host "$e[32;1m$run_symbol $e[1;33m$cmd$e[0m $($rest -join ' ')"
+
     & $cmd @rest
+
+    # Turns out `ErrorActionPreference` doesn't affect the behavior of external
+    # processes. So if any process returns a non-zero exit code PowerShell will
+    # still ignore this. Yeah.. Life is cruel, but at least PowerShell has
+    # an experimental feature to fix this: `PSNativeCommandErrorActionPreference`.
+    # Anyway, since we have to support pre-historic PowerShell, we'll do our own
+    # error handling.
+    if ($? -eq $false) {
+        Write-Error "Command $cmd failed with exit code $LASTEXITCODE"
+    }
 }
 
-function Extract-TarGz {
+function Unzip {
     param (
         [string]$bin,
         [string]$dest
     )
     $file_stem = "${bin}-${host_triple}"
 
-    With-Log cd $temp_dir
+    # We have to enter and exit from the temp dir because the destination path may be
+    # relative, and we don't want that path to be relative to the temp dir.
+    Step Push-Location $temp_dir
+    Step Check-Sha256Sum $file_stem "zip"
+    Step Pop-Location
 
-    Check-Sha256Sum $file_stem "tar.gz"
-
-    With-Log tar --extract --file (Join-Path $temp_dir "$file_stem.tar.gz") --directory $dest
+    # There is `tar` on Windows installed by default, but it looks like different
+    # environments have extremely different variations of tar installed.
+    #
+    # For example, my home laptop with Windows 11 has `bsdtar 3.5.2` installed.
+    # It works fine with Windows paths out of the box. However, Windows Github Actions
+    # runner has `tar (GNU tar) 1.34`, which somehow doesn't work with Windows paths.
+    # It just doesn't eat a path with a drive letter and says "No such file or directory".
+    #
+    # Anyway, there is so much inconsistency between home Windows and Github Actions, that
+    # it's just easier to use the PowerShell builtin utility that has always been there.
+    Step Expand-Archive `
+        -Force `
+        -LiteralPath (Join-Path $temp_dir "$file_stem.zip") `
+        -DestinationPath $dest
 }
 
 # There isn't mktemp on Windows, so we have to reinvent the wheel.
 function New-TemporaryDirectory {
     $parent = [System.IO.Path]::GetTempPath()
     [string] $name = [System.Guid]::NewGuid()
-    New-Item -ItemType Directory -Path (Join-Path $parent $name)
+    Step New-Item -ItemType Directory -Path (Join-Path $parent $name)
 }
 
 # There isn't sha256sum on Windows, so we have to reinvent the wheel.
@@ -68,7 +128,8 @@ function Check-Sha256Sum {
     $expected = Get-Content "$file_stem.sha256"
 
     foreach ($line in $expected) {
-        $line -match '(\S+)\s*\*?(.*)'
+        # Silence the output from the match, otherwise it prints `True` or `False`
+        $null = $line -match '(\S+)\s*\*?(.*)'
         $expected_hash = $Matches[1]
         $expected_file = $Matches[2]
 
@@ -81,11 +142,14 @@ function Check-Sha256Sum {
             return
         }
 
-        throw "Checksum verification failed for $file. Expected: $expected_hash, actual: $actual"
+
+        Write-Error "Checksum verification failed for $file. Expected: $expected_hash, actual: $actual"
     }
 
-    throw "No checksum found for $file"
+    Write-Error "No checksum found for $file"
 }
+
+Write-Output "PowerShell version: $($PSVersionTable.PSVersion)"
 
 # This script can run on unix too if you have PowerShell installed there.
 # The only difference is that on Windows's old PowerShell 5 there is an alias
@@ -103,7 +167,9 @@ $exe = if ([System.Environment]::OSVersion.Platform -eq "Win32NT") {
     ""
 }
 
-With-Log rustup install --profile minimal --no-self-update $toolchain
+Step curl$exe --version
+
+Step rustup install --profile minimal --no-self-update $toolchain
 
 $host_triple = (
     rustc +$toolchain --version --verbose `
@@ -115,13 +181,13 @@ $current_dir = (Get-Location).Path
 $temp_dir = New-TemporaryDirectory
 
 try {
-    $files = "{cargo-marker,marker_rustc_driver}-$host_triple.{tar.gz,sha256}"
+    $files = "{cargo-marker,marker_rustc_driver}-$host_triple.{zip,sha256}"
 
     # Curl is available by default on windows, yay!
     # https://curl.se/windows/microsoft.html
     #
     # Download all files using a single TCP connection with HTTP2 multiplexing
-    With-Log curl$exe `
+    Step curl$exe `
         --location `
         --silent `
         --fail `
@@ -140,18 +206,20 @@ try {
         Join-Path $HOME ".cargo"
     }
 
-    Extract-TarGz "cargo-marker" (Join-Path $cargo_home "bin")
+    Unzip "cargo-marker" (Join-Path $cargo_home "bin")
 
     $sysroot = (rustc +$toolchain --print sysroot)
-    Extract-TarGz "marker_rustc_driver" (Join-Path $sysroot "bin")
-} finally {
-    Write-Output "Removing the temp directory $temp_dir"
+    Unzip "marker_rustc_driver" (Join-Path $sysroot "bin")
 
+    # We use `+$toolchain` to make sure we don't try to install the default toolchain
+    # in the workspace via the rustup proxy, but use the toolchain we just installed.
+    Step cargo +$toolchain marker --version
+} finally {
     # Go back to the original directory before removing the temp directory
     # otherwise it will fail because the temporary directory is in use.
     cd $current_dir
 
-    Remove-Item -Force -Recurse $temp_dir
+    Step Remove-Item -Force -Recurse $temp_dir
 }
 
 # You, my friend will be surprised. But the workability of this entire

--- a/scripts/release/install.sh
+++ b/scripts/release/install.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # This script downloads the `cargo-marker` and the `marker_rustc_driver`
 # binaries from the GitHub release assets. It also sets up the required
 # Rust toolchain that the `marker_rustc_driver` depends on.
@@ -21,16 +22,28 @@ version=0.2.1
 
 toolchain=nightly-2023-08-24
 
-function with_log {
-    echo -e "\033[32;1m❱\033[0m $@" >&2
-    "$@"
+function step {
+    local cmd="$1"
+    shift
+    echo -e "\033[32;1m❱ \033[1;33m$cmd\033[0m $@" >&2
+    $cmd "$@"
 }
 
-with_log rustup install --profile minimal --no-self-update $toolchain
+echo "Bash version: $BASH_VERSION" >&2
 
+step curl --version
+step grep --version
+step tar --version
+
+step rustup install --profile minimal --no-self-update $toolchain
+
+# MacOS uses some shitty BSD grep by default, and there isn't support for
+# `--perl-regexp` option there, so we have to go without using that.
+# Example of such envs are `macos-11` and `macos-12` Github Actions runners.
 host_triple=$(\
-    rustc +$toolchain --version --verbose \
-    | grep --only-matching --perl-regexp 'host: \K.*' \
+    rustc "+$toolchain" --version --verbose \
+    | grep --only-matching 'host: .*' \
+    | grep --only-matching '[^ ]*$'
 )
 
 trap cleanup SIGINT SIGTERM ERR EXIT
@@ -41,13 +54,17 @@ function cleanup {
     # Unset the trap to prevent an infinite loop
     trap - SIGINT SIGTERM ERR EXIT
 
-    with_log rm -rf "$temp_dir"
+    step rm -rf "$temp_dir"
 }
 
 files="{cargo-marker,marker_rustc_driver}-$host_triple.{tar.gz,sha256}"
 
 # Download all files using a single TCP connection with HTTP2 multiplexing
-with_log curl \
+# Unfortunately, `curl 7.68.0` installed on Ubuntu 20.04 Github Actions runner
+# doesn't have the `--output-dir` option (it was added in `7.73.0`), so we have
+# to do an explicit `pushd/popd` for the temp directory.
+step pushd "$temp_dir"
+step curl \
     --location \
     --silent \
     --fail \
@@ -55,21 +72,31 @@ with_log curl \
     --retry 5 \
     --retry-connrefused \
     --remote-name \
-    --output-dir "$temp_dir" \
     "https://github.com/rust-marker/marker/releases/download/v$version/$files"
+step popd
 
 function extract_archive {
     local bin="$1"
     local dest="$2"
     local file_stem="$bin-$host_triple"
 
+    # We have to enter and exit from the temp dir because the destination path may be
+    # relative, and we don't want that path to be relative to the temp dir.
+    #
+    # Another thing:
     # `--ignore-missing` because the `sha256` file also includes the checksum for `zip` archive,
     # but we only download the `tar.gz` one.
-    (with_log cd $temp_dir && with_log sha256sum --ignore-missing --check "$file_stem".sha256)
+    #
+    # On MacOS there isn't `sha256sum` command, but there is `shasum` which is compatible.
+    (step cd $temp_dir && step shasum --ignore-missing --check "$file_stem".sha256)
 
-    with_log tar --extract --file "$temp_dir/$file_stem.tar.gz" --directory "$dest"
+    step tar --extract --file "$temp_dir/$file_stem.tar.gz" --directory "$dest"
 }
 
 extract_archive cargo-marker "${CARGO_HOME-$HOME/.cargo}/bin"
 
-extract_archive marker_rustc_driver "$(rustc +$toolchain --print sysroot)/bin"
+extract_archive marker_rustc_driver "$(rustc "+$toolchain" --print sysroot)/bin"
+
+# We use `+$toolchain` to make sure we don't try to install the default toolchain
+# in the workspace via the rustup proxy, but use the toolchain we just installed.
+step cargo "+$toolchain" marker --version


### PR DESCRIPTION
Added a github action template that will allow anyone to include `marker` into their CI using the following code:

```yaml
- uses: rust-marker/marker@v0.3
```

This PR encompasses several important changes.

## New `action.yml` template

This is a dead simple composite github action template file that just runs a couple of bash lines. It is cross-platform, meaning the same syntax may be used for both `windows` and `unix`. The action handles the selection of the bash or powershell script internally.

It runs `cargo marker` command by default. That can be disabled with `install-only` option if there is some more elaborate use case than this. The action is pretty conservative in its API, as it exposes just this single input parameter for now. I believe in the future its API may grow. For example, it we may have `lints` input variable that would use toml-syntax to pass that as `--lints` input parameter. But I'm not sure that is actually needed. I believe that will be a really rare use case. 99% of the time simple `cargo marker` will suffice. We'll hear from anyone who uses the action if they want more builtin configurablity for the run command, otherwise if they are stuck they may use this syntax:
```yaml
- uses: rust-marker@v0.3
  with: { install-only: true }
- run: cargo marker --any-command-you-want
```

The action will install the version of marker specified in the git tag it was referenced with. To make the syntax higher work I had to amend the releases flow to support the sliding `v{major}` and `v{major}.{minor}` tags. 

## New sliding `v{major}` and `v{major}.{minor}` tags.

I updated the `release.md` documentation about this.

## A bunch of improvements and most importantly compatibility fixes in the installation scripts

I knew the installation scripts will break on Github Actions, because I didn't test them there. I only tested them on my home Ubuntu and Windows environments. So no wonder they broke when I ran them as part of the Github Action on CI on various OSes that Github Actions support today.

I also improved logging output of both scripts. They now have a consistent logging style for both bash and powershell. You can see example output on [CI in my fork](https://github.com/Veetaha/marker/actions/runs/6329481150/job/17189845125?pr=9) where I tested the Github Action.
![image](https://github.com/rust-marker/marker/assets/36276403/f123fab0-c6a7-4168-8b64-7cf6fe21ad15)


## New CI tests for the Github Action

I extended the current CI with tests for the Github Action. With the new `github-action-test` CI job we test both the Github Action and the installation scripts.

Right now these jobs fail on `rust-marker` CI and they will be red until `0.3` is officially released and we have the pre-compiled binaries that these CI jobs actually depend on.
I would like to leave this job like this even if it is red for now. It won't block the merge of any PRs unless you add the new CI jobs as required in the repo settings, and this is what you should do after `0.3` is released.

The CI jobs run on every OS that Github Actions support today, and we'll need to maintain the list of `runs-on` platforms used in the job matrix manually. Unfortunately there isn't a syntax to expand the list of all OSes in GitHub, but anyway, this way it makes CI more stable, and it makes more explicitly that we need to switch our OSes support when a new one is added and we have to update the CI code.

## Documentation

No documentation was updated yet, mainly because the action isn't usable yet because we don't have pre-compiled binaries released.

However, I'll update the docs in https://github.com/rust-marker/marker/pull/255 a bit later this week

## Call to action

I'd like to ask you to announce the `0.3` release on Reddit only after you sanity check that the installation scripts and the Github Action work for this release manually. This is because I tested all of the things in my custom fork, and I had to do some manually replacements of the URLs and tags in my fork to make it work there temporarily and returned my changes back to `rust-marker` and `0.2.1` manually. Hopefully, I didn't make a mistake there, but a double-check won't hurt.

You may test that by running the following 4 versions of the installation scripts with the following URLs to also check that the sliding tags and master work:
```
https://raw.githubusercontent.com/rust-marker/marker/v0.3.0/scripts/release/install.sh
https://raw.githubusercontent.com/rust-marker/marker/v0.3/scripts/release/install.sh
https://raw.githubusercontent.com/rust-marker/marker/v0/scripts/release/install.sh
https://raw.githubusercontent.com/rust-marker/marker/master/scripts/release/install.sh
```
You may also install powershell if your don't have Windows, or if you have run powershell versions of these as well.

For the Github Action you may just create a draft PR in marker repo itself you may replace the `uses: ./` in the new CI job with the following combinations:
```
uses: rust-marker/marker@v0.3.1
uses: rust-marker/marker@v0.3
uses: rust-marker/marker@v0
```

The most important is `@v0.3` variant, because this ensures the updates of that tag will be compatible, and users will be recommended to use this syntax.

### Github Marketplace

I also figured out that you may publish the action to Github Marketplace. It's the website that Github uses to promote Github Actions. It often appears in search results in google when you search for some github action. It should be a good source incoming interest. To publish the action to marketplace you actually need to have a Github Release with that action. I'm not yet sure how exactly it works. Hopefully you'll have to do this once. So once you create a Github Release, you should go to edit that Github Release, and there you will see a checkmark at the top that suggests publishing the Github Action to the Marketplace like this:

![image](https://github.com/rust-marker/marker/assets/36276403/0861b9ba-0205-4c4d-8555-b55f7329986b)

> (actually if you do this for the first time it will ask you to accept some terms-and-conditions, but I suppose you'll figure this out).

I didn't try to publish the Github Action from my fork for testing, because I'm not sure if I can remove it from there and I wouldn't like to occupy the name of the action.