### PR TITLE
Fix the marker action version referenced in the book

### DIFF
--- a/docs/book/src/usage/ci.md
+++ b/docs/book/src/usage/ci.md
@@ -46,6 +46,7 @@ These example workflows will use the lint crates specified in the `Cargo.toml` f
 
 Checkout the repository code, install the toolchain, Marker, and start linting.
 
+<!-- region replace marker action version stable -->
 ```yml
 jobs:
   rust-marker-lints:
@@ -55,8 +56,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: rust-marker/marker@v0.2
+      - uses: rust-marker/marker@v0.3
 ```
+<!-- endregion replace marker action version stable -->
+
 
 #### Advanced usage
 
@@ -64,6 +67,7 @@ If you need something more than just the `cargo marker` command, you may use the
 
 Here is an example of how you could limit the set of crates that you want to lint. Refer to `cargo marker --help` for a full list of available options.
 
+<!-- region replace marker action version stable -->
 ```yml
 jobs:
   rust-marker-lints:
@@ -73,11 +77,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: rust-marker/marker@v0.2
+      - uses: rust-marker/marker@v0.3
         with:
           install-only: true
       - run: cargo marker -- -p crate-foo -p crate-bar
 ```
+<!-- endregion replace marker action version stable -->
 
 If you have an example of advanced usage of `cargo marker` command that you have to repeat in your CI template again and again consider opening a [new issue] in our repository. We will be glad to hear any suggestions about extending the inputs for the GitHub Action for your use case.
 

--- a/scripts/release/set-version.diff
+++ b/scripts/release/set-version.diff
@@ -123,6 +123,14 @@
 -- **Fixed tags, like `vX.Y.Z`:**
 +- **Fixed tags, like `v0.1.0`:**
  
+       - uses: actions-rust-lang/setup-rust-toolchain@v1
+-      - uses: rust-marker/marker@vX.Y
++      - uses: rust-marker/marker@v0.1
+ ```
+       - uses: actions-rust-lang/setup-rust-toolchain@v1
+-      - uses: rust-marker/marker@vX.Y
++      - uses: rust-marker/marker@v0.1
+         with:
      --retry-connrefused \
 -    https://raw.githubusercontent.com/rust-marker/marker/vX.Y/scripts/release/install.sh \
 +    https://raw.githubusercontent.com/rust-marker/marker/v0.1/scripts/release/install.sh \

--- a/scripts/release/set-version.sh
+++ b/scripts/release/set-version.sh
@@ -44,6 +44,14 @@ fi
 # Only suffixless `x.y.z` versions are replaced in stable mode
 if [[ "$new_version" != *-* ]]; then
     replace_semver_in_regions "marker version stable" "$new_version"
+
+    # Special case for the GitHub action syntax used in examples of `yml` markdown
+    # fenced code blocks where there we can't limit the region to exclude other
+    # semver versions of other GitHub actions in the region.
+    replace_semver_in_regions \
+        "marker action version stable" \
+        "$new_version" \
+        --prefix "rust-marker\/marker@"
 fi
 
 # We need any version of cargo executable to update the `Cargo.lock` file.

--- a/scripts/replace-in-regions.sh
+++ b/scripts/replace-in-regions.sh
@@ -42,6 +42,14 @@ function replace_semver_in_regions {
     local region="$1"
     local x_y_z="$2"
 
+    # Optionally require a prefix before the version. This may be used to
+    # disambiguate the version from other text that we don't want to consider for replacement.
+    local prefix=""
+
+    if [[ "${3:-}" == "--prefix" ]]; then
+        prefix="$4"
+    fi
+
     local suffix='(-[0-9a-zA-Z.\-]+)?'
     local num='[0-9]+'
     local pattern="$num\.$num\.$num$suffix"
@@ -54,9 +62,9 @@ function replace_semver_in_regions {
     local x=$(echo "$x_y_z" | cut --delimiter . --fields 1)
 
     replace_in_regions "$region" "
-        s/(v|\W)$pattern/\1$x_y_z/g
-        s/(v|\W)$num\.$num$suffix/\1$x_y/g
-        s/v$num$suffix/v$x/g
+        s/${prefix}(v|\W)$pattern/${prefix}\1$x_y_z/g
+        s/${prefix}(v|\W)$num\.$num$suffix/${prefix}\1$x_y/g
+        s/${prefix}v$num$suffix/${prefix}v$x/g
     "
 }
 


### PR DESCRIPTION
I guess it may be a candidate for backporting to 0.3 book deployment :sweat:. At least the markdown text fix (not the script change)