### PR TITLE
CI: Add semantic versioning test for controlled breakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,12 +140,7 @@ jobs:
   # This check is allowed to fail, while Marker is still unstable. It's mostly
   # a sanity check, to make sure we don't have any unintentional API breakage :)
   semver-checks:
-    env:
-      PR_NUM: ${{ github.event.pull_request.number }}
     runs-on: ubuntu-latest
-    # This CI check isn't required to pass just yet.
-    # Marker isn't stable so semver breaking changes are allowed.
-    continue-on-error: true
     if: ${{ github.event.pull_request }}
     steps:
       - uses: actions/checkout@v4
@@ -165,6 +160,6 @@ jobs:
           --baseline-root './upstream'
           --default-features
           --release-type minor
-      - run: gh pr edit $PR_NUM --add-label "I-api-break"
-        if: ${{ github.repository == 'rust-marker/marker' && failure() }}
-      - run: echo "$PR_NUM"
+        # This CI check isn't required to pass just yet.
+        # Marker isn't stable so semver breaking changes are allowed.
+        continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,23 +140,31 @@ jobs:
   # This check is allowed to fail, while Marker is still unstable. It's mostly
   # a sanity check, to make sure we don't have any unintentional API breakage :)
   semver-checks:
+    env:
+      PR_NUM: ${{ github.event.pull_request.number }}
     runs-on: ubuntu-latest
+    # This CI check isn't required to pass just yet.
+    # Marker isn't stable so semver breaking changes are allowed.
+    continue-on-error: true
     if: ${{ github.event.pull_request }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref }}
-          path: './base'
+          path: './upstream'
       - uses: actions/checkout@v4
         with:
-          path: './source'
-      - run: source/scripts/download/cargo-semver-checks.sh
+          path: './downstream'
+      - run: downstream/scripts/download/cargo-semver-checks.sh
       - run: >-
           cargo semver-checks
-          --manifest-path './source/Cargo.toml'
+          --manifest-path './downstream/Cargo.toml'
           --package marker_api
           --package marker_utils
           --package marker_uitest
-          --baseline-root './base'
+          --baseline-root './upstream'
           --default-features
           --release-type minor
+      - run: gh pr edit $PR_NUM --add-label "I-api-break"
+        if: ${{ github.repository == 'rust-marker/marker' && failure() }}
+      - run: echo "$PR_NUM"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,11 +58,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # We don't need any cache here, so use dtolnay action directly
-      # The version of toolchain here should track the latest stable
-      # version of Rust. The version of `cargo fmt` we use here doesn't
-      # influence the version of Rust that is used when `cargo-marker` is built.
-      - uses: dtolnay/rust-toolchain@1.72.0
+      # rustfmt, might change some formatting between versions. This check should
+      # use the toolchain version from `rust-toolchain.toml` since that is also the
+      # version invoked during normal development in the repo. The formatting
+      # shouldn't matter for consumers of Marker. Therefore it's safe to use the
+      # nightly version of rustfmt
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo fmt --check
 
   # This job ensures required packages can be built with a stable toolchain
@@ -135,3 +136,27 @@ jobs:
 
       # Check that the release automation works as expected
       - run: scripts/release/test.sh
+
+  # This check is allowed to fail, while Marker is still unstable. It's mostly
+  # a sanity check, to make sure we don't have any unintentional API breakage :)
+  semver-checks:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          path: './base'
+      - uses: actions/checkout@v4
+        with:
+          path: './source'
+      - run: source/scripts/download/cargo-semver-checks.sh
+      - run: >-
+          cargo semver-checks
+          --manifest-path './source/Cargo.toml'
+          --package marker_api
+          --package marker_utils
+          --package marker_uitest
+          --baseline-root './base'
+          --default-features
+          --release-type minor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,9 @@ jobs:
   # a sanity check, to make sure we don't have any unintentional API breakage :)
   semver-checks:
     runs-on: ubuntu-latest
+    # This CI check isn't required to pass just yet.
+    # Marker isn't stable so semver breaking changes are allowed.
+    continue-on-error: true
     if: ${{ github.event.pull_request }}
     steps:
       - uses: actions/checkout@v4
@@ -160,6 +163,3 @@ jobs:
           --baseline-root './upstream'
           --default-features
           --release-type minor
-        # This CI check isn't required to pass just yet.
-        # Marker isn't stable so semver breaking changes are allowed.
-        continue-on-error: true

--- a/marker_api/src/ast/ty/fn_ty.rs
+++ b/marker_api/src/ast/ty/fn_ty.rs
@@ -64,7 +64,7 @@ pub struct SemClosureTy<'ast> {
 
 impl<'ast> SemClosureTy<'ast> {
     /// This returns the [`ItemId`] of the identified function.
-    pub fn closure_ty_id(&self) -> TyDefId {
+    pub fn closure_ty_d(&self) -> TyDefId {
         self.closure_ty_id
     }
 

--- a/scripts/download/cargo-semver-checks.sh
+++ b/scripts/download/cargo-semver-checks.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
+
+. $script_dir/lib.sh
+
+version=0.23.0
+
+base_url=https://github.com/obi1kenobi/cargo-semver-checks/releases/download/v$version
+
+file_stem=cargo-semver-checks-$triple_rust
+
+download_and_decompress $base_url/$file_stem.tar.gz
+
+move_to_path cargo-semver-checks


### PR DESCRIPTION
This PR adds [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks) to marker's CI, as a sanity check. This CI job shouldn't block a PR from being merged, but it's a good indicator, that a change should be listed in Marker's changelog.

Ideally, I would have liked a job status, between success and failed. Maybe a nice orange icon, saying that the job failed, but that that's acceptable? I know GitLab had something like this in the past, but GitHub doesn't seem to support it. It's either: success, failure, or cancelled. Oh well, an indicator is an indicator.

Here is an example, of a failed semver check, due to a removed public function: https://github.com/xFrednet/marker/actions/runs/6340462879/job/17221897343?pr=1

---

I should really stop procrastinating on my uni assignments... Oh well, at least this way I have the feeling I'm doing something useful.

Anyways:

Closes: rust-marker/marker#120

And anyone reading this, have a beautiful day :D