### PR TITLE
uitest: Don't bless by default

### DIFF
--- a/marker_lints/tests/uitest.rs
+++ b/marker_lints/tests/uitest.rs
@@ -6,19 +6,8 @@ fn main() -> color_eyre::Result<()> {
 
     config.dependencies_crate_manifest_path = Some("./Cargo.toml".into());
 
-    let bless = env::var_os("BLESS").is_some() || env::args().any(|arg| arg == "--bless");
-    if bless {
-        config.output_conflict_handling = OutputConflictHandling::Bless
-    }
-
-    let filters = [
-        // Normalization for windows...
-        (r"ui//", "ui/"),
-    ];
-    for (pat, repl) in filters {
-        config.stderr_filter(pat, repl);
-        config.stdout_filter(pat, repl);
-    }
+    config.filter(r"\\/", "/");
+    config.filter(r"\\\\", "/");
 
     run_tests_generic(
         vec![config],

--- a/marker_uilints/tests/uitest.rs
+++ b/marker_uilints/tests/uitest.rs
@@ -2,25 +2,10 @@ use marker_uitest::ui_test::*;
 use std::env;
 
 fn main() -> color_eyre::Result<()> {
-    let mut config = marker_uitest::simple_ui_test_config!("tests/ui", "../target")?;
+    let mut config: Config = marker_uitest::simple_ui_test_config!("tests/ui", "../target")?;
 
-    let bless = env::var_os("BLESS").is_some() || env::args().any(|arg| arg == "--bless");
-    if bless {
-        config.output_conflict_handling = OutputConflictHandling::Bless
-    }
-
-    let filters = [
-        // Normalization for windows...
-        (r"ui//", "ui/"),
-        (r"item//", "item/"),
-        (r"expr//", "expr/"),
-        (r"sugar//", "sugar/"),
-        (r"context//", "context/"),
-    ];
-    for (pat, repl) in filters {
-        config.stderr_filter(pat, repl);
-        config.stdout_filter(pat, repl);
-    }
+    config.filter(r"\\/", "/");
+    config.filter(r"\\\\", "/");
 
     run_tests_generic(
         vec![config],

--- a/marker_uitest/src/lib.rs
+++ b/marker_uitest/src/lib.rs
@@ -76,6 +76,12 @@ pub fn create_ui_test_config(
         env::set_var(key, val);
     }
 
+    let output_conflict_handling = if env::var_os("RUST_BLESS").is_some() || env::args().any(|arg| arg == "--bless") {
+        ui_test::OutputConflictHandling::Bless
+    } else {
+        ui_test::OutputConflictHandling::Error("cargo test -- -- --bless".into())
+    };
+
     // Create config
     let mut config = ui_test::Config {
         mode: ui_test::Mode::Yolo {
@@ -85,6 +91,7 @@ pub fn create_ui_test_config(
             .map(|filters| filters.split(',').map(str::to_string).collect())
             .unwrap_or_default(),
         out_dir: fs::canonicalize(target_dir)?,
+        output_conflict_handling,
         ..ui_test::Config::rustc(ui_dir)
     };
 


### PR DESCRIPTION
The `ui_test` update from rust-marker/marker#263 changed the process, to bless by default. This was unexpected for me, and can lead to users thinking that a test passed, even if it should have failed.

See: https://github.com/rust-marker/marker/pull/268#discussion_r1343790060 as an example
