### PR TITLE
API: Make item `Visibility` visible in the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,12 @@ The [v0.4.0 milestone] contains a list of planned changes.
 [v0.4.0 milestone]: https://github.com/rust-marker/marker/milestone/4
 [#278]: https://github.com/rust-marker/marker/pull/278
 [#288]: https://github.com/rust-marker/marker/pull/288
+[#294]: https://github.com/rust-marker/marker/pull/294
 [#306]: https://github.com/rust-marker/marker/pull/306
 
 ### Added
 - [#306]: The `LintPass` trait now as a new `check_crate` method.
+- [#294]: Items and fields now provide information about their visibility
 
 ### Fixed
 - [#306]: Rustc's driver no longer ICEs on spans from compiler generated code.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Marker is still growing up, and that's a good thing. We can still shape the API 
     * Higher order types
     * Attributes [#51](https://github.com/rust-marker/marker/issues/51)
     * Macros [rust-marker/design#47](https://github.com/rust-marker/design/issues/47)
-    * Item visibility [#26](https://github.com/rust-marker/marker/issues/26)
+    * Item visibility [#26](https://github.com/rust-marker/marker/issues/26) (Will be added in v0.4)
 * **Utility**: The API is currently lacking a lot of utility functions, to handle edge cases and make linting more pleasant.
 * **Documentation**: Marker still requires a lot of documentation, in the form of doc comments and a book, which explains the basic concept and works as a guide for end-users, lint- and marker-devs alike.
 

--- a/marker_api/src/ast/expr.rs
+++ b/marker_api/src/ast/expr.rs
@@ -372,14 +372,10 @@ impl<'ast> ConstExpr<'ast> {
 
 #[cfg(all(test, target_arch = "x86_64", target_pointer_width = "64"))]
 mod test {
-    use super::*;
-    use expect_test::{expect, Expect};
+    use crate::test::assert_size_of;
 
-    #[track_caller]
-    fn assert_size_of<T>(expected: &Expect) {
-        let actual = std::mem::size_of::<T>();
-        expected.assert_eq(&actual.to_string());
-    }
+    use super::*;
+    use expect_test::expect;
 
     #[test]
     fn expr_struct_size() {

--- a/marker_api/src/ast/item.rs
+++ b/marker_api/src/ast/item.rs
@@ -333,8 +333,8 @@ impl<'ast> Visibility<'ast> {
         matches!(self.kind, VisibilityKind::Crate(_))
     }
 
-    /// Returns `true` if a visibility has been defined.
-    pub fn is_defined(&self) -> bool {
+    /// Returns `true` if a visibility has been explicitly specified.
+    pub fn is_explicit(&self) -> bool {
         !matches!(self.kind, VisibilityKind::Default(_) | VisibilityKind::DefaultPub)
     }
 

--- a/marker_api/src/ast/item.rs
+++ b/marker_api/src/ast/item.rs
@@ -454,25 +454,31 @@ impl<'ast> Body<'ast> {
 #[cfg(all(test, target_arch = "x86_64", target_pointer_width = "64"))]
 mod test {
     use super::*;
-    use std::mem::size_of;
+    use expect_test::{expect, Expect};
+
+    #[track_caller]
+    fn assert_size_of<T>(expected: &Expect) {
+        let actual = std::mem::size_of::<T>();
+        expected.assert_eq(&actual.to_string());
+    }
 
     #[test]
     fn test_item_struct_size() {
         // These sizes are allowed to change, this is just a check to have a
         // general overview and to prevent accidental changes
-        assert_eq!(56, size_of::<ModItem<'_>>(), "ModItem");
-        assert_eq!(48, size_of::<ExternCrateItem<'_>>(), "ExternCrateItem");
-        assert_eq!(64, size_of::<UseItem<'_>>(), "UseItem");
-        assert_eq!(80, size_of::<StaticItem<'_>>(), "StaticItem");
-        assert_eq!(72, size_of::<ConstItem<'_>>(), "ConstItem");
-        assert_eq!(144, size_of::<FnItem<'_>>(), "FnItem");
-        assert_eq!(112, size_of::<TyAliasItem<'_>>(), "TyAliasItem");
-        assert_eq!(96, size_of::<StructItem<'_>>(), "StructItem");
-        assert_eq!(88, size_of::<EnumItem<'_>>(), "EnumItem");
-        assert_eq!(88, size_of::<UnionItem<'_>>(), "UnionItem");
-        assert_eq!(112, size_of::<TraitItem<'_>>(), "TraitItem");
-        assert_eq!(144, size_of::<ImplItem<'_>>(), "ImplItem");
-        assert_eq!(64, size_of::<ExternBlockItem<'_>>(), "ExternBlockItem");
-        assert_eq!(48, size_of::<UnstableItem<'_>>(), "UnstableItem");
+        assert_size_of::<ModItem<'_>>(&expect!["80"]);
+        assert_size_of::<ExternCrateItem<'_>>(&expect!["72"]);
+        assert_size_of::<UseItem<'_>>(&expect!["88"]);
+        assert_size_of::<StaticItem<'_>>(&expect!["104"]);
+        assert_size_of::<ConstItem<'_>>(&expect!["96"]);
+        assert_size_of::<FnItem<'_>>(&expect!["168"]);
+        assert_size_of::<TyAliasItem<'_>>(&expect!["136"]);
+        assert_size_of::<StructItem<'_>>(&expect!["120"]);
+        assert_size_of::<EnumItem<'_>>(&expect!["112"]);
+        assert_size_of::<UnionItem<'_>>(&expect!["112"]);
+        assert_size_of::<TraitItem<'_>>(&expect!["136"]);
+        assert_size_of::<ImplItem<'_>>(&expect!["168"]);
+        assert_size_of::<ExternBlockItem<'_>>(&expect!["88"]);
+        assert_size_of::<UnstableItem<'_>>(&expect!["72"]);
     }
 }

--- a/marker_api/src/ast/item.rs
+++ b/marker_api/src/ast/item.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, marker::PhantomData};
+use std::fmt::Debug;
 
 use crate::{
     common::{HasNodeId, ItemId, SpanId},
@@ -264,144 +264,23 @@ use impl_item_data;
 #[derive(Debug)]
 #[cfg_attr(feature = "driver-api", derive(typed_builder::TypedBuilder))]
 pub struct Visibility<'ast> {
-    #[cfg_attr(feature = "driver-api", builder(setter(skip), default))]
-    _lifetime: PhantomData<&'ast ()>,
     #[cfg_attr(feature = "driver-api", builder(setter(into), default))]
     span: FfiOption<SpanId>,
-    kind: VisibilityKind,
+    sem: crate::sem::Visibility<'ast>,
 }
 
 impl<'ast> Visibility<'ast> {
+    /// The [`Span`] of the visibility, if it has been declared.
     pub fn span(&self) -> Option<&Span<'ast>> {
         self.span.copy().map(|span| with_cx(self, |cx| cx.span(span)))
     }
 
-    /// Returns `true` if the item is declared as public, without any restrictions.
-    ///
-    /// ```
-    /// // This returns `true`
-    /// pub fn unicorn() {}
-    ///
-    /// // This returns `false`, since the visibility is restricted to a specified path.
-    /// pub(crate) fn giraffe() {}
-    ///
-    /// // This returns `false`, since the visibility is not defined
-    /// fn dragon() {}
-    /// ```
-    ///
-    /// See [`Visibility::is_pub_with_path`] to detect pub declarations with a
-    /// defined path.
-    pub fn is_pub(&self) -> bool {
-        matches!(self.kind, VisibilityKind::Public | VisibilityKind::DefaultPub)
+    /// This function returns the semantic representation for the [`Visibility`]
+    /// of this item. That visibility can be used to check if the item is public
+    /// or restricted to specific modules.
+    pub fn semantics(&self) -> &crate::sem::Visibility<'ast> {
+        &self.sem
     }
-
-    /// Returns `true` if the item is declared as `pub(...)` with a path in brackets
-    /// that defines the scope, where the item is visible.
-    pub fn is_pub_with_path(&self) -> bool {
-        matches!(self.kind, VisibilityKind::Path(_) | VisibilityKind::Crate(_))
-    }
-
-    /// Returns `true` if the visibility is declared as `pub(crate)`. This is a
-    /// special case of the `pub(<path>)` visibility.
-    ///
-    /// This function checks if the visibility is restricted and the defined path
-    /// belongs to the root module of the crate. Meaning, that this can also be `true`,
-    /// if the visibility uses `pub(super)` to travel up to the crate root.
-    // Ignore, since the `in crate::example_1` path doesn't work for doc tests
-    /// ```ignore
-    /// // lib.rs
-    ///
-    /// mod example_1 {
-    ///     // Returns `false` since no visibility is declared
-    ///     fn foo() {}
-    ///
-    ///     // Returns `false` since the item is not visible from the root of the crate.
-    ///     pub(in crate::example_1) fn bar() {}
-    ///
-    ///     // Returns `true` as the visibility is restricted to the root of the crate.
-    ///     pub(crate) fn baz() {}
-    ///
-    ///     // Returns `true` as the visibility is restricted to `super` which is the
-    ///     // root of the crate.
-    ///     pub(super) fn boo() {}
-    /// }
-    ///
-    /// // Returns `false` since the visibility is not restricted
-    /// fn example_in_root() {}
-    /// ```
-    pub fn is_pub_crate(&self) -> bool {
-        matches!(self.kind, VisibilityKind::Crate(_))
-    }
-
-    /// Returns `true` if a visibility has been explicitly specified.
-    pub fn is_explicit(&self) -> bool {
-        !matches!(self.kind, VisibilityKind::Default(_) | VisibilityKind::DefaultPub)
-    }
-
-    /// Returns the [`ItemId`] of the module where this item is visible in, if the
-    /// visibility is defined to be public inside a specified path.
-    ///
-    /// See [`Visibility::module_id`] to get the `ItemId`, even if the item or
-    /// field uses the default visibility.
-    pub fn pub_with_path_module_id(&self) -> Option<ItemId> {
-        match self.kind {
-            VisibilityKind::Path(id) | VisibilityKind::Crate(id) => Some(id),
-            _ => None,
-        }
-    }
-
-    /// Returns the [`ItemId`] of the module that this item or field is visible in.
-    /// It will return `None`, if the item is public, as the visibility extends even past
-    /// the root module of the crate.
-    ///
-    /// This function also works for items which have the default visibility, of the
-    /// module they are declared in.
-    ///
-    /// ```
-    /// mod scope {
-    ///     // Returns `None` since this is even visible outside the current crate
-    ///     pub fn turtle() {}
-    ///     
-    ///     // Returns the `ItemId` of the root module of the crate
-    ///     pub(crate) fn shark() {}
-    ///
-    ///     // Returns the `ItemId` of the module it is declared in
-    ///     fn dolphin() {}
-    /// }
-    /// ```
-    ///
-    /// Note that this only returns the [`ItemId`] that this item is visible in
-    /// based on the declared visibility. The item might be reexported, which can
-    /// increase the visibility.
-    pub fn module_id(&self) -> Option<ItemId> {
-        match self.kind {
-            VisibilityKind::Path(id) | VisibilityKind::Crate(id) | VisibilityKind::Default(id) => Some(id),
-            _ => None,
-        }
-    }
-
-    // FIXME(xFrednet): Implement functions to check if an item is visible from a
-    // given `ItemId`. This can be done once rust-marker/marker#242 is implemented.
-}
-
-#[derive(Debug)]
-#[allow(clippy::exhaustive_enums)]
-#[cfg_attr(feature = "driver-api", visibility::make(pub))]
-enum VisibilityKind {
-    /// The item is declared as `pub` without any restrictions
-    Public,
-    /// The visibility is restricted to a specific module using `pub(<path>)`.
-    /// The module, targeted by the path is identified by the [`ItemId`].
-    /// The `pub(crate)` has it's own variant in this struct.
-    Path(ItemId),
-    /// The visibility is restricted to the root module of the crate. The [`ItemId`]
-    /// identifies the root module.
-    Crate(ItemId),
-    /// The items doesn't have a declared visibility. The default is restricted to
-    /// a module, identified by the stored [`ItemId`]
-    Default(ItemId),
-    /// For items which are `pub` by default, like trait functions or enum variants
-    DefaultPub,
 }
 
 /// A body represents the expression of items.

--- a/marker_api/src/ffi.rs
+++ b/marker_api/src/ffi.rs
@@ -84,9 +84,10 @@ impl std::hash::Hash for FfiStr<'_> {
 /// This is an FFI safe option. In most cases it's better to pass a pointer and
 /// then use `as_ref()` but this doesn't work for owned return values.
 #[repr(C)]
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Default)]
 pub enum FfiOption<T> {
     Some(T),
+    #[default]
     None,
 }
 

--- a/marker_api/src/lib.rs
+++ b/marker_api/src/lib.rs
@@ -7,12 +7,7 @@
 #![allow(clippy::missing_panics_doc)] // Temporary allow for `todo!`s
 #![allow(clippy::new_without_default)] // Not very helpful as `new` is almost always cfged
 #![cfg_attr(not(feature = "driver-api"), allow(dead_code))]
-// FIXME(#26): this is commented out because it is the lint that we want to enable
-// here makes sense only on a public items, but it triggers of private/pub(crate)
-// methods today. There isn't a way to inspect the item visibility in this lint's
-// impl yet. Once #26 is done and lint impl ignores private functions we may enable
-// this lint.
-// #![cfg_attr(marker, warn(marker::not_using_has_span_trait))]
+#![cfg_attr(marker, warn(marker::marker_lints::not_using_has_span_trait))]
 
 pub static MARKER_API_VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/marker_api/src/lib.rs
+++ b/marker_api/src/lib.rs
@@ -17,6 +17,9 @@ pub use interface::*;
 mod lint;
 pub use lint::*;
 
+#[cfg(test)]
+pub(crate) mod test;
+
 pub mod ast;
 pub mod common;
 pub mod context;

--- a/marker_api/src/sem.rs
+++ b/marker_api/src/sem.rs
@@ -3,8 +3,10 @@
 
 mod common;
 mod generic;
+mod item;
 mod ty;
 
 pub use common::*;
 pub use generic::*;
+pub use item::*;
 pub use ty::*;

--- a/marker_api/src/sem/item.rs
+++ b/marker_api/src/sem/item.rs
@@ -88,10 +88,10 @@ impl<'ast> Visibility<'ast> {
     /// Returns `true` if a visibility is the default visibility, meaning that it wasn't
     /// declared.
     pub fn is_default(&self) -> bool {
-        matches!(
-            self.kind,
-            VisibilityKind::DefaultPub | VisibilityKind::DefaultCrate(_) | VisibilityKind::Default(_)
-        )
+        match self.kind {
+            VisibilityKind::DefaultPub | VisibilityKind::DefaultCrate(_) | VisibilityKind::Default(_) => true,
+            VisibilityKind::Public | VisibilityKind::Crate(_) | VisibilityKind::Path(_) => false,
+        }
     }
 
     /// Returns the [`ItemId`] of the module that this item or field is visible in.
@@ -121,7 +121,7 @@ impl<'ast> Visibility<'ast> {
             | VisibilityKind::Crate(id)
             | VisibilityKind::DefaultCrate(id)
             | VisibilityKind::Default(id) => Some(id),
-            _ => None,
+            VisibilityKind::Public | VisibilityKind::DefaultPub => None,
         }
     }
 

--- a/marker_api/src/sem/item.rs
+++ b/marker_api/src/sem/item.rs
@@ -1,0 +1,160 @@
+use std::marker::PhantomData;
+
+use crate::common::ItemId;
+
+/// The declared visibility of an item or field.
+///
+/// ```
+/// // An item without a visibility
+/// fn moon() {}
+///
+/// // A public item
+/// pub fn sun() {}
+///
+/// // An item with a restricted scope
+/// pub(crate) fn star() {}
+///
+/// pub trait Planet {
+///     // An item without a visibility. But it still has the semantic visibility
+///     // of `pub` as this is inside a trait declaration.
+///     fn mass();
+/// }
+/// ```
+#[repr(C)]
+#[derive(Debug)]
+#[cfg_attr(feature = "driver-api", derive(typed_builder::TypedBuilder))]
+pub struct Visibility<'ast> {
+    #[cfg_attr(feature = "driver-api", builder(setter(skip), default))]
+    _lifetime: PhantomData<&'ast ()>,
+    kind: VisibilityKind,
+}
+
+impl<'ast> Visibility<'ast> {
+    /// Returns `true` if the item is declared as public, without any restrictions.
+    ///
+    /// ```
+    /// // This returns `true`
+    /// pub fn unicorn() {}
+    ///
+    /// // This returns `false`, since the visibility is restricted to a specified path.
+    /// pub(crate) fn giraffe() {}
+    ///
+    /// // This returns `false`, since the visibility is not defined
+    /// fn dragon() {}
+    /// ```
+    ///
+    /// See [`Visibility::is_pub_with_path`] to detect pub declarations with a
+    /// defined path.
+    pub fn is_pub(&self) -> bool {
+        matches!(self.kind, VisibilityKind::Public | VisibilityKind::DefaultPub)
+    }
+
+    /// Returns `true` if the item is declared as `pub(in ..)` with a path in brackets
+    /// that defines the scope, where the item is visible.
+    pub fn is_pub_in_path(&self) -> bool {
+        matches!(self.kind, VisibilityKind::Path(_))
+    }
+
+    /// Returns `true` if the visibility is declared as `pub(crate)`. This is a
+    /// special case of the `pub(<path>)` visibility.
+    ///
+    /// This function checks if the visibility is restricted and the defined path
+    /// belongs to the root module of the crate. Meaning, that this can also be `true`,
+    /// if the visibility uses `pub(super)` to travel up to the crate root.
+    // Ignore, since the `in crate::example_1` path doesn't work for doc tests
+    /// ```ignore
+    /// // lib.rs
+    ///
+    /// mod example_1 {
+    ///     // Returns `false` since no visibility is declared
+    ///     fn foo() {}
+    ///
+    ///     // Returns `false` since the item is not visible from the root of the crate.
+    ///     pub(in crate::example_1) fn bar() {}
+    ///
+    ///     // Returns `true` as the visibility is restricted to the root of the crate.
+    ///     pub(crate) fn baz() {}
+    ///
+    ///     // Returns `true` as the visibility is restricted to `super` which is the
+    ///     // root of the crate.
+    ///     pub(super) fn boo() {}
+    /// }
+    ///
+    /// // Returns `false` since the visibility is not restricted
+    /// fn example_in_root() {}
+    /// ```
+    pub fn is_pub_crate(&self) -> bool {
+        matches!(self.kind, VisibilityKind::Crate(_))
+    }
+
+    /// Returns `true` if a visibility is the default visibility, meaning that it wasn't
+    /// declared.
+    pub fn is_default(&self) -> bool {
+        matches!(self.kind, VisibilityKind::Default(_) | VisibilityKind::DefaultPub)
+    }
+
+    /// Returns the [`ItemId`] of the module where this item is visible in, if the
+    /// visibility is defined to be public inside a specified path.
+    ///
+    /// See [`Visibility::module_id`] to get the `ItemId`, even if the item or
+    /// field uses the default visibility.
+    pub fn pub_with_path_module_id(&self) -> Option<ItemId> {
+        match self.kind {
+            VisibilityKind::Path(id) | VisibilityKind::Crate(id) => Some(id),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`ItemId`] of the module that this item or field is visible in.
+    /// It will return `None`, if the item is public, as the visibility extends even past
+    /// the root module of the crate.
+    ///
+    /// This function also works for items which have the default visibility, of the
+    /// module they are declared in.
+    ///
+    /// ```
+    /// mod scope {
+    ///     // Returns `None` since this is even visible outside the current crate
+    ///     pub fn turtle() {}
+    ///     
+    ///     // Returns the `ItemId` of the root module of the crate
+    ///     pub(crate) fn shark() {}
+    ///
+    ///     // Returns the `ItemId` of the module it is declared in
+    ///     fn dolphin() {}
+    /// }
+    /// ```
+    ///
+    /// Note that this only returns the [`ItemId`] that this item is visible in
+    /// based on the declared visibility. The item might be reexported, which can
+    /// increase the visibility.
+    pub fn module_id(&self) -> Option<ItemId> {
+        match self.kind {
+            VisibilityKind::Path(id) | VisibilityKind::Crate(id) | VisibilityKind::Default(id) => Some(id),
+            _ => None,
+        }
+    }
+
+    // FIXME(xFrednet): Implement functions to check if an item is visible from a
+    // given `ItemId`. This can be done once rust-marker/marker#242 is implemented.
+}
+
+#[derive(Debug)]
+#[allow(clippy::exhaustive_enums)]
+#[cfg_attr(feature = "driver-api", visibility::make(pub))]
+enum VisibilityKind {
+    /// The item is declared as `pub` without any restrictions
+    Public,
+    /// The visibility is restricted to a specific module using `pub(<path>)`.
+    /// The module, targeted by the path is identified by the [`ItemId`].
+    /// The `pub(crate)` has it's own variant in this struct.
+    Path(ItemId),
+    /// The visibility is restricted to the root module of the crate. The [`ItemId`]
+    /// identifies the root module.
+    Crate(ItemId),
+    /// The items doesn't have a declared visibility. The default is restricted to
+    /// a module, identified by the stored [`ItemId`]
+    Default(ItemId),
+    /// For items which are `pub` by default, like trait functions or enum variants
+    DefaultPub,
+}

--- a/marker_api/src/sem/item.rs
+++ b/marker_api/src/sem/item.rs
@@ -43,7 +43,7 @@ impl<'ast> Visibility<'ast> {
     /// fn dragon() {}
     /// ```
     ///
-    /// See [`Visibility::is_pub_with_path`] to detect pub declarations with a
+    /// See [`Visibility::is_pub_in_path`] to detect pub declarations with a
     /// defined path.
     pub fn is_pub(&self) -> bool {
         matches!(self.kind, VisibilityKind::Public | VisibilityKind::DefaultPub)

--- a/marker_api/src/sem/item.rs
+++ b/marker_api/src/sem/item.rs
@@ -30,7 +30,8 @@ pub struct Visibility<'ast> {
 }
 
 impl<'ast> Visibility<'ast> {
-    /// Returns `true` if the item is declared as public, without any restrictions.
+    /// Returns `true` if the item is public, meaning that it can be visible outside
+    /// the crate.
     ///
     /// ```
     /// // This returns `true`
@@ -41,35 +42,29 @@ impl<'ast> Visibility<'ast> {
     ///
     /// // This returns `false`, since the visibility is not defined
     /// fn dragon() {}
+    ///
+    /// pub trait MythicalCreature {
+    ///     // This returns `true`, since the default visibility for trait items is public
+    ///     fn name() -> &'static str;
+    /// }
     /// ```
-    ///
-    /// See [`Visibility::is_pub_in_path`] to detect pub declarations with a
-    /// defined path.
     pub fn is_pub(&self) -> bool {
-        matches!(self.kind, VisibilityKind::Public | VisibilityKind::DefaultPub)
+        self.scope().is_none()
     }
 
-    /// Returns `true` if the item is declared as `pub(in ..)` with a path in brackets
-    /// that defines the scope, where the item is visible.
-    pub fn is_pub_in_path(&self) -> bool {
-        matches!(self.kind, VisibilityKind::Path(_))
-    }
-
-    /// Returns `true` if the visibility is declared as `pub(crate)`. This is a
-    /// special case of the `pub(<path>)` visibility.
+    /// Returns `true` if the item is visible in the entire crate. This is
+    /// the case for items declared as `pub(crate)`. Items declared in the root
+    /// module of the crate or specify the path of the root module are also
+    /// scoped to the entire crate.
     ///
-    /// This function checks if the visibility is restricted and the defined path
-    /// belongs to the root module of the crate. Meaning, that this can also be `true`,
-    /// if the visibility uses `pub(super)` to travel up to the crate root.
-    // Ignore, since the `in crate::example_1` path doesn't work for doc tests
-    /// ```ignore
+    /// ```
     /// // lib.rs
     ///
     /// mod example_1 {
-    ///     // Returns `false` since no visibility is declared
+    ///     // Returns `false` since it's only visible in `crate::example_1`
     ///     fn foo() {}
     ///
-    ///     // Returns `false` since the item is not visible from the root of the crate.
+    ///     // Returns `false` since it's only visible in `crate::example_1`
     ///     pub(in crate::example_1) fn bar() {}
     ///
     ///     // Returns `true` as the visibility is restricted to the root of the crate.
@@ -80,39 +75,35 @@ impl<'ast> Visibility<'ast> {
     ///     pub(super) fn boo() {}
     /// }
     ///
-    /// // Returns `false` since the visibility is not restricted
+    /// // Returns `true` since this item is at the root of the crate and the default
+    /// // visibility is therefore `pub(crate)`
     /// fn example_in_root() {}
+    ///
+    /// # fn main() {}
     /// ```
-    pub fn is_pub_crate(&self) -> bool {
-        matches!(self.kind, VisibilityKind::Crate(_))
+    pub fn is_crate_scoped(&self) -> bool {
+        matches!(self.kind, VisibilityKind::Crate(_) | VisibilityKind::DefaultCrate(_))
     }
 
     /// Returns `true` if a visibility is the default visibility, meaning that it wasn't
     /// declared.
     pub fn is_default(&self) -> bool {
-        matches!(self.kind, VisibilityKind::Default(_) | VisibilityKind::DefaultPub)
-    }
-
-    /// Returns the [`ItemId`] of the module where this item is visible in, if the
-    /// visibility is defined to be public inside a specified path.
-    ///
-    /// See [`Visibility::module_id`] to get the `ItemId`, even if the item or
-    /// field uses the default visibility.
-    pub fn pub_with_path_module_id(&self) -> Option<ItemId> {
-        match self.kind {
-            VisibilityKind::Path(id) | VisibilityKind::Crate(id) => Some(id),
-            _ => None,
-        }
+        matches!(
+            self.kind,
+            VisibilityKind::DefaultPub | VisibilityKind::DefaultCrate(_) | VisibilityKind::Default(_)
+        )
     }
 
     /// Returns the [`ItemId`] of the module that this item or field is visible in.
-    /// It will return `None`, if the item is public, as the visibility extends even past
+    /// It will return `None`, if the item is public, as the visibility extends past
     /// the root module of the crate.
     ///
     /// This function also works for items which have the default visibility, of the
     /// module they are declared in.
     ///
     /// ```
+    /// // lib.rs
+    ///
     /// mod scope {
     ///     // Returns `None` since this is even visible outside the current crate
     ///     pub fn turtle() {}
@@ -120,17 +111,16 @@ impl<'ast> Visibility<'ast> {
     ///     // Returns the `ItemId` of the root module of the crate
     ///     pub(crate) fn shark() {}
     ///
-    ///     // Returns the `ItemId` of the module it is declared in
+    ///     // Returns the `ItemId` of the module it is declared in, in this case `crate::scope`
     ///     fn dolphin() {}
     /// }
     /// ```
-    ///
-    /// Note that this only returns the [`ItemId`] that this item is visible in
-    /// based on the declared visibility. The item might be reexported, which can
-    /// increase the visibility.
-    pub fn module_id(&self) -> Option<ItemId> {
+    pub fn scope(&self) -> Option<ItemId> {
         match self.kind {
-            VisibilityKind::Path(id) | VisibilityKind::Crate(id) | VisibilityKind::Default(id) => Some(id),
+            VisibilityKind::Path(id)
+            | VisibilityKind::Crate(id)
+            | VisibilityKind::DefaultCrate(id)
+            | VisibilityKind::Default(id) => Some(id),
             _ => None,
         }
     }
@@ -145,16 +135,19 @@ impl<'ast> Visibility<'ast> {
 enum VisibilityKind {
     /// The item is declared as `pub` without any restrictions
     Public,
+    /// For items which are `pub` by default, like trait functions or enum variants
+    DefaultPub,
+    /// The visibility is restricted to the root module of the crate. The [`ItemId`]
+    /// identifies the root module.
+    Crate(ItemId),
+    /// The items doesn't have a declared visibility. The default is visible in the
+    /// entire crate. The [`ItemId`] identifies the root module.
+    DefaultCrate(ItemId),
     /// The visibility is restricted to a specific module using `pub(<path>)`.
     /// The module, targeted by the path is identified by the [`ItemId`].
     /// The `pub(crate)` has it's own variant in this struct.
     Path(ItemId),
-    /// The visibility is restricted to the root module of the crate. The [`ItemId`]
-    /// identifies the root module.
-    Crate(ItemId),
     /// The items doesn't have a declared visibility. The default is restricted to
     /// a module, identified by the stored [`ItemId`]
     Default(ItemId),
-    /// For items which are `pub` by default, like trait functions or enum variants
-    DefaultPub,
 }

--- a/marker_api/src/test.rs
+++ b/marker_api/src/test.rs
@@ -1,0 +1,7 @@
+use expect_test::Expect;
+
+#[track_caller]
+pub(crate) fn assert_size_of<T>(expected: &Expect) {
+    let actual = std::mem::size_of::<T>();
+    expected.assert_eq(&actual.to_string());
+}

--- a/marker_lints/src/not_using_has_span_trait.rs
+++ b/marker_lints/src/not_using_has_span_trait.rs
@@ -4,7 +4,7 @@ marker_api::declare_lint! {
     /// ### What it does
     /// Suggests using `impl HasSpan` for functions that need to take `Span` as
     /// a parameter to make them more ergonomic.
-    /// 
+    ///
     /// This function only triggers on public items, as it's targeted to towards
     /// the public interface of crates.
     NOT_USING_HAS_SPAN_TRAIT,

--- a/marker_lints/src/not_using_has_span_trait.rs
+++ b/marker_lints/src/not_using_has_span_trait.rs
@@ -4,15 +4,18 @@ marker_api::declare_lint! {
     /// ### What it does
     /// Suggests using `impl HasSpan` for functions that need to take `Span` as
     /// a parameter to make them more ergonomic.
+    /// 
+    /// This function only triggers on public items, as it's targeted to towards
+    /// the public interface of crates.
     NOT_USING_HAS_SPAN_TRAIT,
-    // FIXME(#26): This allow by default until we have the item visibility info
-    // in the AST. Once that is in place the lint should be made `warn` by default,
-    // and it should ignore non `pub` functions.
     Allow,
 }
 
 pub(crate) fn check_item<'ast>(cx: &'ast MarkerContext<'ast>, item: ItemKind<'ast>) {
     let ItemKind::Fn(func) = item else { return };
+    if !func.visibility().is_pub() {
+        return;
+    }
 
     for param in func.params() {
         let ast::TyKind::Path(path) = param.ty().peel_refs() else {

--- a/marker_lints/src/not_using_has_span_trait.rs
+++ b/marker_lints/src/not_using_has_span_trait.rs
@@ -13,7 +13,7 @@ marker_api::declare_lint! {
 
 pub(crate) fn check_item<'ast>(cx: &'ast MarkerContext<'ast>, item: ItemKind<'ast>) {
     let ItemKind::Fn(func) = item else { return };
-    if !func.visibility().is_pub() {
+    if !func.visibility().semantics().is_pub() {
         return;
     }
 

--- a/marker_rustc_driver/src/conversion/marker/sem.rs
+++ b/marker_rustc_driver/src/conversion/marker/sem.rs
@@ -1,2 +1,3 @@
 mod generic;
+mod item;
 mod ty;

--- a/marker_rustc_driver/src/conversion/marker/sem/item.rs
+++ b/marker_rustc_driver/src/conversion/marker/sem/item.rs
@@ -9,11 +9,20 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
         let vis = self.rustc_cx.visibility(owner_id);
         let kind = match vis {
             mid::ty::Visibility::Public => sem::VisibilityKind::Public,
-            mid::ty::Visibility::Restricted(id) if !has_span => sem::VisibilityKind::Default(self.to_item_id(id)),
             mid::ty::Visibility::Restricted(id) if id == hir::def_id::CRATE_DEF_ID.to_def_id() => {
-                sem::VisibilityKind::Crate(self.to_item_id(id))
+                if has_span {
+                    sem::VisibilityKind::Crate(self.to_item_id(id))
+                } else {
+                    sem::VisibilityKind::DefaultCrate(self.to_item_id(id))
+                }
             },
-            mid::ty::Visibility::Restricted(id) => sem::VisibilityKind::Path(self.to_item_id(id)),
+            mid::ty::Visibility::Restricted(id) => {
+                if has_span {
+                    sem::VisibilityKind::Path(self.to_item_id(id))
+                } else {
+                    sem::VisibilityKind::Default(self.to_item_id(id))
+                }
+            },
         };
 
         sem::Visibility::builder().kind(kind).build()

--- a/marker_rustc_driver/src/conversion/marker/sem/item.rs
+++ b/marker_rustc_driver/src/conversion/marker/sem/item.rs
@@ -1,0 +1,21 @@
+use marker_api::prelude::*;
+use rustc_hir as hir;
+use rustc_middle as mid;
+
+use crate::conversion::marker::MarkerConverterInner;
+
+impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
+    pub fn to_sem_visibility(&self, owner_id: hir::def_id::LocalDefId, has_span: bool) -> sem::Visibility<'ast> {
+        let vis = self.rustc_cx.visibility(owner_id);
+        let kind = match vis {
+            mid::ty::Visibility::Public => sem::VisibilityKind::Public,
+            mid::ty::Visibility::Restricted(id) if !has_span => sem::VisibilityKind::Default(self.to_item_id(id)),
+            mid::ty::Visibility::Restricted(id) if id == hir::def_id::CRATE_DEF_ID.to_def_id() => {
+                sem::VisibilityKind::Crate(self.to_item_id(id))
+            },
+            mid::ty::Visibility::Restricted(id) => sem::VisibilityKind::Path(self.to_item_id(id)),
+        };
+
+        sem::Visibility::builder().kind(kind).build()
+    }
+}

--- a/marker_uilints/src/lib.rs
+++ b/marker_uilints/src/lib.rs
@@ -160,15 +160,10 @@ impl LintPass for TestLintPass {
                         let ast_vis = item.visibility();
                         let vis = ast_vis.semantics();
                         diag.span(item.ident().unwrap().span());
-                        diag.note(format!("vis.is_pub()                  -> {}", vis.is_pub()));
-                        diag.note(format!("vis.is_pub_in_path()          -> {}", vis.is_pub_in_path()));
-                        diag.note(format!("vis.is_pub_crate()            -> {}", vis.is_pub_crate()));
-                        diag.note(format!("vis.is_default()              -> {}", vis.is_default()));
-                        diag.note(format!(
-                            "vis.pub_with_path_module_id() -> {:?}",
-                            vis.pub_with_path_module_id()
-                        ));
-                        diag.note(format!("vis.module_id()               -> {:?}", vis.module_id()));
+                        diag.note(format!("vis.is_default()      -> {}", vis.is_default()));
+                        diag.note(format!("vis.is_pub()          -> {}", vis.is_pub()));
+                        diag.note(format!("vis.is_crate_scoped() -> {}", vis.is_crate_scoped()));
+                        diag.note(format!("vis.scope()           -> {:?}", vis.scope()));
                         diag.note(format!("vis.span(): `{:?}`", ast_vis.span().map(|s| s.snippet_or(""))));
                     });
             }

--- a/marker_uilints/src/lib.rs
+++ b/marker_uilints/src/lib.rs
@@ -162,7 +162,7 @@ impl LintPass for TestLintPass {
                         diag.note(format!("vis.is_pub()                  -> {}", vis.is_pub()));
                         diag.note(format!("vis.is_pub_with_path()        -> {}", vis.is_pub_with_path()));
                         diag.note(format!("vis.is_pub_crate()            -> {}", vis.is_pub_crate()));
-                        diag.note(format!("vis.is_defined()              -> {}", vis.is_defined()));
+                        diag.note(format!("vis.is_explicit()             -> {}", vis.is_explicit()));
                         diag.note(format!(
                             "vis.pub_with_path_module_id() -> {:?}",
                             vis.pub_with_path_module_id()

--- a/marker_uilints/src/lib.rs
+++ b/marker_uilints/src/lib.rs
@@ -56,10 +56,15 @@ marker_api::declare_lint! {
 
 marker_api::declare_lint! {
     /// # What it does
-    /// A lint used for marker's uitests.
-    ///
     /// A lint to test [`marker_api::AstMap`].
     TEST_AST_MAP,
+    Warn,
+}
+
+marker_api::declare_lint! {
+    /// # What it does
+    /// A lint to test Marker's `Visibility` representation.
+    TEST_ITEM_VISIBILITY,
     Warn,
 }
 
@@ -142,6 +147,26 @@ impl LintPass for TestLintPass {
                         diag.span(item.ident().unwrap().span());
                         diag.note(format!("Item: {item:#?}"));
                         diag.note(format!("Body: {:#?}", cx.ast().body(func.body_id().unwrap())));
+                    });
+            }
+            if matches!(
+                item.ident().map(marker_api::span::Ident::name),
+                Some(name) if name.starts_with("test_vis")
+            ) {
+                cx.emit_lint(TEST_ITEM_VISIBILITY, item, "can you see this item?")
+                    .decorate(|diag| {
+                        let vis = item.visibility();
+                        diag.span(item.ident().unwrap().span());
+                        diag.note(format!("vis.is_pub()                  -> {}", vis.is_pub()));
+                        diag.note(format!("vis.is_pub_with_path()        -> {}", vis.is_pub_with_path()));
+                        diag.note(format!("vis.is_pub_crate()            -> {}", vis.is_pub_crate()));
+                        diag.note(format!("vis.is_defined()              -> {}", vis.is_defined()));
+                        diag.note(format!(
+                            "vis.pub_with_path_module_id() -> {:?}",
+                            vis.pub_with_path_module_id()
+                        ));
+                        diag.note(format!("vis.module_id()               -> {:?}", vis.module_id()));
+                        diag.note(format!("vis.span(): `{:?}`", vis.span().map(|s| s.snippet_or(""))));
                     });
             }
         }

--- a/marker_uilints/src/lib.rs
+++ b/marker_uilints/src/lib.rs
@@ -149,10 +149,7 @@ impl LintPass for TestLintPass {
                         diag.note(format!("Body: {:#?}", cx.ast().body(func.body_id().unwrap())));
                     });
             }
-            if matches!(
-                item.ident().map(marker_api::span::Ident::name),
-                Some(name) if name.starts_with("test_vis")
-            ) {
+            if item.ident().is_some_and(|ident| ident.name().starts_with("test_vis")) {
                 cx.emit_lint(TEST_ITEM_VISIBILITY, item, "can you see this item?")
                     .decorate(|diag| {
                         let vis = item.visibility();

--- a/marker_uilints/src/lib.rs
+++ b/marker_uilints/src/lib.rs
@@ -157,18 +157,19 @@ impl LintPass for TestLintPass {
             {
                 cx.emit_lint(TEST_ITEM_VISIBILITY, item, "can you see this item?")
                     .decorate(|diag| {
-                        let vis = item.visibility();
+                        let ast_vis = item.visibility();
+                        let vis = ast_vis.semantics();
                         diag.span(item.ident().unwrap().span());
                         diag.note(format!("vis.is_pub()                  -> {}", vis.is_pub()));
-                        diag.note(format!("vis.is_pub_with_path()        -> {}", vis.is_pub_with_path()));
+                        diag.note(format!("vis.is_pub_in_path()          -> {}", vis.is_pub_in_path()));
                         diag.note(format!("vis.is_pub_crate()            -> {}", vis.is_pub_crate()));
-                        diag.note(format!("vis.is_explicit()             -> {}", vis.is_explicit()));
+                        diag.note(format!("vis.is_default()              -> {}", vis.is_default()));
                         diag.note(format!(
                             "vis.pub_with_path_module_id() -> {:?}",
                             vis.pub_with_path_module_id()
                         ));
                         diag.note(format!("vis.module_id()               -> {:?}", vis.module_id()));
-                        diag.note(format!("vis.span(): `{:?}`", vis.span().map(|s| s.snippet_or(""))));
+                        diag.note(format!("vis.span(): `{:?}`", ast_vis.span().map(|s| s.snippet_or(""))));
                     });
             }
         }

--- a/marker_uilints/src/lib.rs
+++ b/marker_uilints/src/lib.rs
@@ -138,10 +138,11 @@ impl LintPass for TestLintPass {
         }
 
         if let ItemKind::Fn(func) = item {
-            if matches!(
-                item.ident().map(marker_api::span::Ident::name),
-                Some(name) if name.starts_with("print_with_body")
-            ) {
+            if item
+                .ident()
+                .map(|ident| ident.name().starts_with("print_with_body"))
+                .unwrap_or_default()
+            {
                 cx.emit_lint(TEST_LINT, item, "printing item with body")
                     .decorate(|diag| {
                         diag.span(item.ident().unwrap().span());
@@ -149,7 +150,11 @@ impl LintPass for TestLintPass {
                         diag.note(format!("Body: {:#?}", cx.ast().body(func.body_id().unwrap())));
                     });
             }
-            if item.ident().is_some_and(|ident| ident.name().starts_with("test_vis")) {
+            if item
+                .ident()
+                .map(|name| name.name().starts_with("test_vis"))
+                .unwrap_or_default()
+            {
                 cx.emit_lint(TEST_ITEM_VISIBILITY, item, "can you see this item?")
                     .decorate(|diag| {
                         let vis = item.visibility();

--- a/marker_uilints/tests/ui/context/test_ast_map.stderr
+++ b/marker_uilints/tests/ui/context/test_ast_map.stderr
@@ -22,7 +22,13 @@ warning: testing `AstMap::variant`
                        [
                            ItemField {
                                id: FieldId(..),
-                               vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                               vis: Visibility {
+                                   _lifetime: PhantomData<&()>,
+                                   span: None,
+                                   kind: Default(
+                                       ItemId(..),
+                                   ),
+                               },
                                ident: SymbolId(..),
                                ty: Path(
                                    PathTy {
@@ -72,7 +78,13 @@ warning: testing `AstMap::item`
                        data: CommonItemData {
                            id: ItemId(..),
                            span: SpanId(..),
-                           vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                           vis: Visibility {
+                               _lifetime: PhantomData<&()>,
+                               span: None,
+                               kind: Default(
+                                   ItemId(..),
+                               ),
+                           },
                            ident: Ident {
                                name: "LocalStruct",
                                span: $DIR/test_ast_map.rs:6:8 - 6:19,
@@ -86,7 +98,13 @@ warning: testing `AstMap::item`
                            [
                                ItemField {
                                    id: FieldId(..),
-                                   vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                                   vis: Visibility {
+                                       _lifetime: PhantomData<&()>,
+                                       span: None,
+                                       kind: Default(
+                                           ItemId(..),
+                                       ),
+                                   },
                                    ident: SymbolId(..),
                                    ty: Num(
                                        NumTy {

--- a/marker_uilints/tests/ui/context/test_ast_map.stderr
+++ b/marker_uilints/tests/ui/context/test_ast_map.stderr
@@ -23,11 +23,13 @@ warning: testing `AstMap::variant`
                            ItemField {
                                id: FieldId(..),
                                vis: Visibility {
-                                   _lifetime: PhantomData<&()>,
                                    span: None,
-                                   kind: Default(
-                                       ItemId(..),
-                                   ),
+                                   sem: Visibility {
+                                       _lifetime: PhantomData<&()>,
+                                       kind: Default(
+                                           ItemId(..),
+                                       ),
+                                   },
                                },
                                ident: SymbolId(..),
                                ty: Path(
@@ -79,11 +81,13 @@ warning: testing `AstMap::item`
                            id: ItemId(..),
                            span: SpanId(..),
                            vis: Visibility {
-                               _lifetime: PhantomData<&()>,
                                span: None,
-                               kind: Default(
-                                   ItemId(..),
-                               ),
+                               sem: Visibility {
+                                   _lifetime: PhantomData<&()>,
+                                   kind: Default(
+                                       ItemId(..),
+                                   ),
+                               },
                            },
                            ident: Ident {
                                name: "LocalStruct",
@@ -99,11 +103,13 @@ warning: testing `AstMap::item`
                                ItemField {
                                    id: FieldId(..),
                                    vis: Visibility {
-                                       _lifetime: PhantomData<&()>,
                                        span: None,
-                                       kind: Default(
-                                           ItemId(..),
-                                       ),
+                                       sem: Visibility {
+                                           _lifetime: PhantomData<&()>,
+                                           kind: Default(
+                                               ItemId(..),
+                                           ),
+                                       },
                                    },
                                    ident: SymbolId(..),
                                    ty: Num(

--- a/marker_uilints/tests/ui/context/test_ast_map.stderr
+++ b/marker_uilints/tests/ui/context/test_ast_map.stderr
@@ -26,7 +26,7 @@ warning: testing `AstMap::variant`
                                    span: None,
                                    sem: Visibility {
                                        _lifetime: PhantomData<&()>,
-                                       kind: Default(
+                                       kind: DefaultCrate(
                                            ItemId(..),
                                        ),
                                    },
@@ -84,7 +84,7 @@ warning: testing `AstMap::item`
                                span: None,
                                sem: Visibility {
                                    _lifetime: PhantomData<&()>,
-                                   kind: Default(
+                                   kind: DefaultCrate(
                                        ItemId(..),
                                    ),
                                },
@@ -106,7 +106,7 @@ warning: testing `AstMap::item`
                                        span: None,
                                        sem: Visibility {
                                            _lifetime: PhantomData<&()>,
-                                           kind: Default(
+                                           kind: DefaultCrate(
                                                ItemId(..),
                                            ),
                                        },

--- a/marker_uilints/tests/ui/item/print_async_fn.stderr
+++ b/marker_uilints/tests/ui/item/print_async_fn.stderr
@@ -9,7 +9,13 @@ warning: printing item with body
                   data: CommonItemData {
                       id: ItemId(..),
                       span: SpanId(..),
-                      vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                      vis: Visibility {
+                          _lifetime: PhantomData<&()>,
+                          span: None,
+                          kind: Default(
+                              ItemId(..),
+                          ),
+                      },
                       ident: Ident {
                           name: "print_with_body_foo",
                           span: $DIR/print_async_fn.rs:1:10 - 1:29,
@@ -85,7 +91,13 @@ warning: printing item with body
                   data: CommonItemData {
                       id: ItemId(..),
                       span: SpanId(..),
-                      vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                      vis: Visibility {
+                          _lifetime: PhantomData<&()>,
+                          span: None,
+                          kind: Default(
+                              ItemId(..),
+                          ),
+                      },
                       ident: Ident {
                           name: "print_with_body_bar",
                           span: $DIR/print_async_fn.rs:9:10 - 9:29,
@@ -509,7 +521,13 @@ warning: printing item with body
                    data: CommonItemData {
                        id: ItemId(..),
                        span: SpanId(..),
-                       vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                       vis: Visibility {
+                           _lifetime: PhantomData<&()>,
+                           span: None,
+                           kind: Default(
+                               ItemId(..),
+                           ),
+                       },
                        ident: Ident {
                            name: "print_with_body_with_lifetime",
                            span: $DIR/print_async_fn.rs:16:10 - 16:39,

--- a/marker_uilints/tests/ui/item/print_async_fn.stderr
+++ b/marker_uilints/tests/ui/item/print_async_fn.stderr
@@ -10,11 +10,13 @@ warning: printing item with body
                       id: ItemId(..),
                       span: SpanId(..),
                       vis: Visibility {
-                          _lifetime: PhantomData<&()>,
                           span: None,
-                          kind: Default(
-                              ItemId(..),
-                          ),
+                          sem: Visibility {
+                              _lifetime: PhantomData<&()>,
+                              kind: Default(
+                                  ItemId(..),
+                              ),
+                          },
                       },
                       ident: Ident {
                           name: "print_with_body_foo",
@@ -92,11 +94,13 @@ warning: printing item with body
                       id: ItemId(..),
                       span: SpanId(..),
                       vis: Visibility {
-                          _lifetime: PhantomData<&()>,
                           span: None,
-                          kind: Default(
-                              ItemId(..),
-                          ),
+                          sem: Visibility {
+                              _lifetime: PhantomData<&()>,
+                              kind: Default(
+                                  ItemId(..),
+                              ),
+                          },
                       },
                       ident: Ident {
                           name: "print_with_body_bar",
@@ -522,11 +526,13 @@ warning: printing item with body
                        id: ItemId(..),
                        span: SpanId(..),
                        vis: Visibility {
-                           _lifetime: PhantomData<&()>,
                            span: None,
-                           kind: Default(
-                               ItemId(..),
-                           ),
+                           sem: Visibility {
+                               _lifetime: PhantomData<&()>,
+                               kind: Default(
+                                   ItemId(..),
+                               ),
+                           },
                        },
                        ident: Ident {
                            name: "print_with_body_with_lifetime",

--- a/marker_uilints/tests/ui/item/print_async_fn.stderr
+++ b/marker_uilints/tests/ui/item/print_async_fn.stderr
@@ -13,7 +13,7 @@ warning: printing item with body
                           span: None,
                           sem: Visibility {
                               _lifetime: PhantomData<&()>,
-                              kind: Default(
+                              kind: DefaultCrate(
                                   ItemId(..),
                               ),
                           },
@@ -97,7 +97,7 @@ warning: printing item with body
                           span: None,
                           sem: Visibility {
                               _lifetime: PhantomData<&()>,
-                              kind: Default(
+                              kind: DefaultCrate(
                                   ItemId(..),
                               ),
                           },
@@ -529,7 +529,7 @@ warning: printing item with body
                            span: None,
                            sem: Visibility {
                                _lifetime: PhantomData<&()>,
-                               kind: Default(
+                               kind: DefaultCrate(
                                    ItemId(..),
                                ),
                            },

--- a/marker_uilints/tests/ui/item/print_fn_item.stderr
+++ b/marker_uilints/tests/ui/item/print_fn_item.stderr
@@ -9,7 +9,13 @@ warning: printing item
                   data: CommonItemData {
                       id: ItemId(..),
                       span: SpanId(..),
-                      vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                      vis: Visibility {
+                          _lifetime: PhantomData<&()>,
+                          span: Some(
+                              SpanId(..),
+                          ),
+                          kind: Public,
+                      },
                       ident: Ident {
                           name: "print_me_simple",
                           span: $DIR/print_fn_item.rs:1:8 - 1:23,
@@ -45,7 +51,13 @@ warning: printing item
                   data: CommonItemData {
                       id: ItemId(..),
                       span: SpanId(..),
-                      vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                      vis: Visibility {
+                          _lifetime: PhantomData<&()>,
+                          span: Some(
+                              SpanId(..),
+                          ),
+                          kind: Public,
+                      },
                       ident: Ident {
                           name: "print_me_special",
                           span: $DIR/print_fn_item.rs:3:21 - 3:37,
@@ -80,7 +92,13 @@ warning: printing item
                   data: CommonItemData {
                       id: ItemId(..),
                       span: SpanId(..),
-                      vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                      vis: Visibility {
+                          _lifetime: PhantomData<&()>,
+                          span: Some(
+                              SpanId(..),
+                          ),
+                          kind: Public,
+                      },
                       ident: Ident {
                           name: "print_me_params",
                           span: $DIR/print_fn_item.rs:5:8 - 5:23,
@@ -237,7 +255,11 @@ warning: printing item
                    data: CommonItemData {
                        id: ItemId(..),
                        span: SpanId(..),
-                       vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                       vis: Visibility {
+                           _lifetime: PhantomData<&()>,
+                           span: None,
+                           kind: DefaultPub,
+                       },
                        ident: Ident {
                            name: "print_me_trait_with_body",
                            span: $DIR/print_fn_item.rs:10:8 - 10:32,
@@ -394,7 +416,11 @@ warning: printing item
                    data: CommonItemData {
                        id: ItemId(..),
                        span: SpanId(..),
-                       vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                       vis: Visibility {
+                           _lifetime: PhantomData<&()>,
+                           span: None,
+                           kind: DefaultPub,
+                       },
                        ident: Ident {
                            name: "print_me_trait_no_body",
                            span: $DIR/print_fn_item.rs:14:8 - 14:30,

--- a/marker_uilints/tests/ui/item/print_fn_item.stderr
+++ b/marker_uilints/tests/ui/item/print_fn_item.stderr
@@ -10,11 +10,13 @@ warning: printing item
                       id: ItemId(..),
                       span: SpanId(..),
                       vis: Visibility {
-                          _lifetime: PhantomData<&()>,
                           span: Some(
                               SpanId(..),
                           ),
-                          kind: Public,
+                          sem: Visibility {
+                              _lifetime: PhantomData<&()>,
+                              kind: Public,
+                          },
                       },
                       ident: Ident {
                           name: "print_me_simple",
@@ -52,11 +54,13 @@ warning: printing item
                       id: ItemId(..),
                       span: SpanId(..),
                       vis: Visibility {
-                          _lifetime: PhantomData<&()>,
                           span: Some(
                               SpanId(..),
                           ),
-                          kind: Public,
+                          sem: Visibility {
+                              _lifetime: PhantomData<&()>,
+                              kind: Public,
+                          },
                       },
                       ident: Ident {
                           name: "print_me_special",
@@ -93,11 +97,13 @@ warning: printing item
                       id: ItemId(..),
                       span: SpanId(..),
                       vis: Visibility {
-                          _lifetime: PhantomData<&()>,
                           span: Some(
                               SpanId(..),
                           ),
-                          kind: Public,
+                          sem: Visibility {
+                              _lifetime: PhantomData<&()>,
+                              kind: Public,
+                          },
                       },
                       ident: Ident {
                           name: "print_me_params",
@@ -256,9 +262,11 @@ warning: printing item
                        id: ItemId(..),
                        span: SpanId(..),
                        vis: Visibility {
-                           _lifetime: PhantomData<&()>,
                            span: None,
-                           kind: DefaultPub,
+                           sem: Visibility {
+                               _lifetime: PhantomData<&()>,
+                               kind: DefaultPub,
+                           },
                        },
                        ident: Ident {
                            name: "print_me_trait_with_body",
@@ -417,9 +425,11 @@ warning: printing item
                        id: ItemId(..),
                        span: SpanId(..),
                        vis: Visibility {
-                           _lifetime: PhantomData<&()>,
                            span: None,
-                           kind: DefaultPub,
+                           sem: Visibility {
+                               _lifetime: PhantomData<&()>,
+                               kind: DefaultPub,
+                           },
                        },
                        ident: Ident {
                            name: "print_me_trait_no_body",

--- a/marker_uilints/tests/ui/item/print_me_root_module.stderr
+++ b/marker_uilints/tests/ui/item/print_me_root_module.stderr
@@ -5,7 +5,13 @@ warning: printing item
                   data: CommonItemData {
                       id: ItemId(..),
                       span: SpanId(..),
-                      vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                      vis: Visibility {
+                          span: None,
+                          sem: Visibility {
+                              _lifetime: PhantomData<&()>,
+                              kind: DefaultPub,
+                          },
+                      },
                       ident: Ident {
                           name: "print_me_root_module",
                           span: $DIR/print_me_root_module.rs:1:1 - 1:1,
@@ -17,7 +23,15 @@ warning: printing item
                               data: CommonItemData {
                                   id: ItemId(..),
                                   span: SpanId(..),
-                                  vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                                  vis: Visibility {
+                                      span: None,
+                                      sem: Visibility {
+                                          _lifetime: PhantomData<&()>,
+                                          kind: Default(
+                                              ItemId(..),
+                                          ),
+                                      },
+                                  },
                                   ident: Ident {
                                       name: "main",
                                       span: $DIR/print_me_root_module.rs:7:4 - 7:8,

--- a/marker_uilints/tests/ui/item/print_me_root_module.stderr
+++ b/marker_uilints/tests/ui/item/print_me_root_module.stderr
@@ -27,7 +27,7 @@ warning: printing item
                                       span: None,
                                       sem: Visibility {
                                           _lifetime: PhantomData<&()>,
-                                          kind: Default(
+                                          kind: DefaultCrate(
                                               ItemId(..),
                                           ),
                                       },

--- a/marker_uilints/tests/ui/item/test_visibility.rs
+++ b/marker_uilints/tests/ui/item/test_visibility.rs
@@ -1,0 +1,17 @@
+fn test_vis_private() {}
+
+pub fn test_vis_public() {}
+
+mod module {
+    pub(crate) fn test_vis_pub_crate() {}
+
+    pub(super) fn test_vis_pub_super_crate_root() {}
+
+    mod nested {
+        pub(super) fn test_vis_pub_super() {}
+
+        pub(in crate::module) fn test_vis_pub_in_path() {}
+    }
+}
+
+fn main() {}

--- a/marker_uilints/tests/ui/item/test_visibility.stderr
+++ b/marker_uilints/tests/ui/item/test_visibility.stderr
@@ -4,12 +4,10 @@ warning: can you see this item?
 1 | fn test_vis_private() {}
   |    ^^^^^^^^^^^^^^^^
   |
-  = note: vis.is_pub()                  -> false
-  = note: vis.is_pub_in_path()          -> false
-  = note: vis.is_pub_crate()            -> false
-  = note: vis.is_default()              -> true
-  = note: vis.pub_with_path_module_id() -> None
-  = note: vis.module_id()               -> Some(ItemId(..))
+  = note: vis.is_default()      -> true
+  = note: vis.is_pub()          -> false
+  = note: vis.is_crate_scoped() -> true
+  = note: vis.scope()           -> Some(ItemId(..))
   = note: vis.span(): `None`
   = note: `#[warn(marker::marker_uilints::test_item_visibility)]` on by default
 
@@ -19,12 +17,10 @@ warning: can you see this item?
 3 | pub fn test_vis_public() {}
   |        ^^^^^^^^^^^^^^^
   |
-  = note: vis.is_pub()                  -> true
-  = note: vis.is_pub_in_path()          -> false
-  = note: vis.is_pub_crate()            -> false
-  = note: vis.is_default()              -> false
-  = note: vis.pub_with_path_module_id() -> None
-  = note: vis.module_id()               -> None
+  = note: vis.is_default()      -> false
+  = note: vis.is_pub()          -> true
+  = note: vis.is_crate_scoped() -> false
+  = note: vis.scope()           -> None
   = note: vis.span(): `Some("pub")`
 
 warning: can you see this item?
@@ -33,12 +29,10 @@ warning: can you see this item?
 6 |     pub(crate) fn test_vis_pub_crate() {}
   |                   ^^^^^^^^^^^^^^^^^^
   |
-  = note: vis.is_pub()                  -> false
-  = note: vis.is_pub_in_path()          -> false
-  = note: vis.is_pub_crate()            -> true
-  = note: vis.is_default()              -> false
-  = note: vis.pub_with_path_module_id() -> Some(ItemId(..))
-  = note: vis.module_id()               -> Some(ItemId(..))
+  = note: vis.is_default()      -> false
+  = note: vis.is_pub()          -> false
+  = note: vis.is_crate_scoped() -> true
+  = note: vis.scope()           -> Some(ItemId(..))
   = note: vis.span(): `Some("pub(crate)")`
 
 warning: can you see this item?
@@ -47,12 +41,10 @@ warning: can you see this item?
 8 |     pub(super) fn test_vis_pub_super_crate_root() {}
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: vis.is_pub()                  -> false
-  = note: vis.is_pub_in_path()          -> false
-  = note: vis.is_pub_crate()            -> true
-  = note: vis.is_default()              -> false
-  = note: vis.pub_with_path_module_id() -> Some(ItemId(..))
-  = note: vis.module_id()               -> Some(ItemId(..))
+  = note: vis.is_default()      -> false
+  = note: vis.is_pub()          -> false
+  = note: vis.is_crate_scoped() -> true
+  = note: vis.scope()           -> Some(ItemId(..))
   = note: vis.span(): `Some("pub(super)")`
 
 warning: can you see this item?
@@ -61,12 +53,10 @@ warning: can you see this item?
 11 |         pub(super) fn test_vis_pub_super() {}
    |                       ^^^^^^^^^^^^^^^^^^
    |
-   = note: vis.is_pub()                  -> false
-   = note: vis.is_pub_in_path()          -> true
-   = note: vis.is_pub_crate()            -> false
-   = note: vis.is_default()              -> false
-   = note: vis.pub_with_path_module_id() -> Some(ItemId(..))
-   = note: vis.module_id()               -> Some(ItemId(..))
+   = note: vis.is_default()      -> false
+   = note: vis.is_pub()          -> false
+   = note: vis.is_crate_scoped() -> false
+   = note: vis.scope()           -> Some(ItemId(..))
    = note: vis.span(): `Some("pub(super)")`
 
 warning: can you see this item?
@@ -75,12 +65,10 @@ warning: can you see this item?
 13 |         pub(in crate::module) fn test_vis_pub_in_path() {}
    |                                  ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: vis.is_pub()                  -> false
-   = note: vis.is_pub_in_path()          -> true
-   = note: vis.is_pub_crate()            -> false
-   = note: vis.is_default()              -> false
-   = note: vis.pub_with_path_module_id() -> Some(ItemId(..))
-   = note: vis.module_id()               -> Some(ItemId(..))
+   = note: vis.is_default()      -> false
+   = note: vis.is_pub()          -> false
+   = note: vis.is_crate_scoped() -> false
+   = note: vis.scope()           -> Some(ItemId(..))
    = note: vis.span(): `Some("pub(in crate::module)")`
 
 warning: 6 warnings emitted

--- a/marker_uilints/tests/ui/item/test_visibility.stderr
+++ b/marker_uilints/tests/ui/item/test_visibility.stderr
@@ -7,7 +7,7 @@ warning: can you see this item?
   = note: vis.is_pub()                  -> false
   = note: vis.is_pub_with_path()        -> false
   = note: vis.is_pub_crate()            -> false
-  = note: vis.is_defined()              -> false
+  = note: vis.is_explicit()             -> false
   = note: vis.pub_with_path_module_id() -> None
   = note: vis.module_id()               -> Some(ItemId(..))
   = note: vis.span(): `None`
@@ -22,7 +22,7 @@ warning: can you see this item?
   = note: vis.is_pub()                  -> true
   = note: vis.is_pub_with_path()        -> false
   = note: vis.is_pub_crate()            -> false
-  = note: vis.is_defined()              -> true
+  = note: vis.is_explicit()             -> true
   = note: vis.pub_with_path_module_id() -> None
   = note: vis.module_id()               -> None
   = note: vis.span(): `Some("pub")`
@@ -36,7 +36,7 @@ warning: can you see this item?
   = note: vis.is_pub()                  -> false
   = note: vis.is_pub_with_path()        -> true
   = note: vis.is_pub_crate()            -> true
-  = note: vis.is_defined()              -> true
+  = note: vis.is_explicit()             -> true
   = note: vis.pub_with_path_module_id() -> Some(ItemId(..))
   = note: vis.module_id()               -> Some(ItemId(..))
   = note: vis.span(): `Some("pub(crate)")`
@@ -50,7 +50,7 @@ warning: can you see this item?
   = note: vis.is_pub()                  -> false
   = note: vis.is_pub_with_path()        -> true
   = note: vis.is_pub_crate()            -> true
-  = note: vis.is_defined()              -> true
+  = note: vis.is_explicit()             -> true
   = note: vis.pub_with_path_module_id() -> Some(ItemId(..))
   = note: vis.module_id()               -> Some(ItemId(..))
   = note: vis.span(): `Some("pub(super)")`
@@ -64,7 +64,7 @@ warning: can you see this item?
    = note: vis.is_pub()                  -> false
    = note: vis.is_pub_with_path()        -> true
    = note: vis.is_pub_crate()            -> false
-   = note: vis.is_defined()              -> true
+   = note: vis.is_explicit()             -> true
    = note: vis.pub_with_path_module_id() -> Some(ItemId(..))
    = note: vis.module_id()               -> Some(ItemId(..))
    = note: vis.span(): `Some("pub(super)")`
@@ -78,7 +78,7 @@ warning: can you see this item?
    = note: vis.is_pub()                  -> false
    = note: vis.is_pub_with_path()        -> true
    = note: vis.is_pub_crate()            -> false
-   = note: vis.is_defined()              -> true
+   = note: vis.is_explicit()             -> true
    = note: vis.pub_with_path_module_id() -> Some(ItemId(..))
    = note: vis.module_id()               -> Some(ItemId(..))
    = note: vis.span(): `Some("pub(in crate::module)")`

--- a/marker_uilints/tests/ui/item/test_visibility.stderr
+++ b/marker_uilints/tests/ui/item/test_visibility.stderr
@@ -1,0 +1,87 @@
+warning: can you see this item?
+ --> $DIR/test_visibility.rs:1:4
+  |
+1 | fn test_vis_private() {}
+  |    ^^^^^^^^^^^^^^^^
+  |
+  = note: vis.is_pub()                  -> false
+  = note: vis.is_pub_with_path()        -> false
+  = note: vis.is_pub_crate()            -> false
+  = note: vis.is_defined()              -> false
+  = note: vis.pub_with_path_module_id() -> None
+  = note: vis.module_id()               -> Some(ItemId(..))
+  = note: vis.span(): `None`
+  = note: `#[warn(marker::marker_uilints::test_item_visibility)]` on by default
+
+warning: can you see this item?
+ --> $DIR/test_visibility.rs:3:8
+  |
+3 | pub fn test_vis_public() {}
+  |        ^^^^^^^^^^^^^^^
+  |
+  = note: vis.is_pub()                  -> true
+  = note: vis.is_pub_with_path()        -> false
+  = note: vis.is_pub_crate()            -> false
+  = note: vis.is_defined()              -> true
+  = note: vis.pub_with_path_module_id() -> None
+  = note: vis.module_id()               -> None
+  = note: vis.span(): `Some("pub")`
+
+warning: can you see this item?
+ --> $DIR/test_visibility.rs:6:19
+  |
+6 |     pub(crate) fn test_vis_pub_crate() {}
+  |                   ^^^^^^^^^^^^^^^^^^
+  |
+  = note: vis.is_pub()                  -> false
+  = note: vis.is_pub_with_path()        -> true
+  = note: vis.is_pub_crate()            -> true
+  = note: vis.is_defined()              -> true
+  = note: vis.pub_with_path_module_id() -> Some(ItemId(..))
+  = note: vis.module_id()               -> Some(ItemId(..))
+  = note: vis.span(): `Some("pub(crate)")`
+
+warning: can you see this item?
+ --> $DIR/test_visibility.rs:8:19
+  |
+8 |     pub(super) fn test_vis_pub_super_crate_root() {}
+  |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: vis.is_pub()                  -> false
+  = note: vis.is_pub_with_path()        -> true
+  = note: vis.is_pub_crate()            -> true
+  = note: vis.is_defined()              -> true
+  = note: vis.pub_with_path_module_id() -> Some(ItemId(..))
+  = note: vis.module_id()               -> Some(ItemId(..))
+  = note: vis.span(): `Some("pub(super)")`
+
+warning: can you see this item?
+  --> $DIR/test_visibility.rs:11:23
+   |
+11 |         pub(super) fn test_vis_pub_super() {}
+   |                       ^^^^^^^^^^^^^^^^^^
+   |
+   = note: vis.is_pub()                  -> false
+   = note: vis.is_pub_with_path()        -> true
+   = note: vis.is_pub_crate()            -> false
+   = note: vis.is_defined()              -> true
+   = note: vis.pub_with_path_module_id() -> Some(ItemId(..))
+   = note: vis.module_id()               -> Some(ItemId(..))
+   = note: vis.span(): `Some("pub(super)")`
+
+warning: can you see this item?
+  --> $DIR/test_visibility.rs:13:34
+   |
+13 |         pub(in crate::module) fn test_vis_pub_in_path() {}
+   |                                  ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: vis.is_pub()                  -> false
+   = note: vis.is_pub_with_path()        -> true
+   = note: vis.is_pub_crate()            -> false
+   = note: vis.is_defined()              -> true
+   = note: vis.pub_with_path_module_id() -> Some(ItemId(..))
+   = note: vis.module_id()               -> Some(ItemId(..))
+   = note: vis.span(): `Some("pub(in crate::module)")`
+
+warning: 6 warnings emitted
+

--- a/marker_uilints/tests/ui/item/test_visibility.stderr
+++ b/marker_uilints/tests/ui/item/test_visibility.stderr
@@ -5,9 +5,9 @@ warning: can you see this item?
   |    ^^^^^^^^^^^^^^^^
   |
   = note: vis.is_pub()                  -> false
-  = note: vis.is_pub_with_path()        -> false
+  = note: vis.is_pub_in_path()          -> false
   = note: vis.is_pub_crate()            -> false
-  = note: vis.is_explicit()             -> false
+  = note: vis.is_default()              -> true
   = note: vis.pub_with_path_module_id() -> None
   = note: vis.module_id()               -> Some(ItemId(..))
   = note: vis.span(): `None`
@@ -20,9 +20,9 @@ warning: can you see this item?
   |        ^^^^^^^^^^^^^^^
   |
   = note: vis.is_pub()                  -> true
-  = note: vis.is_pub_with_path()        -> false
+  = note: vis.is_pub_in_path()          -> false
   = note: vis.is_pub_crate()            -> false
-  = note: vis.is_explicit()             -> true
+  = note: vis.is_default()              -> false
   = note: vis.pub_with_path_module_id() -> None
   = note: vis.module_id()               -> None
   = note: vis.span(): `Some("pub")`
@@ -34,9 +34,9 @@ warning: can you see this item?
   |                   ^^^^^^^^^^^^^^^^^^
   |
   = note: vis.is_pub()                  -> false
-  = note: vis.is_pub_with_path()        -> true
+  = note: vis.is_pub_in_path()          -> false
   = note: vis.is_pub_crate()            -> true
-  = note: vis.is_explicit()             -> true
+  = note: vis.is_default()              -> false
   = note: vis.pub_with_path_module_id() -> Some(ItemId(..))
   = note: vis.module_id()               -> Some(ItemId(..))
   = note: vis.span(): `Some("pub(crate)")`
@@ -48,9 +48,9 @@ warning: can you see this item?
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: vis.is_pub()                  -> false
-  = note: vis.is_pub_with_path()        -> true
+  = note: vis.is_pub_in_path()          -> false
   = note: vis.is_pub_crate()            -> true
-  = note: vis.is_explicit()             -> true
+  = note: vis.is_default()              -> false
   = note: vis.pub_with_path_module_id() -> Some(ItemId(..))
   = note: vis.module_id()               -> Some(ItemId(..))
   = note: vis.span(): `Some("pub(super)")`
@@ -62,9 +62,9 @@ warning: can you see this item?
    |                       ^^^^^^^^^^^^^^^^^^
    |
    = note: vis.is_pub()                  -> false
-   = note: vis.is_pub_with_path()        -> true
+   = note: vis.is_pub_in_path()          -> true
    = note: vis.is_pub_crate()            -> false
-   = note: vis.is_explicit()             -> true
+   = note: vis.is_default()              -> false
    = note: vis.pub_with_path_module_id() -> Some(ItemId(..))
    = note: vis.module_id()               -> Some(ItemId(..))
    = note: vis.span(): `Some("pub(super)")`
@@ -76,9 +76,9 @@ warning: can you see this item?
    |                                  ^^^^^^^^^^^^^^^^^^^^
    |
    = note: vis.is_pub()                  -> false
-   = note: vis.is_pub_with_path()        -> true
+   = note: vis.is_pub_in_path()          -> true
    = note: vis.is_pub_crate()            -> false
-   = note: vis.is_explicit()             -> true
+   = note: vis.is_default()              -> false
    = note: vis.pub_with_path_module_id() -> Some(ItemId(..))
    = note: vis.module_id()               -> Some(ItemId(..))
    = note: vis.span(): `Some("pub(in crate::module)")`

--- a/marker_uilints/tests/ui/print_adt_item.stderr
+++ b/marker_uilints/tests/ui/print_adt_item.stderr
@@ -10,11 +10,13 @@ warning: printing item
                       id: ItemId(..),
                       span: SpanId(..),
                       vis: Visibility {
-                          _lifetime: PhantomData<&()>,
                           span: Some(
                               SpanId(..),
                           ),
-                          kind: Public,
+                          sem: Visibility {
+                              _lifetime: PhantomData<&()>,
+                              kind: Public,
+                          },
                       },
                       ident: Ident {
                           name: "PrintMeEnum",

--- a/marker_uilints/tests/ui/print_adt_item.stderr
+++ b/marker_uilints/tests/ui/print_adt_item.stderr
@@ -9,7 +9,13 @@ warning: printing item
                   data: CommonItemData {
                       id: ItemId(..),
                       span: SpanId(..),
-                      vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                      vis: Visibility {
+                          _lifetime: PhantomData<&()>,
+                          span: Some(
+                              SpanId(..),
+                          ),
+                          kind: Public,
+                      },
                       ident: Ident {
                           name: "PrintMeEnum",
                           span: $DIR/print_adt_item.rs:1:10 - 1:21,

--- a/marker_uilints/tests/ui/print_const_generics.stderr
+++ b/marker_uilints/tests/ui/print_const_generics.stderr
@@ -10,11 +10,13 @@ warning: printing item
                       id: ItemId(..),
                       span: SpanId(..),
                       vis: Visibility {
-                          _lifetime: PhantomData<&()>,
                           span: None,
-                          kind: Default(
-                              ItemId(..),
-                          ),
+                          sem: Visibility {
+                              _lifetime: PhantomData<&()>,
+                              kind: Default(
+                                  ItemId(..),
+                              ),
+                          },
                       },
                       ident: Ident {
                           name: "PrintMeConstGenerics",
@@ -48,11 +50,13 @@ warning: printing item
                           ItemField {
                               id: FieldId(..),
                               vis: Visibility {
-                                  _lifetime: PhantomData<&()>,
                                   span: None,
-                                  kind: Default(
-                                      ItemId(..),
-                                  ),
+                                  sem: Visibility {
+                                      _lifetime: PhantomData<&()>,
+                                      kind: Default(
+                                          ItemId(..),
+                                      ),
+                                  },
                               },
                               ident: SymbolId(..),
                               ty: Array(
@@ -125,11 +129,13 @@ warning: printing item
                       id: ItemId(..),
                       span: SpanId(..),
                       vis: Visibility {
-                          _lifetime: PhantomData<&()>,
                           span: None,
-                          kind: Default(
-                              ItemId(..),
-                          ),
+                          sem: Visibility {
+                              _lifetime: PhantomData<&()>,
+                              kind: Default(
+                                  ItemId(..),
+                              ),
+                          },
                       },
                       ident: Ident {
                           name: "print_me",

--- a/marker_uilints/tests/ui/print_const_generics.stderr
+++ b/marker_uilints/tests/ui/print_const_generics.stderr
@@ -9,7 +9,13 @@ warning: printing item
                   data: CommonItemData {
                       id: ItemId(..),
                       span: SpanId(..),
-                      vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                      vis: Visibility {
+                          _lifetime: PhantomData<&()>,
+                          span: None,
+                          kind: Default(
+                              ItemId(..),
+                          ),
+                      },
                       ident: Ident {
                           name: "PrintMeConstGenerics",
                           span: $DIR/print_const_generics.rs:1:8 - 1:28,
@@ -41,7 +47,13 @@ warning: printing item
                       [
                           ItemField {
                               id: FieldId(..),
-                              vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                              vis: Visibility {
+                                  _lifetime: PhantomData<&()>,
+                                  span: None,
+                                  kind: Default(
+                                      ItemId(..),
+                                  ),
+                              },
                               ident: SymbolId(..),
                               ty: Array(
                                   ArrayTy {
@@ -112,7 +124,13 @@ warning: printing item
                   data: CommonItemData {
                       id: ItemId(..),
                       span: SpanId(..),
-                      vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                      vis: Visibility {
+                          _lifetime: PhantomData<&()>,
+                          span: None,
+                          kind: Default(
+                              ItemId(..),
+                          ),
+                      },
                       ident: Ident {
                           name: "print_me",
                           span: $DIR/print_const_generics.rs:5:4 - 5:12,

--- a/marker_uilints/tests/ui/print_const_generics.stderr
+++ b/marker_uilints/tests/ui/print_const_generics.stderr
@@ -13,7 +13,7 @@ warning: printing item
                           span: None,
                           sem: Visibility {
                               _lifetime: PhantomData<&()>,
-                              kind: Default(
+                              kind: DefaultCrate(
                                   ItemId(..),
                               ),
                           },
@@ -53,7 +53,7 @@ warning: printing item
                                   span: None,
                                   sem: Visibility {
                                       _lifetime: PhantomData<&()>,
-                                      kind: Default(
+                                      kind: DefaultCrate(
                                           ItemId(..),
                                       ),
                                   },
@@ -132,7 +132,7 @@ warning: printing item
                           span: None,
                           sem: Visibility {
                               _lifetime: PhantomData<&()>,
-                              kind: Default(
+                              kind: DefaultCrate(
                                   ItemId(..),
                               ),
                           },

--- a/marker_uilints/tests/ui/print_use.stderr
+++ b/marker_uilints/tests/ui/print_use.stderr
@@ -9,7 +9,13 @@ warning: printing item
                   data: CommonItemData {
                       id: ItemId(..),
                       span: SpanId(..),
-                      vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                      vis: Visibility {
+                          _lifetime: PhantomData<&()>,
+                          span: None,
+                          kind: Default(
+                              ItemId(..),
+                          ),
+                      },
                       ident: Ident {
                           name: "PrintMeBTreeMap",
                           span: $DIR/print_use.rs:1:36 - 1:51,
@@ -62,7 +68,13 @@ warning: printing item
                   data: CommonItemData {
                       id: ItemId(..),
                       span: SpanId(..),
-                      vis: Visibility {{ /* WIP: See rust-marker/marker#26 */}},
+                      vis: Visibility {
+                          _lifetime: PhantomData<&()>,
+                          span: None,
+                          kind: Default(
+                              ItemId(..),
+                          ),
+                      },
                       ident: Ident {
                           name: "PrintMeHashMap",
                           span: $DIR/print_use.rs:1:64 - 1:78,

--- a/marker_uilints/tests/ui/print_use.stderr
+++ b/marker_uilints/tests/ui/print_use.stderr
@@ -13,7 +13,7 @@ warning: printing item
                           span: None,
                           sem: Visibility {
                               _lifetime: PhantomData<&()>,
-                              kind: Default(
+                              kind: DefaultCrate(
                                   ItemId(..),
                               ),
                           },
@@ -74,7 +74,7 @@ warning: printing item
                           span: None,
                           sem: Visibility {
                               _lifetime: PhantomData<&()>,
-                              kind: Default(
+                              kind: DefaultCrate(
                                   ItemId(..),
                               ),
                           },

--- a/marker_uilints/tests/ui/print_use.stderr
+++ b/marker_uilints/tests/ui/print_use.stderr
@@ -10,11 +10,13 @@ warning: printing item
                       id: ItemId(..),
                       span: SpanId(..),
                       vis: Visibility {
-                          _lifetime: PhantomData<&()>,
                           span: None,
-                          kind: Default(
-                              ItemId(..),
-                          ),
+                          sem: Visibility {
+                              _lifetime: PhantomData<&()>,
+                              kind: Default(
+                                  ItemId(..),
+                              ),
+                          },
                       },
                       ident: Ident {
                           name: "PrintMeBTreeMap",
@@ -69,11 +71,13 @@ warning: printing item
                       id: ItemId(..),
                       span: SpanId(..),
                       vis: Visibility {
-                          _lifetime: PhantomData<&()>,
                           span: None,
-                          kind: Default(
-                              ItemId(..),
-                          ),
+                          sem: Visibility {
+                              _lifetime: PhantomData<&()>,
+                              kind: Default(
+                                  ItemId(..),
+                              ),
+                          },
                       },
                       ident: Ident {
                           name: "PrintMeHashMap",


### PR DESCRIPTION
Designing a sensible `Visibility` representation is surprisingly hard. I had to update the function names several times, and still feel like they can be improved. There is also still one util function missing, which requires the implementation of https://github.com/rust-marker/marker/issues/242 first. I've left a corresponding comment in the PR.

I think this implementation will cover 99% of the current use cases. This PR also updates the `not_using_has_span_trait` lint and enables it by default inside the `marker_api` crate

---

Closes: rust-marker/marker#26