### PR TITLE
Run doc tests for binaries on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - run: cargo test --locked
+      - run: cargo test --locked --all-features --all-targets
+      - run: cargo test --locked --all-features --doc
 
   rust-lint:
     runs-on: ${{ matrix.os }}-latest

--- a/marker_rustc_driver/src/conversion/marker/ast/expr.rs
+++ b/marker_rustc_driver/src/conversion/marker/ast/expr.rs
@@ -505,7 +505,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     /// understand how this desugaring works. Here is a simple example to
     /// illustrate the current desugar:
     ///
-    /// ```
+    /// ```ignore
     /// # let mut a = 0;
     /// # let mut b = 0;
     /// // This expression
@@ -603,6 +603,7 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
     /// # let range = 0..10;
     /// // This expression
     /// for _ in range { /* body */ }
+    /// # let range = 0..10;
     /// // Is desugared to:
     /// match IntoIterator::into_iter(range) {
     ///     mut iter =>


### PR DESCRIPTION
Turns out a simple `cargo test` doesn't run doctests for binaries. It does run them for libraries though.

The solution is to separate the test command into two `cargo test --all-targets` (which, unintuitively, doesn't invoke doc tests https://github.com/rust-lang/cargo/issues/6669), and then run `cargo test --doc`.

This doesn't solve https://github.com/rust-marker/marker/issues/303 though.