### PR TITLE
API: Add `AstMap` (`MarkerContext` cleanup and more breakage :bomb:)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ See the [v0.3.0 milestone] for a full list of all changes.
 [#252]: https://github.com/rust-marker/marker/pull/252
 [#256]: https://github.com/rust-marker/marker/pull/256
 [#259]: https://github.com/rust-marker/marker/pull/259
+[#260]: https://github.com/rust-marker/marker/pull/260
 [#263]: https://github.com/rust-marker/marker/pull/263
 [#265]: https://github.com/rust-marker/marker/pull/265
 
@@ -53,6 +54,7 @@ See the [v0.3.0 milestone] for a full list of all changes.
 - [#244]: `StmtKind` and `PatKind` no longer wrap `Kind*` directly
 - [#245]: `emit_lint()` takes less arguments and returns a `DiagnosticBuilder` instance
 - [#263]: Updated the [`ui_test`](https://crates.io/crates/ui_test) used by `marker_uitest` from `v0.11.7` to `v0.21.2`
+- [#260]: Moved `AstContext::{body, item, lint_level_at}` to the new `AstMap` struct accessible via `MarkerContext::ast()`
 - [#265]: Removed the `CallableData` trait
 
 ### Internal

--- a/marker_adapter/src/context.rs
+++ b/marker_adapter/src/context.rs
@@ -1,12 +1,101 @@
+//! The [`marker_api`] crate is designed to be driver-independent and lightweight.
+//! Communication from the lint-crate to the driver is done via structs inside the
+//! [`marker_api::context`] module. For example, [`marker_api::MarkerContext`].
+//!
+//! The communication needs to be ABI safe, since it goes over an FFI function
+//! boundary. For this reason, it's not (directly) possible to use `dyn Trait`objects.
+//! Marker instead uses `*Callback` structs, that contain function pointers, which can
+//! be filled by the driver. This is like a `dyn Trait` object, without all the nice
+//! syntax and build in compiler support.
+//!
+//! These `*Callbacks` structs need to be filled and some ABI-specific transformations
+//! have to be performed. This module hides all the gore behind some structs and
+//! traits, which can be implemented by the specific driver. The following is an
+//! explanation of this structure and some naming conventions. The explanation will use
+//! an imaginary `Magic` struct, to illustrate the structure:
+//!
+//! * The `marker_api` crate defines the `Magic` struct with an interface for external and internal
+//!   consumers.
+//!
+//!    It also defines the `MagicCallbacks` struct, which stores function pointers.
+//!    All `*Callbacks` structs have a special `data: &'ast MarkerContextData` field that will be
+//!    passed to all stored function pointers, as the first argument. All function
+//!    pointers are marked as `extern "C"` and need to use FFI safe types. Lifetimes
+//!    are allowed by Rust, but not enforced over FFI bounds.
+//!
+//! * The `marker_adapter` crate defines a `MagicDriver` trait, that has all the functions, needed
+//!   to provide a backend for the `Magic` struct.
+//!
+//!    It also defines the `MagicWrapper` struct, that has a `driver: &'ast dyn
+//!    MagicDriver` field. This struct will be used to fill the `MagicCallbacks.data`
+//!    field. Wrapping it in a separate `*Wrapper` struct makes the `&'ast *Wrapper`
+//!    pointer a thin pointer and cleans up the interface.
+//!
+//!    The `marker_adapter` module containing the `MagicWrapper` struct defines a
+//!    bunch of `extern "C"` functions, which build the counterpart to the `extern
+//!    "C"` functions inside `MagicCallbacks`. These functions cast the `data`
+//!    argument into the `&'ast MagicWrapper` instance it originated from and calls
+//!    the corresponding trait function from the `driver: &'ast dyn MagicDriver` field
+//!    stored inside the `Wrapper` struct. The `extern "C"` functions are also
+//!    responsible for converting all types into FFI safe types and back.
+//!
+//! * The driver simply implements the `MagicDriver` trait and instantiates `MagicWrapper`. This
+//!   wrapper instance is then used to fill `MagicCallbacks` and instantiate the `Magic` struct from
+//!   `marker_api`.
+//!
+//! ---
+//!
+//! Short Q&A with @xFrednet
+//!
+//! * **Isn't there a simpler way?**
+//!
+//!     Most likely... Or better say hopefully there is.
+//!
+//!     However, I couldn't find one. Most libraries I found either didn't support these
+//!     types of callbacks, were experimental, or are unsound.
+//!
+//!     I also have high hopes for Rust adding some cross crate boundary communication
+//!     support some time in the future. But there is no point in waiting on this. There
+//!     are lints which need to be written, and we can always replace this infrastructure
+//!     later.
+//!
+//! * **Isn't there a simpler way to make the types FFI safe?**
+//!
+//!     Not really. There are some tools to generate ABI safe types, but they are geared
+//!     towards C/C++ consumers. As a result, they usually lose lifetime information,
+//!     which we want to keep since both sides are using Rust.
+//!
+//!     There are also crates that rely on serialization. A nice and simple solution, but
+//!     not feasible for an entire AST over multiple FFI boundaries for every lint crate.
+//!
+//! * **Do you use code generation for all this infrastructure?**
+//!
+//!     I would love to! However, I haven't found the time to implement this. Normal macro
+//!     rules are basically out of the question due to all the required FFI type
+//!     transformation.
+//!
+//!     If anyone is interested in implementing this, I would be grateful!!! See
+//!     rust-marker/marker#122
+//!
+//! * **Is this implementation even safe and sound?**
+//!
+//!     Theoretically speaking? From my understanding? Yes, it is, assuming that both sides
+//!     reconstruct the lifetimes correctly.
+//!
+//!     Practically speaking? It wouldn't surprise me if there were several bugs. So far,
+//!     it has been working suspiciously well, but I won't complain.
+
 // The lifetimes are destroyed by unsafe, but help with readability
 #![allow(clippy::needless_lifetimes)]
 
+mod map;
+pub use map::*;
+
 use marker_api::{
     ast::{ty::SemTyKind, ExpnId, ExprId, SpanId, SymbolId},
-    context::DriverCallbacks,
+    context::{MarkerContextCallbacks, MarkerContextData},
     diagnostic::Diagnostic,
     ffi::{self, FfiOption},
-    lint::{Level, Lint},
     prelude::*,
     span::{ExpnInfo, FileInfo, FilePos, SpanPos, SpanSource},
 };
@@ -17,30 +106,26 @@ use marker_api::{
 /// change and calling functions on them would require a stable ABI which Rust
 /// doesn't provide.
 ///
-/// In this case, the [`DriverContextWrapper`] will be passed as a `*const ()`
-/// pointer to [`DriverCallbacks`] which will do nothing with this data other
+/// In this case, the [`MarkerContextWrapper`] will be passed as a `*const ()`
+/// pointer to [`MarkerContextCallbacks`] which will do nothing with this data other
 /// than giving it back to functions declared in this module. Since the `&dyn`
 /// object is created, only used here and everything is compiled during the same
 /// compiler run, it should be safe to use `&dyn`.
 #[repr(C)]
-pub struct DriverContextWrapper<'ast> {
-    driver_cx: &'ast dyn DriverContext<'ast>,
+pub struct MarkerContextWrapper<'ast> {
+    driver: &'ast dyn MarkerContextDriver<'ast>,
 }
 
-impl<'ast> DriverContextWrapper<'ast> {
-    #[must_use]
-    pub fn new(driver_cx: &'ast dyn DriverContext<'ast>) -> Self {
-        Self { driver_cx }
+impl<'ast> MarkerContextWrapper<'ast> {
+    pub fn new(driver: &'ast dyn MarkerContextDriver<'ast>) -> Self {
+        Self { driver }
     }
 
     #[must_use]
-    pub fn create_driver_callback(&'ast self) -> DriverCallbacks<'ast> {
-        DriverCallbacks {
-            driver_context: unsafe { &*(self as *const DriverContextWrapper).cast::<()>() },
-            lint_level_at,
+    pub fn create_callbacks(&'ast self) -> MarkerContextCallbacks<'ast> {
+        MarkerContextCallbacks {
+            data: unsafe { &*(self as *const MarkerContextWrapper).cast::<MarkerContextData>() },
             emit_diag,
-            item,
-            body,
             resolve_ty_ids,
             expr_ty,
             span,
@@ -54,83 +139,8 @@ impl<'ast> DriverContextWrapper<'ast> {
     }
 }
 
-// False positive because `EmissionNode` are non-exhaustive
-#[allow(improper_ctypes_definitions)]
-extern "C" fn lint_level_at<'ast>(data: &'ast (), lint: &'static Lint, node: NodeId) -> Level {
-    unsafe { as_driver_cx(data) }.lint_level_at(lint, node)
-}
-
-extern "C" fn emit_diag<'a, 'ast>(data: &'ast (), diag: &Diagnostic<'a, 'ast>) {
-    unsafe { as_driver_cx(data) }.emit_diag(diag);
-}
-
-// False positive because `ItemKind` is non-exhaustive
-#[allow(improper_ctypes_definitions)]
-extern "C" fn item<'ast>(data: &'ast (), id: ItemId) -> FfiOption<ItemKind<'ast>> {
-    unsafe { as_driver_cx(data) }.item(id).into()
-}
-
-extern "C" fn body<'ast>(data: &'ast (), id: BodyId) -> &'ast Body<'ast> {
-    unsafe { as_driver_cx(data) }.body(id)
-}
-
-extern "C" fn resolve_ty_ids<'ast>(data: &'ast (), path: ffi::FfiStr<'_>) -> ffi::FfiSlice<'ast, TyDefId> {
-    unsafe { as_driver_cx(data) }.resolve_ty_ids((&path).into()).into()
-}
-
-// False positive because `SemTyKind` is non-exhaustive
-#[allow(improper_ctypes_definitions)]
-extern "C" fn expr_ty<'ast>(data: &'ast (), expr: ExprId) -> SemTyKind<'ast> {
-    unsafe { as_driver_cx(data) }.expr_ty(expr)
-}
-
-extern "C" fn span<'ast>(data: &'ast (), span_id: SpanId) -> &'ast Span<'ast> {
-    unsafe { as_driver_cx(data) }.span(span_id)
-}
-
-extern "C" fn span_snippet<'ast>(data: &'ast (), span: &Span<'ast>) -> ffi::FfiOption<ffi::FfiStr<'ast>> {
-    unsafe { as_driver_cx(data) }.span_snippet(span).map(Into::into).into()
-}
-
-// False positive because `SpanSource` is non-exhaustive
-#[allow(improper_ctypes_definitions)]
-extern "C" fn span_source<'ast>(data: &'ast (), span: &Span<'_>) -> SpanSource<'ast> {
-    unsafe { as_driver_cx(data) }.span_source(span)
-}
-
-extern "C" fn span_pos_to_file_loc<'ast>(
-    data: &'ast (),
-    file: &FileInfo<'ast>,
-    pos: SpanPos,
-) -> ffi::FfiOption<FilePos<'ast>> {
-    unsafe { as_driver_cx(data) }.span_pos_to_file_loc(file, pos).into()
-}
-
-extern "C" fn span_expn_info<'ast>(data: &'ast (), expn_id: ExpnId) -> FfiOption<&'ast ExpnInfo<'ast>> {
-    unsafe { as_driver_cx(data) }.span_expn_info(expn_id).into()
-}
-
-extern "C" fn symbol_str<'ast>(data: &'ast (), sym: SymbolId) -> ffi::FfiStr<'ast> {
-    unsafe { as_driver_cx(data) }.symbol_str(sym).into()
-}
-
-extern "C" fn resolve_method_target<'ast>(data: &'ast (), id: ExprId) -> ItemId {
-    unsafe { as_driver_cx(data) }.resolve_method_target(id)
-}
-
-/// # Safety
-/// The `data` must be a valid pointer to a [`DriverContextWrapper`]
-unsafe fn as_driver_cx<'ast>(data: &'ast ()) -> &'ast dyn DriverContext<'ast> {
-    let wrapper = &*(data as *const ()).cast::<DriverContextWrapper>();
-    wrapper.driver_cx
-}
-
-pub trait DriverContext<'ast> {
-    fn lint_level_at(&'ast self, lint: &'static Lint, node: NodeId) -> Level;
+pub trait MarkerContextDriver<'ast> {
     fn emit_diag(&'ast self, diag: &Diagnostic<'_, 'ast>);
-
-    fn item(&'ast self, api_id: ItemId) -> Option<ItemKind<'ast>>;
-    fn body(&'ast self, api_id: BodyId) -> &'ast Body<'ast>;
 
     fn resolve_ty_ids(&'ast self, path: &str) -> &'ast [TyDefId];
 
@@ -142,4 +152,65 @@ pub trait DriverContext<'ast> {
     fn span_pos_to_file_loc(&'ast self, file: &FileInfo<'ast>, pos: SpanPos) -> Option<FilePos<'ast>>;
     fn symbol_str(&'ast self, api_id: SymbolId) -> &'ast str;
     fn resolve_method_target(&'ast self, id: ExprId) -> ItemId;
+}
+
+extern "C" fn emit_diag<'a, 'ast>(data: &'ast MarkerContextData, diag: &Diagnostic<'a, 'ast>) {
+    unsafe { as_driver(data) }.emit_diag(diag);
+}
+
+extern "C" fn resolve_ty_ids<'ast>(
+    data: &'ast MarkerContextData,
+    path: ffi::FfiStr<'_>,
+) -> ffi::FfiSlice<'ast, TyDefId> {
+    unsafe { as_driver(data) }.resolve_ty_ids((&path).into()).into()
+}
+
+// False positive because `SemTyKind` is non-exhaustive
+#[allow(improper_ctypes_definitions)]
+extern "C" fn expr_ty<'ast>(data: &'ast MarkerContextData, expr: ExprId) -> SemTyKind<'ast> {
+    unsafe { as_driver(data) }.expr_ty(expr)
+}
+
+extern "C" fn span<'ast>(data: &'ast MarkerContextData, span_id: SpanId) -> &'ast Span<'ast> {
+    unsafe { as_driver(data) }.span(span_id)
+}
+
+extern "C" fn span_snippet<'ast>(
+    data: &'ast MarkerContextData,
+    span: &Span<'ast>,
+) -> ffi::FfiOption<ffi::FfiStr<'ast>> {
+    unsafe { as_driver(data) }.span_snippet(span).map(Into::into).into()
+}
+
+// False positive because `SpanSource` is non-exhaustive
+#[allow(improper_ctypes_definitions)]
+extern "C" fn span_source<'ast>(data: &'ast MarkerContextData, span: &Span<'_>) -> SpanSource<'ast> {
+    unsafe { as_driver(data) }.span_source(span)
+}
+
+extern "C" fn span_pos_to_file_loc<'ast>(
+    data: &'ast MarkerContextData,
+    file: &FileInfo<'ast>,
+    pos: SpanPos,
+) -> ffi::FfiOption<FilePos<'ast>> {
+    unsafe { as_driver(data) }.span_pos_to_file_loc(file, pos).into()
+}
+
+extern "C" fn span_expn_info<'ast>(data: &'ast MarkerContextData, expn_id: ExpnId) -> FfiOption<&'ast ExpnInfo<'ast>> {
+    unsafe { as_driver(data) }.span_expn_info(expn_id).into()
+}
+
+extern "C" fn symbol_str<'ast>(data: &'ast MarkerContextData, sym: SymbolId) -> ffi::FfiStr<'ast> {
+    unsafe { as_driver(data) }.symbol_str(sym).into()
+}
+
+extern "C" fn resolve_method_target<'ast>(data: &'ast MarkerContextData, id: ExprId) -> ItemId {
+    unsafe { as_driver(data) }.resolve_method_target(id)
+}
+
+/// # Safety
+/// The `data` must be a valid pointer to a [`MarkerContextWrapper`]
+unsafe fn as_driver<'ast>(data: &'ast MarkerContextData) -> &'ast dyn MarkerContextDriver<'ast> {
+    let wrapper = &*(data as *const MarkerContextData).cast::<MarkerContextWrapper>();
+    wrapper.driver
 }

