### PR TITLE
Rustc: Librarify `marker_rustc_driver`

### DIFF
--- a/marker_rustc_driver/Cargo.toml
+++ b/marker_rustc_driver/Cargo.toml
@@ -9,6 +9,9 @@ license    = { workspace = true }
 repository = { workspace = true }
 version    = { workspace = true }
 
+[lib]
+doctest = false
+
 [dependencies]
 marker_adapter = { workspace = true }
 marker_api     = { workspace = true, features = ["driver-api"] }

--- a/marker_rustc_driver/src/bin/marker_rustc_driver.rs
+++ b/marker_rustc_driver/src/bin/marker_rustc_driver.rs
@@ -1,29 +1,12 @@
 #![doc = include_str!("../../README.md")]
 #![feature(rustc_private)]
 #![feature(lint_reasons)]
-#![feature(non_exhaustive_omitted_patterns_lint)]
 #![warn(clippy::pedantic)]
-#![warn(non_exhaustive_omitted_patterns)]
 #![allow(clippy::missing_panics_doc)]
-#![allow(clippy::module_name_repetitions)]
-#![allow(clippy::needless_lifetimes, reason = "lifetimes will be required to fix ICEs")]
-#![allow(clippy::needless_collect, reason = "false positives for `alloc_slice`")]
-#![allow(clippy::too_many_lines, reason = "long functions are unavoidable for matches")]
 
-extern crate rustc_ast;
-extern crate rustc_data_structures;
 extern crate rustc_driver;
-extern crate rustc_errors;
-extern crate rustc_hash;
-extern crate rustc_hir;
-extern crate rustc_hir_analysis;
-extern crate rustc_interface;
-extern crate rustc_lint;
-extern crate rustc_lint_defs;
-extern crate rustc_middle;
 extern crate rustc_session;
 extern crate rustc_span;
-extern crate rustc_target;
 
 use std::env;
 

--- a/marker_rustc_driver/src/bin/marker_rustc_driver.rs
+++ b/marker_rustc_driver/src/bin/marker_rustc_driver.rs
@@ -1,0 +1,68 @@
+#![doc = include_str!("../../README.md")]
+#![feature(rustc_private)]
+#![feature(lint_reasons)]
+#![feature(non_exhaustive_omitted_patterns_lint)]
+#![warn(clippy::pedantic)]
+#![warn(non_exhaustive_omitted_patterns)]
+#![allow(clippy::missing_panics_doc)]
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::needless_lifetimes, reason = "lifetimes will be required to fix ICEs")]
+#![allow(clippy::needless_collect, reason = "false positives for `alloc_slice`")]
+#![allow(clippy::too_many_lines, reason = "long functions are unavoidable for matches")]
+
+extern crate rustc_ast;
+extern crate rustc_data_structures;
+extern crate rustc_driver;
+extern crate rustc_errors;
+extern crate rustc_hash;
+extern crate rustc_hir;
+extern crate rustc_hir_analysis;
+extern crate rustc_interface;
+extern crate rustc_lint;
+extern crate rustc_lint_defs;
+extern crate rustc_middle;
+extern crate rustc_session;
+extern crate rustc_span;
+extern crate rustc_target;
+
+use std::env;
+
+use rustc_session::config::ErrorOutputType;
+use rustc_session::EarlyErrorHandler;
+
+use marker_rustc_driver::{try_main, MainError};
+
+const BUG_REPORT_URL: &str = "https://github.com/rust-marker/marker/issues/new?template=panic.yml";
+
+fn main() {
+    let handler = EarlyErrorHandler::new(ErrorOutputType::default());
+    rustc_driver::init_rustc_env_logger(&handler);
+
+    // FIXME(xFrednet): The ICE hook would ideally distinguish where the error
+    // happens. Panics from lint crates should probably not terminate Marker
+    // completely, but instead warn the user and continue linting with the other
+    // lint crate. It would also be cool if the ICE hook printed the node that
+    // caused the panic in the lint crate. rust-marker/marker#10
+
+    rustc_driver::install_ice_hook(BUG_REPORT_URL, |handler| {
+        handler.note_without_error(format!("{}", rustc_tools_util::get_version_info!()));
+        handler.note_without_error("Achievement Unlocked: [Free Ice Cream]");
+    });
+
+    std::process::exit(rustc_driver::catch_with_exit_code(|| {
+        try_main(env::args()).map_err(|err| {
+            let err = match err {
+                MainError::Custom(err) => err,
+                MainError::Rustc(err) => return err,
+            };
+
+            // Emit the error to stderr
+            err.print();
+
+            // This is a bit of a hack, but this way we can emit our own errors
+            // without having to change the rustc driver.
+            #[expect(deprecated)]
+            rustc_span::ErrorGuaranteed::unchecked_claim_error_was_emitted()
+        })
+    }))
+}

