### PR TITLE
API: Undo accidental API break from rust-marker/marker#262

### DIFF
--- a/marker_api/src/ast/ty/fn_ty.rs
+++ b/marker_api/src/ast/ty/fn_ty.rs
@@ -42,7 +42,7 @@ pub struct SemClosureTy<'ast> {
 
 impl<'ast> SemClosureTy<'ast> {
     /// This returns the [`ItemId`] of the identified function.
-    pub fn closure_ty_d(&self) -> TyDefId {
+    pub fn closure_ty_id(&self) -> TyDefId {
         self.closure_ty_id
     }
 


### PR DESCRIPTION
I broke the API for testing in rust-marker/marker#262, but forgot to undo the change before merging. This just corrects the mistake. 