--- a/marker_adapter/src/context/map.rs
+++ b/marker_adapter/src/context/map.rs
@@ -1,0 +1,80 @@
+use marker_api::{
+    ast::item::{EnumVariant, Field},
+    context::{AstMap, AstMapCallbacks, AstMapData},
+    ffi,
+    lint::Level,
+    prelude::*,
+};
+
+#[repr(C)]
+pub struct AstMapWrapper<'ast> {
+    driver: &'ast dyn AstMapDriver<'ast>,
+}
+
+impl<'ast> AstMapWrapper<'ast> {
+    pub fn new(driver: &'ast dyn AstMapDriver<'ast>) -> Self {
+        Self { driver }
+    }
+
+    #[must_use]
+    pub fn create_callbacks(&'ast self) -> AstMap<'ast> {
+        AstMap::builder()
+            .callbacks(AstMapCallbacks {
+                data: unsafe { &*(self as *const AstMapWrapper).cast::<AstMapData>() },
+                item,
+                variant,
+                field,
+                body,
+                stmt,
+                expr,
+                lint_level_at,
+            })
+            .build()
+    }
+}
+
+/// The driver trait for [`AstMap`](marker_api::context::AstMap).
+pub trait AstMapDriver<'ast> {
+    fn item(&'ast self, id: ItemId) -> Option<ItemKind<'ast>>;
+    fn variant(&'ast self, id: VariantId) -> Option<&'ast EnumVariant<'ast>>;
+    fn field(&'ast self, id: FieldId) -> Option<&'ast Field<'ast>>;
+    fn body(&'ast self, id: BodyId) -> &'ast Body<'ast>;
+    fn stmt(&'ast self, id: StmtId) -> StmtKind<'ast>;
+    fn expr(&'ast self, id: ExprId) -> ExprKind<'ast>;
+
+    fn lint_level_at(&'ast self, lint: &'static Lint, node: NodeId) -> Level;
+}
+
+#[allow(improper_ctypes_definitions)] // FP because `ItemKind` is non-exhaustive
+extern "C" fn item<'ast>(data: &'ast AstMapData, id: ItemId) -> ffi::FfiOption<ItemKind<'ast>> {
+    unsafe { as_driver(data) }.item(id).into()
+}
+extern "C" fn variant<'ast>(data: &'ast AstMapData, id: VariantId) -> ffi::FfiOption<&'ast EnumVariant<'ast>> {
+    unsafe { as_driver(data) }.variant(id).into()
+}
+extern "C" fn field<'ast>(data: &'ast AstMapData, id: FieldId) -> ffi::FfiOption<&'ast Field<'ast>> {
+    unsafe { as_driver(data) }.field(id).into()
+}
+extern "C" fn body<'ast>(data: &'ast AstMapData, id: BodyId) -> &'ast Body<'ast> {
+    unsafe { as_driver(data) }.body(id)
+}
+#[allow(improper_ctypes_definitions)] // FP because `StmtKind` is non-exhaustive
+extern "C" fn stmt<'ast>(data: &'ast AstMapData, id: StmtId) -> StmtKind<'ast> {
+    unsafe { as_driver(data) }.stmt(id)
+}
+#[allow(improper_ctypes_definitions)] // FP because `ExprKind` is non-exhaustive
+extern "C" fn expr<'ast>(data: &'ast AstMapData, id: ExprId) -> ExprKind<'ast> {
+    unsafe { as_driver(data) }.expr(id)
+}
+
+#[allow(improper_ctypes_definitions)] // FP because `NodeId` is non-exhaustive
+extern "C" fn lint_level_at<'ast>(data: &'ast AstMapData, lint: &'static Lint, node: NodeId) -> Level {
+    unsafe { as_driver(data) }.lint_level_at(lint, node)
+}
+
+/// # Safety
+/// `data` must be a valid pointer to [`AstMapDriver`]
+unsafe fn as_driver<'ast>(data: &'ast AstMapData) -> &'ast dyn AstMapDriver<'ast> {
+    let wrapper = &*(data as *const AstMapData).cast::<AstMapWrapper>();
+    wrapper.driver
+}

