### PR TITLE
Fix archive layout for marker_rustc_driver on ARM

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -156,9 +156,9 @@ jobs:
           run: |
             export PATH="/root/.cargo/bin:$PATH"
             cargo build -p marker_rustc_driver --release
-            cp target/release/marker_rustc_driver /artifacts/${{ env.artifact }}
+            cp target/release/marker_rustc_driver /artifacts/marker_rustc_driver
 
-      - run: ./scripts/release/upload.sh ${{ github.ref_name }} ${{ env.artifact }}
+      - run: ./scripts/release/upload.sh ${{ github.ref_name }} marker_rustc_driver ${{ env.artifact }}
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,11 +55,8 @@ jobs:
           --commit "🚧 Development v${{ env.next_dev_version }}"
 
       # Push the changes to the remote
-      - run: git push origin ${{ github.ref_name }} --force-with-lease
-
-      # We use `--force` because the tags that are pushed here will include the
-      # sliding `v{major}` and `v{major}.{minor}` tags, so we have to overwrite
-      # them with the new ones. To prevent force-pushing the master branch we
-      # do this push with --force in a separate step, so it's not fully atomic,
-      # but it's good enough.
-      - run: git push --force --atomic origin ${{ env.tags }}
+      #
+      # We use `--force-with-lease` because the tags that are pushed here will
+      # include the  sliding `v{major}` and `v{major}.{minor}` tags, so we have
+      # to overwrite them with the new ones.
+      - run: git push --force-with-lease --atomic origin ${{ github.ref_name }} ${{ env.tags }}

--- a/scripts/release/upload.sh
+++ b/scripts/release/upload.sh
@@ -6,17 +6,23 @@ script_dir=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 
 . $script_dir/../lib.sh
 
+# The tag of the release that will be updated with the new artifact
 tag="$1"
+
+# Path to the file on the local file system that will be uploaded to GitHub
 file="$2"
 
-with_log tar --auto-compress --create --file "$file.tar.gz" "$file"
-with_log zip -r $file.zip $file
+# The name of the artifact that will be uploaded to GitHub
+artifact="$3"
 
-with_log shasum -a 256 "$file.tar.gz" "$file.zip" > "$file.sha256"
+with_log tar --auto-compress --create --file "$artifact.tar.gz" "$file"
+with_log zip -r $artifact.zip $file
+
+with_log shasum -a 256 "$artifact.tar.gz" "$artifact.zip" > "$artifact.sha256"
 
 with_backoff gh release upload \
     "$tag" \
-    "$file.tar.gz" \
-    "$file.zip" \
-    "$file.sha256" \
+    "$artifact.tar.gz" \
+    "$artifact.zip" \
+    "$artifact.sha256" \
     --clobber


### PR DESCRIPTION
The layout of `marker_rustc_driver-aarch64-unknown-linux-gnu.tar.gz` and `zip` turns out to differ from the layout of all other artifacts. This is because this version of driver is compiled separately using a custom quemu setup, packaging and upload and so it went slightly wrong.

The difference is that the file inside of the archive contains the architecture suffix, but it shouldn't.

I've manually updated the current 0.3.0 release by downloading the marker_rustc_driver ARM build, decompressing it, renaming the file to `marker_rustc_driver`, and running the part of `upload.sh` script that does the packaging.