--- a/marker_rustc_driver/src/lib.rs
+++ b/marker_rustc_driver/src/lib.rs
@@ -14,6 +14,7 @@
 #![allow(clippy::needless_lifetimes, reason = "lifetimes will be required to fix ICEs")]
 #![allow(clippy::needless_collect, reason = "false positives for `alloc_slice`")]
 #![allow(clippy::too_many_lines, reason = "long functions are unavoidable for matches")]
+#![allow(rustdoc::private_intra_doc_links)]
 
 extern crate rustc_ast;
 extern crate rustc_data_structures;

--- a/marker_rustc_driver/src/lib.rs
+++ b/marker_rustc_driver/src/lib.rs
@@ -199,6 +199,7 @@ interfacing with the driver directly and use `cargo marker` instead.
     );
 }
 
+#[allow(clippy::missing_errors_doc)]
 pub fn try_main(args: impl Iterator<Item = String>) -> Result<(), MainError> {
     // Note: This driver has two different kinds of "arguments".
     // 1. Normal arguments, passed directly to the binary. (Collected below)

--- a/marker_rustc_driver/src/lint_pass.rs
+++ b/marker_rustc_driver/src/lint_pass.rs
@@ -24,6 +24,7 @@ thread_local! {
 pub struct RustcLintPass;
 
 impl RustcLintPass {
+    #[allow(clippy::missing_errors_doc)]
     pub fn init_adapter(lint_crates: &[LintCrateInfo]) -> Result<(), marker_adapter::Error> {
         ADAPTER.with(move |cell| {
             cell.get_or_try_init(|| Adapter::new(lint_crates))?;
@@ -31,6 +32,7 @@ impl RustcLintPass {
         })
     }
 
+    #[must_use]
     pub fn marker_lints() -> Vec<&'static Lint> {
         ADAPTER.with(|adapter| adapter.get().unwrap().marker_lints())
     }

--- a/marker_rustc_driver/src/lint_pass.rs
+++ b/marker_rustc_driver/src/lint_pass.rs
@@ -46,7 +46,7 @@ impl<'tcx> rustc_lint::LateLintPass<'tcx> for RustcLintPass {
     }
 }
 
-fn process_crate(rustc_cx: &rustc_lint::LateContext<'_>, adapter: &Adapter) {
+pub fn process_crate(rustc_cx: &rustc_lint::LateContext<'_>, adapter: &Adapter) {
     let storage = Storage::default();
     process_crate_lifetime(rustc_cx, &storage, adapter);
 }

--- a/marker_rustc_driver/src/main.rs
+++ b/marker_rustc_driver/src/main.rs
@@ -1,4 +1,4 @@
-//! This is the source file for the `rustc_marker_driver` binary. However, the bulk of its logic is
+//! This is the source file for the `marker_rustc_driver` binary. However, the bulk of its logic is
 //! in `../lib.rs`.
 
 #![doc = include_str!("../README.md")]

--- a/marker_rustc_driver/src/main.rs
+++ b/marker_rustc_driver/src/main.rs
@@ -1,7 +1,7 @@
 //! This is the source file for the `rustc_marker_driver` binary. However, the bulk of its logic is
 //! in `../lib.rs`.
 
-#![doc = include_str!("../../README.md")]
+#![doc = include_str!("../README.md")]
 #![feature(rustc_private)]
 #![feature(lint_reasons)]
 #![warn(clippy::pedantic)]

--- a/marker_rustc_driver/src/main.rs
+++ b/marker_rustc_driver/src/main.rs
@@ -1,3 +1,6 @@
+//! This is the source file for the `rustc_marker_driver` binary. However, the bulk of its logic is
+//! in `../lib.rs`.
+
 #![doc = include_str!("../../README.md")]
 #![feature(rustc_private)]
 #![feature(lint_reasons)]


### PR DESCRIPTION
Fixes #257

How do you feel about this?

I would summarize the changes as follows:
- marker_rustc_driver/src/bin/marker_rustc_driver.rs is a new file that contains a slightly modified version of the old `main` function.
- `try_main` was updated to accept an `impl Iterator<Item = String>`. `main` passes `std::env::args()` as this argument.[^1^]
- The following were made `pub`:
  - `try_main`
  - `lint_pass`
  - `MainError`
  - `process_crate`

---

[^1^]: This change was not strictly necessary. But since `try_main` is now a public function, the idea of it reading from `std::env::args()` directly seemed weird to me.