--- a/marker_api/src/context/map.rs
+++ b/marker_api/src/context/map.rs
@@ -1,0 +1,157 @@
+use crate::{
+    ast::{
+        expr::ExprKind,
+        item::{Body, EnumVariant, Field, ItemKind},
+        stmt::StmtKind,
+        BodyId, ExprId, FieldId, ItemId, StmtId, VariantId,
+    },
+    ffi,
+    lint::{Level, Lint},
+    prelude::{HasNodeId, NodeId},
+};
+
+/// A map, which allows the request of AST nodes by their ids. An instance of this
+/// map can be accessed from [`MarkerContext::ast`](super::MarkerContext::ast).
+///
+/// # Availability of Nodes
+///
+/// Rustc, as a compiler and driver for Marker, compiles each crate individually
+/// [^compilation-unit]. This setup means that at a given time, there are only
+/// the AST of one crate available. Therefore, it can happen that the AST node
+/// representation for a valid ID is unavailable.
+///
+/// Generally speaking, it's advised to use the failable variant of the provided
+/// functions and just bail if the expected node is unavailable. The API also
+/// provides some functions that automatically unwrap the requested nodes. These
+/// functions, starting with `unwrap_`, are great for prototyping but should be
+/// used carefully.
+///
+/// FIXME(xFrednet): While the driver might not have the dependency loaded, it
+/// usually has some semantic information about what types and functions are
+/// available. The API should provide some way to request this semantic information
+/// based on the ID. (See: rust-marker/marker#266)
+///
+/// [^compilation-unit]: For more context, ASTs can take up a lot of space.
+///     Splitting the compilation of a project into separate compilation units
+///     is one way to handle memory better. This approach also allows for some
+///     optimizations. For example, Rustc was able to reduce the size of some
+///     structs, as it was known that they only need to handle one crate at a time.
+#[repr(C)]
+#[cfg_attr(feature = "driver-api", derive(typed_builder::TypedBuilder))]
+pub struct AstMap<'ast> {
+    callbacks: AstMapCallbacks<'ast>,
+}
+
+impl<'ast> AstMap<'ast> {
+    pub fn lint_level_at(&self, lint: &'static Lint, node: impl HasNodeId) -> Level {
+        (self.callbacks.lint_level_at)(self.callbacks.data, lint, node.node_id())
+    }
+
+    /// Returns the [`ItemKind`] belonging to the given [`ItemId`], if available.
+    ///
+    /// Checkout the documentation of [`AstMap`] for more information, when a node
+    /// might be unavailable, even if the given ID is valid.
+    pub fn item(&self, id: ItemId) -> Option<ItemKind<'ast>> {
+        (self.callbacks.item)(self.callbacks.data, id).copy()
+    }
+
+    /// Returns the [`ItemKind`] belonging to the given [`ItemId`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requested item is currently unavailable. Checkout the
+    /// documentation of [`AstMap`] for an explanation, when AST nodes might be
+    /// unavailable. [`AstMap::item`] can be used as a non-panicking alternative.
+    pub fn unwrap_item(&self, id: ItemId) -> ItemKind<'ast> {
+        self.item(id)
+            .unwrap_or_else(|| panic!("The requested item is unavailable (id = {id:?})"))
+    }
+
+    /// Returns the [`EnumVariant`] belonging to the given [`VariantId`], if available.
+    ///
+    /// Checkout the documentation of [`AstMap`] for more information, when a node
+    /// might be unavailable, even if the given ID is valid.
+    pub fn variant(&self, id: VariantId) -> Option<&EnumVariant<'ast>> {
+        (self.callbacks.variant)(self.callbacks.data, id).copy()
+    }
+
+    /// Returns the [`EnumVariant`] belonging to the given [`VariantId`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requested enum variant is currently unavailable. Checkout the
+    /// documentation of [`AstMap`] for an explanation, when AST nodes might be
+    /// unavailable. [`AstMap::variant`] can be used as a non-panicking alternative.
+    pub fn unwrap_variant(&self, id: VariantId) -> &EnumVariant<'ast> {
+        self.variant(id)
+            .unwrap_or_else(|| panic!("The requested enum variant is unavailable (id = {id:?})"))
+    }
+
+    /// Returns the [`Field`] belonging to the given [`FieldId`], if available.
+    ///
+    /// Checkout the documentation of [`AstMap`] for more information, when a node
+    /// might be unavailable, even if the given ID is valid.
+    pub fn field(&self, id: FieldId) -> Option<&Field<'ast>> {
+        (self.callbacks.field)(self.callbacks.data, id).copy()
+    }
+
+    /// Returns the [`Field`] belonging to the given [`FieldId`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requested enum variant is currently unavailable. Checkout the
+    /// documentation of [`AstMap`] for an explanation, when AST nodes might be
+    /// unavailable. [`AstMap::variant`] can be used as a non-panicking alternative.
+    pub fn unwrap_field(&self, id: FieldId) -> &Field<'ast> {
+        self.field(id)
+            .unwrap_or_else(|| panic!("The requested field is unavailable (id = {id:?})"))
+    }
+
+    /// Returns the [`Body`] belonging to the given [`BodyId`].
+    pub fn body(&self, id: BodyId) -> &Body<'ast> {
+        (self.callbacks.body)(self.callbacks.data, id)
+    }
+
+    /// Returns the [`StmtKind`] belonging to the given [`StmtId`].
+    pub fn stmt(&self, id: StmtId) -> StmtKind<'ast> {
+        (self.callbacks.stmt)(self.callbacks.data, id)
+    }
+
+    /// Returns the [`ExprKind`] belonging to the given [`ExprId`].
+    pub fn expr(&self, id: ExprId) -> ExprKind<'ast> {
+        (self.callbacks.expr)(self.callbacks.data, id)
+    }
+}
+
+#[repr(C)]
+#[cfg_attr(feature = "driver-api", visibility::make(pub))]
+#[cfg_attr(feature = "driver-api", derive(typed_builder::TypedBuilder))]
+struct AstMapCallbacks<'ast> {
+    /// The data that will be used as the first argument for the callback functions.
+    /// The content of this data is defined by the driver (or by marker_adapter on behalf
+    /// of the driver)
+    pub data: &'ast AstMapData,
+
+    pub item: extern "C" fn(data: &'ast AstMapData, id: ItemId) -> ffi::FfiOption<ItemKind<'ast>>,
+    pub variant: extern "C" fn(data: &'ast AstMapData, id: VariantId) -> ffi::FfiOption<&'ast EnumVariant<'ast>>,
+    pub field: extern "C" fn(data: &'ast AstMapData, id: FieldId) -> ffi::FfiOption<&'ast Field<'ast>>,
+    pub body: extern "C" fn(data: &'ast AstMapData, id: BodyId) -> &'ast Body<'ast>,
+    pub stmt: extern "C" fn(data: &'ast AstMapData, id: StmtId) -> StmtKind<'ast>,
+    pub expr: extern "C" fn(data: &'ast AstMapData, id: ExprId) -> ExprKind<'ast>,
+
+    pub lint_level_at: extern "C" fn(data: &'ast AstMapData, lint: &'static Lint, node: NodeId) -> Level,
+}
+
+/// This type is used by [`AstMapCallbacks`] as the first argument to every
+/// function. For more information, see the documentation of the `data` field
+/// or from `marker_adapter::context`.
+///
+/// This type should never be constructed and is only meant as a pointer
+/// casting target.
+#[repr(C)]
+#[cfg_attr(feature = "driver-api", visibility::make(pub))]
+struct AstMapData {
+    /// `#[repr(C)]` requires a field, to make this a proper type. Using usize
+    /// ensures that the structs has the same alignment requirement as a pointer.
+    _data: usize,
+}

--- a/marker_api/src/context/map.rs
+++ b/marker_api/src/context/map.rs
@@ -26,10 +26,12 @@ use crate::{
 /// functions, starting with `unwrap_`, are great for prototyping but should be
 /// used carefully.
 ///
-/// FIXME(xFrednet): While the driver might not have the dependency loaded, it
+/// # Future plans
+///
+/// While the driver might not have the AST of a dependency loaded, it
 /// usually has some semantic information about what types and functions are
-/// available. The API should provide some way to request this semantic information
-/// based on the ID. (See: rust-marker/marker#266)
+/// available. Marker should provide some way to request this semantic information
+/// based on the ID. (See: <https://github.com/rust-marker/marker/issues/266>)
 ///
 /// [^compilation-unit]: For more context, ASTs can take up a lot of space.
 ///     Splitting the compilation of a project into separate compilation units

--- a/marker_api/src/lint.rs
+++ b/marker_api/src/lint.rs
@@ -1,23 +1,45 @@
+/// This struct defines a lint.
+///
+/// It should never be constructed directly, the [`declare_lint`](crate::declare_lint)
+/// macro should be used instead, like this:
+///
+/// ```
+/// marker_api::declare_lint!{
+///     /// # What it does
+///     /// Here you can describe what your lint does.
+///     ///
+///     /// # Example
+///     /// ```
+///     /// <bad example>
+///     /// ```
+///     ///
+///     /// Use instead
+///     /// ```
+///     /// <bad example>
+///     /// ```
+///     ITEM_WITH_TEST_NAME,
+///     Warn,
+/// }
+/// ```
+///
+/// The fields of this struct are public, to allow the instantiation in constant
+/// context. Marker reserves the right to add new fields, as long the lint can still
+/// be constructed using the [`declare_lint`](crate::declare_lint) macro.
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, Hash)]
-// This sadly cannot be marked as #[non_exhaustive] as the struct construction
-// has to be possible in a static context.
-#[doc(hidden)]
 pub struct Lint {
     /// A string identifier for the lint.
     ///
     /// This identifies the lint in attributes and in command-line arguments.
     /// In those contexts it is always lowercase. This allows
-    /// [`declare_lint!`] macro invocations to follow the convention of upper-case
-    /// statics without repeating the name.
+    /// [`declare_lint`](crate::declare_lint) macro invocations to follow the
+    /// convention of upper-case statics without repeating the name.
     ///
     /// The name is written with underscores, e.g., "unused_imports".
     /// On the command line, underscores become dashes.
     ///
     /// See <https://rustc-dev-guide.rust-lang.org/diagnostics.html#lint-naming>
     /// for naming guidelines.
-    ///
-    /// [`declare_lint!`]: declare_lint
     pub name: &'static str,
 
     /// Default level for the lint.
@@ -35,13 +57,11 @@ pub struct Lint {
     ///
     /// See [`MacroReport`] for the possible levels.
     pub report_in_macro: MacroReport,
-    // FIXME: We might want to add more fields. This should be possible as this
-    // struct is always constructed by a macro controlled by marker. These are some
-    // additional fields used  in rustc:
-    // * pub edition_lint_opts: Option<(Edition, Level)>,
-    // * pub future_incompatible: Option<FutureIncompatibleInfo>,
-    // * pub feature_gate: Option<&'static str>,
-    // * pub crate_level_only: bool,
+
+    /// This struct should always be instantiated using the [`declare_lint`](crate::declare_lint)
+    /// macro. This value is simply here, to force any construction to acknowledge the
+    /// instability of manual construction.
+    pub _unstable_i_accept_the_risk_of_instability: (),
 }
 
 /// FIXME(xFrednet): These settings should be working now, but are still limited
@@ -143,6 +163,7 @@ macro_rules! declare_lint {
             default_level: $crate::lint::Level::$LEVEL,
             explanation: concat!($($doc, '\n',)*),
             report_in_macro: $REPORT_IN_MACRO,
+            _unstable_i_accept_the_risk_of_instability: (),
         };
     };
 }

--- a/marker_api/src/prelude.rs
+++ b/marker_api/src/prelude.rs
@@ -23,6 +23,7 @@ pub use crate::ast::pat::PatKind;
 pub use crate::ast::stmt::StmtKind;
 pub use crate::ast::ty::SemTyKind;
 pub use crate::ast::ty::SynTyKind;
+pub use crate::lint::Lint;
 pub use crate::span::Ident;
 pub use crate::span::Span;
 pub use crate::MarkerContext;

--- a/marker_rustc_driver/src/context/map.rs
+++ b/marker_rustc_driver/src/context/map.rs
@@ -1,0 +1,58 @@
+use marker_adapter::context::AstMapDriver;
+use marker_api::{
+    ast::item::{EnumVariant, Field},
+    lint::Level,
+    prelude::*,
+};
+
+use super::RustcContext;
+
+impl<'ast, 'tcx: 'ast> AstMapDriver<'ast> for RustcContext<'ast, 'tcx> {
+    fn item(&'ast self, id: ItemId) -> Option<ItemKind<'ast>> {
+        let rustc_id = self.rustc_converter.to_item_id(id);
+        self.marker_converter.item(rustc_id)
+    }
+
+    fn variant(&'ast self, id: VariantId) -> Option<&'ast EnumVariant<'ast>> {
+        self.marker_converter.variant(id)
+    }
+
+    fn field(&'ast self, id: FieldId) -> Option<&'ast Field<'ast>> {
+        self.marker_converter.field(id)
+    }
+
+    fn body(&'ast self, id: BodyId) -> &'ast Body<'ast> {
+        let rustc_id = self.rustc_converter.to_body_id(id);
+        self.marker_converter.body(rustc_id)
+    }
+
+    fn stmt(&'ast self, id: StmtId) -> StmtKind<'ast> {
+        let rustc_id = self.rustc_converter.to_hir_id(id);
+        match self.marker_converter.stmt(rustc_id) {
+            Some(stmt) => stmt,
+            None => unreachable!(
+                "the `HirId` belongs to a valid statement, since it comes from a `StmtId`. (HirId: {rustc_id:?})"
+            ),
+        }
+    }
+
+    fn expr(&'ast self, id: ExprId) -> ExprKind<'ast> {
+        let rustc_id = self.rustc_converter.to_hir_id(id);
+        match self.marker_converter.expr(rustc_id) {
+            Some(expr) => expr,
+            None => unreachable!(
+                "the `HirId` belongs to a valid expression, since it comes from a `ExprId`. (HirId: {rustc_id:?})"
+            ),
+        }
+    }
+
+    fn lint_level_at(&'ast self, api_lint: &'static Lint, node: NodeId) -> Level {
+        if let Some(id) = self.rustc_converter.try_to_hir_id_from_emission_node(node) {
+            let lint = self.rustc_converter.to_lint(api_lint);
+            let level = self.rustc_cx.lint_level_at_node(lint, id).0;
+            self.marker_converter.to_lint_level(level)
+        } else {
+            Level::Allow
+        }
+    }
+}

--- a/marker_rustc_driver/src/conversion/marker/item.rs
+++ b/marker_rustc_driver/src/conversion/marker/item.rs
@@ -115,6 +115,13 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                             variant.disr_expr.map(|anon| self.to_const_expr(anon)),
                         )
                     }));
+                    // A block to limit the lifetime of the mut borrow
+                    {
+                        let mut cache = self.variants.borrow_mut();
+                        for var in variants {
+                            cache.insert(var.id(), var);
+                        }
+                    }
                     ItemKind::Enum(self.alloc(EnumItem::new(data, self.to_syn_generic_params(generics), variants)))
                 },
                 hir::ItemKind::Struct(var_data, generics) => ItemKind::Struct(self.alloc(StructItem::new(
@@ -244,7 +251,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     }
 
     fn to_fields(&self, fields: &'tcx [hir::FieldDef]) -> &'ast [Field<'ast>] {
-        self.alloc_slice(fields.iter().map(|field| {
+        let fields = self.alloc_slice(fields.iter().map(|field| {
             // FIXME update Visibility creation to use the stored local def id inside the
             // field after the next sync. See #55
             Field::new(
@@ -254,7 +261,17 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                 self.to_syn_ty(field.ty),
                 self.to_span_id(field.span),
             )
-        }))
+        }));
+
+        // A block to limit the lifetime of the mut borrow
+        {
+            let mut cache = self.fields.borrow_mut();
+            for field in fields {
+                cache.insert(field.id(), field);
+            }
+        }
+
+        fields
     }
 
     fn to_external_items(&self, items: &'tcx [hir::ForeignItemRef], abi: Abi) -> &'ast [ExternItemKind<'ast>] {

--- a/marker_rustc_driver/src/conversion/marker/item.rs
+++ b/marker_rustc_driver/src/conversion/marker/item.rs
@@ -115,13 +115,9 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                             variant.disr_expr.map(|anon| self.to_const_expr(anon)),
                         )
                     }));
-                    // A block to limit the lifetime of the mut borrow
-                    {
-                        let mut cache = self.variants.borrow_mut();
-                        for var in variants {
-                            cache.insert(var.id(), var);
-                        }
-                    }
+                    self.variants
+                        .borrow_mut()
+                        .extend(variants.iter().map(|var| (var.id(), var)));
                     ItemKind::Enum(self.alloc(EnumItem::new(data, self.to_syn_generic_params(generics), variants)))
                 },
                 hir::ItemKind::Struct(var_data, generics) => ItemKind::Struct(self.alloc(StructItem::new(
@@ -263,13 +259,9 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
             )
         }));
 
