### PR TITLE
Don't publish the book on pre-releases

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,7 +9,11 @@ on:
   push:
     # Match only on specific tags. We don't want this workflow to be invoked when
     # we put sliding `v{major}` and `v{major}.{minor}` tags on the same commit.
-    tags: ['v[0-9]+.[0-9]+.[0-9]+*']
+    #
+    # The pattern here doesn't allow for any suffix after the version number because
+    # we don't want prereleases (versions with a suffix) to trigger a book deployment.
+    # We want the book to always reflect the latest stable version only.
+    tags: ['v[0-9]+.[0-9]+.[0-9]+']
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Right now doing a pre-release is a bit broken due to the problem with the toolchain update. I don't know if we even really need pre-releases and how soon, but I don't think anything prevents us from having the ability to do these.

This is a small fix for the book deployment which is just one of the things affected by pre-releases. It makes sense not to deploy the book during a pre-release because it will contain the docs for the new release and not for the stable one.