### PR TITLE
Use region replacements for release/dev rust toolchain versions

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -137,7 +137,7 @@ jobs:
       - run: |
           cat <<EOF >> $GITHUB_ENV
           install_script<<DELIM
-            rust_version=$(sed -n 's/^channel = "\(.*\)"/\1/p' rust-toolchain.toml)
+            rust_version=$(sed -n 's/^channel\s*=\s*"\(.*\)"/\1/p' rust-toolchain.toml)
             $(cat scripts/lib.sh scripts/release/qemu-setup.sh)
           DELIM
           EOF

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,11 +166,11 @@ The following is a small collection of ways you can test Marker right now:
 
     Simply run Marker on any Rust project you can find and report bugs or unexpected behavior. Once you've installed Marker, you can use the following command to run Marker with the `marker_lints` lint crate:
 
-<!-- region replace-version stable -->
+<!-- region replace marker version stable -->
     ```sh
     cargo marker --lints "marker_lints = '0.3.0'"
     ```
-<!-- endregion replace-version stable -->
+<!-- endregion replace marker version stable -->
 
     If you find any bugs or unexpected behavior, please [create an issue]. [rust-marker/marker#198] is a collection of all crates that were linted successfully. You can also add your own crates to the ever-growing list by commenting on the issue.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,21 +23,21 @@ keywords   = ["marker", "lint"]
 license    = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-marker/marker"
 
-# region replace-version dev
+# region replace marker version dev
 version = "0.4.0-dev"
-# endregion replace-version dev
+# endregion replace marker version dev
 
 # The MSRV is applied to the public library crates published to crates.io
 rust-version = "1.66"
 
 [workspace.dependencies]
-# region replace-version dev
+# region replace marker version dev
 marker_adapter = { path = "./marker_adapter", version = "0.4.0-dev" }
 marker_api     = { path = "./marker_api", version = "0.4.0-dev" }
 marker_error   = { path = "./marker_error", version = "0.4.0-dev" }
 marker_uitest  = { path = "./marker_uitest", features = ["dev-build"] }
 marker_utils   = { path = "./marker_utils", version = "0.4.0-dev" }
-# endregion replace-version dev
+# endregion replace marker version dev
 
 bumpalo            = "3.14"
 camino             = { version = "1.1", features = ["serde1"] }

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ We provide pre-compiled binaries for the mainstream platforms. See the list of a
 
 Select one of the installation scripts below according to your platform. The script will install the required Rust toolchain dependency on your machine, download the current version of `cargo-marker` CLI, and the internal driver.
 
-<!-- region replace-version stable -->
+<!-- region replace marker version stable -->
 
 **Linux or MacOS (Bash)**:
 ```bash
@@ -61,7 +61,7 @@ curl.exe -fsSL https://raw.githubusercontent.com/rust-marker/marker/v0.3/scripts
 
 The provided scripts use a sliding git tag `v0.3`, to allow for automatic patch version updates, however a fixed tag `v0.3.0` is also available.
 
-<!-- endregion replace-version stable -->
+<!-- endregion replace marker version stable -->
 
 If you are on a platform that isn't supported yet by the pre-compiled binaries, then you should fall back to building from sources as described below.
 
@@ -78,7 +78,7 @@ cargo marker setup --auto-install-toolchain
 
 Marker provides a Github Action that downloads the pre-compiled binaries and runs `cargo marker`.
 
-<!-- region replace-version stable -->
+<!-- region replace marker version stable -->
 
 ```yml
 - uses: rust-marker/marker@v0.3
@@ -97,13 +97,13 @@ If you want to only install Marker, and not run it, there is an option for that.
 
 See [The Marker Book] for more details and examples of workflows.
 
-<!-- endregion replace-version stable -->
+<!-- endregion replace marker version stable -->
 
 ### Specifying lints
 
 Marker requires lint crates to be specified. The best way is to add them to the `Cargo.toml` file, like this:
 
-<!-- region replace-version stable -->
+<!-- region replace marker version stable -->
 ```toml
 [workspace.metadata.marker.lints]
 # A local crate as a path
@@ -113,7 +113,7 @@ marker_lints = { git = "https://github.com/rust-marker/marker" }
 # An external crate from a registry
 marker_lints = "0.3.0"
 ```
-<!-- endregion replace-version stable -->
+<!-- endregion replace marker version stable -->
 
 ### Making Your Own Lints
 

--- a/cargo-marker/README.md
+++ b/cargo-marker/README.md
@@ -16,10 +16,12 @@
 
 ## Key Features
 
+<!-- region replace rust toolchain release -->
 * **Simple CLI**: *cargo_marker* does all the heavy lifting for you, making custom code analysis, as simple as a single console command.
 * **Seamless Integration**: *cargo_marker* reuses Rust's existing infrastructure for linting, running Marker as part of your workflow is close to the effort needed for its sibling *[Clippy]*.
 * **Automatic Lint-Crate Compilation**: *cargo_marker* automatically fetches and builds specified lint crates, streamlining the process of incorporating additional linting rules into your project.
 * **User-Friendly Setup**: *cargo_marker* can automatically set up the driver and toolchain, allowing you to focus on writing quality code. (This version will setup rustc's driver for `nightly-2023-08-24`)
+<!-- endregion replace rust toolchain release -->
 
 [Clippy]: https://github.com/rust-lang/rust-clippy
 

--- a/cargo-marker/src/backend/driver.rs
+++ b/cargo-marker/src/backend/driver.rs
@@ -16,11 +16,13 @@ pub fn marker_driver_bin_name() -> String {
 /// to install the driver.
 pub(crate) fn default_driver_info() -> DriverVersionInfo {
     DriverVersionInfo {
+        // region replace rust toolchain dev
         toolchain: "nightly-2023-08-24".to_string(),
-        // region replace-version dev
+        // endregion replace rust toolchain dev
+        // region replace marker version dev
         version: "0.4.0-dev".to_string(),
         api_version: "0.4.0-dev".to_string(),
-        // endregion replace-version dev
+        // endregion replace marker version dev
     }
 }
 

--- a/cargo-marker/src/error.rs
+++ b/cargo-marker/src/error.rs
@@ -50,7 +50,7 @@ or:
     BuildDriver,
 }
 
-// region replace-version stable
+// region replace marker version stable
 fn help_for_no_lints() -> String {
     format!(
         r#"The are two ways to specify lints.
@@ -76,7 +76,7 @@ marker_lints = "0.3.0""#
         lints = "--lints".blue(),
     )
 }
-// endregion replace-version stable
+// endregion replace marker version stable
 
 fn help_for_driver_not_found() -> String {
     format!(

--- a/docs/book/src/usage/ci.md
+++ b/docs/book/src/usage/ci.md
@@ -8,7 +8,7 @@ Marker's primary objective is to offer an excellent linting interface, including
 
 Marker provides a GitHub Action that downloads the pre-compiled binaries and runs `cargo marker`.
 
-<!-- region replace-version stable -->
+<!-- region replace marker version stable -->
 
 ```yml
 - uses: rust-marker/marker@v0.3
@@ -26,7 +26,7 @@ The git tag specified in the GitHub Action indicates which version of Marker sho
 
   Use this to pin a specific patch version. If you find a regression in a patch version, please create a [new issue]. Patch versions must never break anything!
 
-<!-- endregion replace-version stable -->
+<!-- endregion replace marker version stable -->
 
 > ⚠️ The minor versions before Marker `v1` contain breaking changes. While there is a sliding `v0` tag, it's highly recommended to include the minor version as well. This prevents uncontrolled CI breakage with every release.
 
@@ -100,7 +100,7 @@ These curl commands differ slightly from the scripts mentioned in the [installat
 
 You can run these scripts on any CI system of your choice, and they will make the `cargo marker` command available for you.
 
-<!-- region replace-version stable -->
+<!-- region replace marker version stable -->
 
 **Linux or MacOS (Bash)**:
 ```bash
@@ -128,7 +128,7 @@ curl.exe `
     | powershell -command -
 ```
 
-<!-- endregion replace-version stable -->
+<!-- endregion replace marker version stable -->
 
 The available version git tags that you may use in the URL are described in the [git tags](#git-tags) paragraph of the Github Action.
 

--- a/docs/book/src/usage/installation.md
+++ b/docs/book/src/usage/installation.md
@@ -19,7 +19,7 @@ We provide pre-compiled binaries for the mainstream platforms. See the list of a
 
 Select one of the installation scripts below according to your platform. The script will install the required Rust toolchain dependency on your machine, download the current version of `cargo-marker` CLI, and the internal driver.
 
-<!-- region replace-version stable -->
+<!-- region replace marker version stable -->
 
 **Linux or MacOS (Bash)**:
 ```bash
@@ -33,7 +33,7 @@ curl.exe -fsSL https://raw.githubusercontent.com/rust-marker/marker/v0.3/scripts
 
 The provided scripts use a sliding git tag `v0.3`, to allow for automatic patch version updates, however a fixed tag `v0.3.0` is also available.
 
-<!-- endregion replace-version stable -->
+<!-- endregion replace marker version stable -->
 
 If you are on a platform that isn't supported yet by the pre-compiled binaries, then you should fall back to building from sources as described below.
 

--- a/docs/book/src/usage/lint-crate-declaration.md
+++ b/docs/book/src/usage/lint-crate-declaration.md
@@ -8,7 +8,7 @@ Marker in itself, is a linting interface. The actual code analysis is implemente
 
 The main way to declare lint crates, is to add them to the `Cargo.toml` file under the `[workspace.metadata.marker.lints]` section. There they can be defined like a normal dependency, with a version, git repository, or path. This is a short example of the three methods:
 
-<!-- region replace-version stable -->
+<!-- region replace marker version stable -->
 ```toml
 [workspace.metadata.marker.lints]
 # An external crate from a registry
@@ -20,7 +20,7 @@ marker_lints = { git = "https://github.com/rust-marker/marker" }
 # A local crate as a path
 marker_lints = { path = './marker_lints' }
 ```
-<!-- endregion replace-version stable -->
+<!-- endregion replace marker version stable -->
 
 ## Declaration as arguments
 
@@ -28,7 +28,7 @@ Lints can also be declared as arguments to the `cargo marker` command. Marker wi
 
 A lint crate can be specified with the `--lints` option. The string is expected to have the same format, that would be used in the `Cargo.toml` file. Here is an example for the same lint crates specified above:
 
-<!-- region replace-version stable -->
+<!-- region replace marker version stable -->
 ```sh
 # An external crate from a registry
 cargo marker --lint "marker_lints = '0.3.0'"
@@ -39,4 +39,4 @@ cargo marker --lint "marker_lints = { git = 'https://github.com/rust-marker/mark
 # A local crate as a path
 cargo marker --lint "marker_lints = { path = './marker_lints' }"
 ```
-<!-- endregion replace-version stable -->
+<!-- endregion replace marker version stable -->

--- a/docs/internal/release.md
+++ b/docs/internal/release.md
@@ -30,9 +30,9 @@ GitHub is very generous with the releases storage limits. They are [almost unlim
 
 The `sha256` sum is a small file that users may optionally download together with the archive itself to verify the integrity of the archive. It serves as a signature of the artifact to make sure it was downloaded as expected bit-by-bit with what was published effectively detecting corruptions during the download and making it harder to forge artifacts for malicious actors.
 
-<!-- region replace-version stable -->
+<!-- region replace marker version stable -->
 This [`install.sh`](https://raw.githubusercontent.com/rust-marker/marker/v0.3.0/scripts/release/install.sh) script, can be used to automatically download and verify Marker's binaries.
-<!-- endregion replace-version stable -->
+<!-- endregion replace marker version stable -->
 
 ### Operating system versions coverage
 

--- a/marker_api/README.md
+++ b/marker_api/README.md
@@ -40,7 +40,7 @@ The simplest way to get started, is to use Marker's [lint crate template], which
 
 To get started, create a new Rust crate that compiles to a library (`cargo init --lib`). Afterwards, edit the `Cargo.toml` to compile the crate to a dynamic library and include `marker_api` as a dependency. You can simply add the following to your `Cargo.toml` file:
 
-<!-- region replace-version stable -->
+<!-- region replace marker version stable -->
 ```toml
 [lib]
 crate-type = ["cdylib"]
@@ -49,7 +49,7 @@ crate-type = ["cdylib"]
 marker_api = "0.3.0"
 marker_utils = "0.3.0"
 ```
-<!-- endregion replace-version stable -->
+<!-- endregion replace marker version stable -->
 
 #### src/lib.rs
 

--- a/marker_lints/README.md
+++ b/marker_lints/README.md
@@ -25,12 +25,12 @@ This crate currently provides the following lints:
 
 To use `marker_lints` in your project, simply add it to your `Cargo.toml` under the `[workspace.metadata.marker.lints]` section. [cargo_marker] will then automatically fetch the crate and include is when running `cargo marker`.
 
-<!-- region replace-version stable -->
+<!-- region replace marker version stable -->
 ```toml
 [workspace.metadata.marker.lints]
 marker_lints = "0.3.0"
 ```
-<!-- endregion replace-version stable -->
+<!-- endregion replace marker version stable -->
 
 If you want to develop something with Marker, you might want to check out the [lint crate template] which already contains everything you need to get started.
 

--- a/marker_rustc_driver/README.md
+++ b/marker_rustc_driver/README.md
@@ -17,7 +17,9 @@ The rustc driver for [Marker], an experimental linting interface for Rust. This 
 
 ## Toolchain
 
+<!-- region replace rust toolchain release -->
 The driver is linked to a specific nightly rust toolchain. The crate will be updated about every six weeks with a new release of Rust. This version of the driver has been developed for: `nightly-2023-08-24`
+<!-- endregion replace rust toolchain release -->
 
 ## Contributing
 
@@ -30,4 +32,3 @@ Copyright (c) 2022-2023 Rust-Marker
 Rust-marker is distributed under the terms of the MIT license or the Apache License (Version 2.0).
 
 See [LICENSE-APACHE](https://github.com/rust-marker/marker/blob/master/LICENSE-APACHE), [LICENSE-MIT](https://github.com/rust-marker/marker/blob/master/LICENSE-MIT).
-

--- a/marker_rustc_driver/src/main.rs
+++ b/marker_rustc_driver/src/main.rs
@@ -47,7 +47,9 @@ use rustc_session::EarlyErrorHandler;
 
 use crate::conversion::rustc::RustcConverter;
 
+// region replace rust toolchain dev
 const RUSTC_TOOLCHAIN_VERSION: &str = "nightly-2023-08-24";
+// endregion replace rust toolchain dev
 
 struct DefaultCallbacks {
     env_vars: Vec<(&'static str, String)>,

--- a/marker_uitest/README.md
+++ b/marker_uitest/README.md
@@ -28,7 +28,7 @@ For a full list of supported features and magic comments, please refer to the do
 
 First add `marker_utils` to the dev-dependencies of the lint crate, and specify that the ui-test doesn't require a test harness, like this:
 
-<!-- region replace-version stable -->
+<!-- region replace marker version stable -->
 ```toml
 [dev-dependencies]
 marker_uitest = "0.3.0"
@@ -37,7 +37,7 @@ marker_uitest = "0.3.0"
 name = "uitest"
 harness = false
 ```
-<!-- endregion replace-version stable -->
+<!-- endregion replace marker version stable -->
 
 ### Setup test file
 

--- a/marker_utils/README.md
+++ b/marker_utils/README.md
@@ -19,7 +19,7 @@ Marker utils aims to be the standard library for the development of lint crates 
 
 To get started, just include *marker_utils* as a dependency:
 
-<!-- region replace-version stable -->
+<!-- region replace marker version stable -->
 ```toml
 [dependencies]
 marker_api = "0.3.0"
@@ -31,7 +31,7 @@ You can also add [marker_lints] as a lint crate, designed for this crate:
 [workspace.metadata.marker.lints]
 marker_lints = "0.3.0"
 ```
-<!-- endregion replace-version stable -->
+<!-- endregion replace marker version stable -->
 
 If you want to develop something with Marker, you might want to check out the [lint crate template] which already contains everything you need to get started.
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,7 @@
 [toolchain]
+# region replace rust toolchain dev
 channel = "nightly-2023-08-24"
+# endregion replace rust toolchain dev
 components = [
   "cargo",
   "clippy",

--- a/scripts/release/install.ps1
+++ b/scripts/release/install.ps1
@@ -45,11 +45,13 @@ $ErrorActionPreference = "Stop"
 
 # This script isn't meant to be run from `master`, but if it is, then
 # it will install the latest version be it a stable version or a pre-release.
-# region replace-version unstable
+# region replace marker version unstable
 $version = "0.3.0"
-# endregion replace-version unstable
+# endregion replace marker version unstable
 
+# region replace rust toolchain release
 $toolchain = "nightly-2023-08-24"
+# endregion replace rust toolchain release
 
 # Log the command, execute, and fail if its exit code is non-zero.
 # Surprisingly PowerShell can't do the exit code checks for us out of the box.

--- a/scripts/release/install.sh
+++ b/scripts/release/install.sh
@@ -16,11 +16,13 @@ set -euo pipefail
 
 # This script isn't meant to be run from `master`, but if it is, then
 # it will install the latest version be it a stable version or a pre-release.
-# region replace-version unstable
+# region replace marker version unstable
 version=0.3.0
-# endregion replace-version unstable
+# endregion replace marker version unstable
 
+# region replace rust toolchain release
 toolchain=nightly-2023-08-24
+# endregion replace rust toolchain release
 
 function step {
     local cmd="$1"

--- a/scripts/release/set-version.diff
+++ b/scripts/release/set-version.diff
@@ -44,11 +44,11 @@
  dependencies = [
 
 === Cargo.toml ===
- # region replace-version dev
+ # region replace marker version dev
 -version = "X.Y.Z-dev"
 +version = "0.1.0"
- # endregion replace-version dev
- # region replace-version dev
+ # endregion replace marker version dev
+ # region replace marker version dev
 -marker_adapter = { path = "./marker_adapter", version = "X.Y.Z-dev" }
 -marker_api     = { path = "./marker_api", version = "X.Y.Z-dev" }
 -marker_error   = { path = "./marker_error", version = "X.Y.Z-dev" }
@@ -58,7 +58,7 @@
  marker_uitest  = { path = "./marker_uitest", features = ["dev-build"] }
 -marker_utils   = { path = "./marker_utils", version = "X.Y.Z-dev" }
 +marker_utils   = { path = "./marker_utils", version = "0.1.0" }
- # endregion replace-version dev
+ # endregion replace marker version dev
 
 === README.md ===
  ```bash
@@ -86,13 +86,20 @@
 +marker_lints = "0.1.0"
  ```
 
+=== cargo-marker/README.md ===
+@@ -22,3 +22,3 @@
+ * **Automatic Lint-Crate Compilation**: *cargo_marker* automatically fetches and builds specified lint crates, streamlining the process of incorporating additional linting rules into your project.
+-* **User-Friendly Setup**: *cargo_marker* can automatically set up the driver and toolchain, allowing you to focus on writing quality code. (This version will setup rustc's driver for `nightly-YYYY-MM-DD`)
++* **User-Friendly Setup**: *cargo_marker* can automatically set up the driver and toolchain, allowing you to focus on writing quality code. (This version will setup rustc's driver for `nightly-2023-01-01`)
+ <!-- endregion replace rust toolchain release -->
+
 === cargo-marker/src/backend/driver.rs ===
-         // region replace-version dev
+         // region replace marker version dev
 -        version: "X.Y.Z-dev".to_string(),
 -        api_version: "X.Y.Z-dev".to_string(),
 +        version: "0.1.0".to_string(),
 +        api_version: "0.1.0".to_string(),
-         // endregion replace-version dev
+         // endregion replace marker version dev
 
 === cargo-marker/src/error.rs ===
  # An external crate from a registry
@@ -150,10 +157,10 @@
  
 
 === docs/internal/release.md ===
- <!-- region replace-version stable -->
+ <!-- region replace marker version stable -->
 -This [`install.sh`](https://raw.githubusercontent.com/rust-marker/marker/vX.Y.Z/scripts/release/install.sh) script, can be used to automatically download and verify Marker's binaries.
 +This [`install.sh`](https://raw.githubusercontent.com/rust-marker/marker/v0.1.0/scripts/release/install.sh) script, can be used to automatically download and verify Marker's binaries.
- <!-- endregion replace-version stable -->
+ <!-- endregion replace marker version stable -->
 
 === marker_api/README.md ===
  [dependencies]
@@ -168,6 +175,12 @@
 -marker_lints = "X.Y.Z"
 +marker_lints = "0.1.0"
  ```
+
+=== marker_rustc_driver/README.md ===
+ <!-- region replace rust toolchain release -->
+-The driver is linked to a specific nightly rust toolchain. The crate will be updated about every six weeks with a new release of Rust. This version of the driver has been developed for: `nightly-YYYY-MM-DD`
++The driver is linked to a specific nightly rust toolchain. The crate will be updated about every six weeks with a new release of Rust. This version of the driver has been developed for: `nightly-2023-01-01`
+ <!-- endregion replace rust toolchain release -->
 
 === marker_uitest/README.md ===
  [dev-dependencies]
@@ -186,13 +199,21 @@
  ```
 
 === scripts/release/install.ps1 ===
- # region replace-version unstable
+ # region replace marker version unstable
 -$version = "X.Y.Z"
 +$version = "0.1.0"
- # endregion replace-version unstable
+ # endregion replace marker version unstable
+ # region replace rust toolchain release
+-$toolchain = "nightly-YYYY-MM-DD"
++$toolchain = "nightly-2023-01-01"
+ # endregion replace rust toolchain release
 
 === scripts/release/install.sh ===
- # region replace-version unstable
+ # region replace marker version unstable
 -version=X.Y.Z
 +version=0.1.0
- # endregion replace-version unstable
+ # endregion replace marker version unstable
+ # region replace rust toolchain release
+-toolchain=nightly-YYYY-MM-DD
++toolchain=nightly-2023-01-01
+ # endregion replace rust toolchain release

--- a/scripts/replace-in-regions.sh
+++ b/scripts/replace-in-regions.sh
@@ -11,11 +11,6 @@ function replace_in_regions_for_file {
     local comment_end="( -->)?$"
 
     # Replace both the version itself, and the sliding tags
-    #
-    # There is a caveat here for the major version. It is rather ambiguous, because
-    # it is just a single number, there are no dots in it that could identify it as
-    # semver version. So for the major version we require that it is always specified
-    # with the `v` prefix e.g. `v1`.
     with_log sed --regexp-extended --follow-symlinks --in-place --file - "$file" <<EOF
         /$comment_begin region $region$comment_end/,/$comment_begin endregion $region$comment_end/ \
         {

--- a/scripts/replace-in-regions.sh
+++ b/scripts/replace-in-regions.sh
@@ -1,0 +1,81 @@
+. $(dirname ${BASH_SOURCE[0]})/lib.sh
+
+# Replaces text using a sed pattern in the region of the file surrounded by
+# `region replace {region}` and `endregion replace {region}` comments.
+function replace_in_regions_for_file {
+    local file="$1"
+    local region="replace $2"
+    local sed_pattern="$3"
+
+    local comment_begin="(#|\/\/|<!--)"
+    local comment_end="( -->)?$"
+
+    # Replace both the version itself, and the sliding tags
+    #
+    # There is a caveat here for the major version. It is rather ambiguous, because
+    # it is just a single number, there are no dots in it that could identify it as
+    # semver version. So for the major version we require that it is always specified
+    # with the `v` prefix e.g. `v1`.
+    with_log sed --regexp-extended --follow-symlinks --in-place --file - "$file" <<EOF
+        /$comment_begin region $region$comment_end/,/$comment_begin endregion $region$comment_end/ \
+        {
+            $sed_pattern
+        }
+EOF
+}
+
+# Applies a sed replacement pattern within the desired regions to all files in the repo
+function replace_in_regions {
+    local file_patterns=(
+        .
+        :!:scripts/release/set-version.diff
+    )
+
+    for file in $(with_log git ls-files -- "${file_patterns[@]}"); do
+        replace_in_regions_for_file "$file" "$@"
+    done
+}
+
+# Replaces semver patterns `X.Y.X(-suffix)?`, `X.Y` and `vX` within the desired
+# regions in all files in the repo.
+#
+# There is a caveat here for the major version. It is rather ambiguous, because
+# it is just a single number, there are no dots in it that could identify it as
+# semver version. So for the major version we require that it is always specified
+# with the `v` prefix e.g. `v1`.
+function replace_semver_in_regions {
+    local region="$1"
+    local x_y_z="$2"
+
+    local suffix='(-[0-9a-zA-Z.\-]+)?'
+    local num='[0-9]+'
+    local pattern="$num\.$num\.$num$suffix"
+
+    if ! [[ "$x_y_z" =~ ^$pattern$ ]]; then
+        die "Please enter a valid semver version like '1.2.3'. Got '$x_y_z'."
+    fi
+
+    local x_y=$(echo "$x_y_z" | cut --delimiter . --fields 1-2)
+    local x=$(echo "$x_y_z" | cut --delimiter . --fields 1)
+
+    replace_in_regions "$region" "
+        s/(v|\W)$pattern/\1$x_y_z/g
+        s/(v|\W)$num\.$num$suffix/\1$x_y/g
+        s/v$num$suffix/v$x/g
+    "
+}
+
+# Replaces date patterns `YYYY-MM-DD` within the desired regions in all files in the repo.
+function replace_date_in_regions {
+    local region="$1"
+    local date="$2"
+
+    local d='[0-9]'
+    local pattern="$d{4}-$d{2}-$d{2}"
+
+    if ! [[ "$date" =~ ^$pattern$ ]]; then
+        die "Please enter a valid date like '2022-01-01'. Got '$date'."
+    fi
+
+    replace_in_regions "$region" "s/$pattern/$date/g"
+}

--- a/scripts/update-toolchain.sh
+++ b/scripts/update-toolchain.sh
@@ -1,18 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-if [[ $1 != nightly-????-??-?? ]]
-then
-    echo "Please enter a valid toolchain like \`nightly-2022-01-01\`"
-    exit 1
-fi
+set -euo pipefail
 
-sed -i "s/nightly-2023-08-24/$1/g" \
-    ./marker_rustc_driver/src/main.rs \
-    ./marker_rustc_driver/README.md \
-    ./rust-toolchain.toml \
-    ./.github/workflows/* \
-    ./scripts/update-toolchain.sh \
-    ./cargo-marker/src/backend/driver.rs \
-    ./cargo-marker/README.md \
-    ./scripts/release/install.sh \
-    ./scripts/release/install.ps1
+. $(dirname ${BASH_SOURCE[0]})/replace-in-regions.sh
+
+replace_date_in_regions "rust toolchain dev" "$1"


### PR DESCRIPTION
This is a prerequisite for https://github.com/rust-marker/marker/pull/281.
I updated the `set-version.sh` script to automatically use the rust toolchain version specified in `rust-toolchain.toml` during the release process, and also made the `update-toolchain.sh` update the specific `dev` regions where the toolchain version is mentioned for the next dev cycle.