-        // A block to limit the lifetime of the mut borrow
-        {
-            let mut cache = self.fields.borrow_mut();
-            for field in fields {
-                cache.insert(field.id(), field);
-            }
-        }
+        self.fields
+            .borrow_mut()
+            .extend(fields.iter().map(|field| (field.id(), field)));
 
         fields
     }

--- a/marker_uilints/src/utils.rs
+++ b/marker_uilints/src/utils.rs
@@ -13,7 +13,7 @@ pub fn check_item<'ast>(cx: &'ast MarkerContext<'ast>, item: ItemKind<'ast>) {
     let Some(ident) = fn_item.ident() else { return };
 
     if ident.name().starts_with("test_contains_return") {
-        let body = cx.body(fn_item.body_id().unwrap());
+        let body = cx.ast().body(fn_item.body_id().unwrap());
         let res = body.contains_return(cx);
 
         cx.emit_lint(

--- a/marker_uilints/tests/ui/context/test_ast_map.rs
+++ b/marker_uilints/tests/ui/context/test_ast_map.rs
@@ -1,0 +1,15 @@
+enum LocalOption<T> {
+    MySome(T),
+    MyNone,
+}
+
+struct LocalStruct {
+    data: u32,
+}
+
+fn main() {
+    let _check_ast_map = Option::Some(12);
+    let _check_ast_map = LocalOption::MySome(17);
+
+    let _check_ast_map = LocalStruct { data: 17 };
+}

--- a/marker_uilints/tests/ui/context/test_ast_map.stderr
+++ b/marker_uilints/tests/ui/context/test_ast_map.stderr
@@ -1,0 +1,109 @@
+warning: testing `AstMap::variant`
+  --> $DIR/test_ast_map.rs:11:26
+   |
+11 |     let _check_ast_map = Option::Some(12);
+   |                          ^^^^^^^^^^^^^^^^
+   |
+   = note: `AstMap::variant()` --> None
+   = note: `#[warn(marker::test_ast_map)]` on by default
+
+warning: testing `AstMap::variant`
+  --> $DIR/test_ast_map.rs:12:26
+   |
+12 |     let _check_ast_map = LocalOption::MySome(17);
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `AstMap::variant()` --> Some(
+               EnumVariant {
+                   id: VariantId(..),
+                   ident: SymbolId(..),
+                   span: SpanId(..),
+                   kind: Tuple(
+                       [
+                           Field {
+                               id: FieldId(..),
+                               vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                               ident: SymbolId(..),
+                               ty: Path(
+                                   SynPathTy {
+                                       data: CommonSynTyData {
+                                           _lifetime: PhantomData<&()>,
+                                           span: SpanId(..),
+                                       },
+                                       path: AstQPath {
+                                           self_ty: None,
+                                           path_ty: None,
+                                           path: AstPath {
+                                               segments: [
+                                                   AstPathSegment {
+                                                       ident: Ident {
+                                                           name: "T",
+                                                           span: $DIR/test_ast_map.rs:2:12 - 2:13,
+                                                       },
+                                                       generics: SynGenericArgs {
+                                                           args: [],
+                                                       },
+                                                   },
+                                               ],
+                                           },
+                                           target: Generic(
+                                               GenericId(..),
+                                           ),
+                                       },
+                                   },
+                               ),
+                               span: SpanId(..),
+                           },
+                       ],
+                   ),
+                   discriminant: None,
+               },
+           )
+
+warning: testing `AstMap::item`
+  --> $DIR/test_ast_map.rs:14:26
+   |
+14 |     let _check_ast_map = LocalStruct { data: 17 };
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `AstMap::item()` --> Some(
+               Struct(
+                   StructItem {
+                       data: CommonItemData {
+                           id: ItemId(..),
+                           span: SpanId(..),
+                           vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                           ident: Ident {
+                               name: "LocalStruct",
+                               span: $DIR/test_ast_map.rs:6:8 - 6:19,
+                           },
+                       },
+                       generics: SynGenericParams {
+                           params: [],
+                           clauses: [],
+                       },
+                       kind: Field(
+                           [
+                               Field {
+                                   id: FieldId(..),
+                                   vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                                   ident: SymbolId(..),
+                                   ty: Num(
+                                       SynNumTy {
+                                           data: CommonSynTyData {
+                                               _lifetime: PhantomData<&()>,
+                                               span: SpanId(..),
+                                           },
+                                           numeric_kind: U32,
+                                       },
+                                   ),
+                                   span: SpanId(..),
+                               },
+                           ],
+                       ),
+                   },
+               ),
+           )
+
+warning: 3 warnings emitted
+

--- a/marker_uilints/tests/uitest.rs
+++ b/marker_uilints/tests/uitest.rs
@@ -15,6 +15,7 @@ fn main() -> color_eyre::Result<()> {
         (r"item//", "item/"),
         (r"expr//", "expr/"),
         (r"sugar//", "sugar/"),
+        (r"context//", "context/"),
     ];
     for (pat, repl) in filters {
         config.stderr_filter(pat, repl);

--- a/marker_utils/src/visitor.rs
+++ b/marker_utils/src/visitor.rs
@@ -112,7 +112,8 @@ pub fn traverse_item<'ast, B>(
         }
 
         if let Some(body_id) = id {
-            traverse_body(cx, visitor, cx.body(body_id))?;
+            let body = cx.ast().body(body_id);
+            traverse_body(cx, visitor, body)?;
         }
 
         ControlFlow::Continue(())
@@ -235,7 +236,8 @@ pub fn traverse_expr<'ast, B>(
         },
         ExprKind::Closure(e) => {
             if let VisitorScope::AllBodies = visitor.scope() {
-                traverse_body(cx, visitor, cx.body(e.body_id()))?;
+                let body = cx.ast().body(e.body_id());
+                traverse_body(cx, visitor, body)?;
             }
         },
         ExprKind::UnaryOp(e) => {


### PR DESCRIPTION
This PR cleans up a central part of Marker, the callbacks to the driver. With the old `AstContext` continuously growing, I had the feeling that it was getting more and more overwhelming to work with. It only had a few public functions, but they had a whole range of functions. The old `AstContext` was basically a box that every tool was thrown into, without much consideration. It was like storing the stone drill next to the sewing kit and toaster. Definitely possible, but probably not useful.

A previous PR already renamed `AstContext` to `MarkerContext` for reasons described in rust-marker/marker#243.

This PR tried to add new structure to the while `context` module. From now on, we'll try to group similar functions together. Some general functions, like `emit_lint` will be available methods of `MarkerContext` directly. But other methods, requesting notes or checking something AST related, are available in a separate `AstMap` instance. This one can be accessed via the `MarkerContext::ast` method.

This separation is not perfect, and most internal callbacks are still stored inside `MarkerContext` itself. They should be moved at some point, but this PR focussed on the user-facing changes.

---

I've also added some documentation about the whole callback infrastructure. For me, the whole thing is like a zombie :zombie:. The existence both amazes and terrifies me.

Anyways, for anyone reading this, I hope you have a fantastic day, full of green CIs and friends to talk to :D

---

Closes: rust-marker/marker#243