### PR TITLE
Chore: Bump nightly -> `2023-08-24`

### DIFF
--- a/cargo-marker/src/backend/driver.rs
+++ b/cargo-marker/src/backend/driver.rs
@@ -17,7 +17,7 @@ pub fn marker_driver_bin_name() -> String {
 pub(crate) fn default_driver_info() -> DriverVersionInfo {
     DriverVersionInfo {
         // region replace rust toolchain dev
-        toolchain: "nightly-2023-08-24".to_string(),
+        toolchain: "nightly-2023-10-05".to_string(),
         // endregion replace rust toolchain dev
         // region replace marker version dev
         version: "0.4.0-dev".to_string(),

--- a/cargo-marker/src/utils/utf8.rs
+++ b/cargo-marker/src/utils/utf8.rs
@@ -67,11 +67,11 @@ mod tests {
     fn test_into_utf8_fail() {
         assert_into_utf8(
             vec![97, 98, 255u8],
-            &expect![[r#"
+            &expect![[r"
                 Error: Failed to convert to UTF-8 encoded string (dumped it on the line bellow):
                 ---
                 ab�
-                ---"#]],
+                ---"]],
         );
     }
 

--- a/marker_rustc_driver/src/conversion/marker/ast/item.rs
+++ b/marker_rustc_driver/src/conversion/marker/ast/item.rs
@@ -175,7 +175,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
         let header = fn_sig.header;
         let return_ty = if let hir::FnRetTy::Return(rust_ty) = fn_sig.decl.output {
             // Unwrap `impl Future<Output = <ty>>` for async
-            if let hir::IsAsync::Async = header.asyncness
+            if let hir::IsAsync::Async(_) = header.asyncness
                 && let hir::TyKind::OpaqueDef(item_id, _bounds, _) = rust_ty.kind
                 && let item = self.rustc_cx.hir().item(item_id)
                 && let hir::ItemKind::OpaqueTy(opty) = &item.kind

--- a/marker_rustc_driver/src/conversion/marker/common.rs
+++ b/marker_rustc_driver/src/conversion/marker/common.rs
@@ -206,7 +206,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
 
     pub fn to_syncness(&self, syncness: hir::IsAsync) -> Syncness {
         match syncness {
-            hir::IsAsync::Async => Syncness::Async,
+            hir::IsAsync::Async(_) => Syncness::Async,
             hir::IsAsync::NotAsync => Syncness::Sync,
         }
     }

--- a/marker_rustc_driver/src/conversion/marker/sem/ty.rs
+++ b/marker_rustc_driver/src/conversion/marker/sem/ty.rs
@@ -96,9 +96,9 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                 self.to_ty_def_id(*id),
                 self.to_sem_generic_args(generics),
             ))),
-            mid::ty::TyKind::Generator(_, _, _)
-            | mid::ty::TyKind::GeneratorWitness(_)
-            | mid::ty::TyKind::GeneratorWitnessMIR(_, _) => TyKind::Unstable(self.alloc(UnstableTy::new())),
+            mid::ty::TyKind::Generator(_, _, _) | mid::ty::TyKind::GeneratorWitness(_, _) => {
+                TyKind::Unstable(self.alloc(UnstableTy::new()))
+            },
             mid::ty::TyKind::Never => TyKind::Never(self.alloc(NeverTy::new())),
             mid::ty::TyKind::Alias(_, info) => TyKind::Alias(self.alloc(AliasTy::new(self.to_item_id(info.def_id)))),
             mid::ty::TyKind::Param(param) => {

--- a/marker_rustc_driver/src/main.rs
+++ b/marker_rustc_driver/src/main.rs
@@ -48,7 +48,7 @@ use rustc_session::EarlyErrorHandler;
 use crate::conversion::rustc::RustcConverter;
 
 // region replace rust toolchain dev
-const RUSTC_TOOLCHAIN_VERSION: &str = "nightly-2023-08-24";
+const RUSTC_TOOLCHAIN_VERSION: &str = "nightly-2023-10-05";
 // endregion replace rust toolchain dev
 
 struct DefaultCallbacks {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # region replace rust toolchain dev
-channel = "nightly-2023-08-24"
+channel = "nightly-2023-10-05"
 # endregion replace rust toolchain dev
 components = [
   "cargo",


### PR DESCRIPTION
New nightly bump after the `update-toolchain.sh` script has been updated in rust-marker/marker#284

This one my break cargos build cache. A simple `cargo clean` will fix any potential errors :)

Closes: https://github.com/rust-marker/marker/issues/236