### PR TITLE
Improve retries in the installation scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,12 @@ jobs:
       #
       # At least this checks that our installation script works as expected.
       - uses: ./
+        env:
+          # Given the default retry sequence of 1, 2, 4, 8, 16, 32, 60, 60, 60, ... 60 (seconds),
+          # this number of retries will give us approximately 30 minutes of total retry time.
+          # This is necessary to make CI wait for the release artifacts to be available on Github
+          # when a new version is released.
+          MARKER_NET_RETRY_COUNT: 35
         with:
           install-only: true
 

--- a/docs/book/src/usage/ci.md
+++ b/docs/book/src/usage/ci.md
@@ -38,6 +38,16 @@ All inputs are optional, they only allow tweaking the default behavior.
 |----------------|---------------------------------------------------------------|-----------|---------|
 | `install-only` | Only install Marker but don't run the `cargo marker` command. | `boolean` | `false` |
 
+
+### Environment variables
+
+| Name                         | Description                                                              | Type      | Default |
+|------------------------------|--------------------------------------------------------------------------|-----------|---------|
+| `MARKER_NET_RETRY_COUNT`     | Max number of retries for downloads. This also sets `RUSTUP_MAX_RETRIES` | `integer` | `5`     |
+| `MARKER_NET_RETRY_MAX_DELAY` | Max delay between subsequent retries for downloads in seconds            | `integer` | `60`    |
+
+These environment variables configure the behavior of the installation script and they may be used if you run that script directly as well e.g. on [other CI systems](#other-ci-systems).
+
 ### Example workflows
 
 These example workflows will use the lint crates specified in the `Cargo.toml` file by default. Refer to the [*Lint Crate Declaration*](./lint-crate-declaration.md) section for more information.
@@ -115,7 +125,7 @@ curl \
     --fail \
     --show-error \
     --retry 5 \
-    --retry-connrefused \
+    --retry-all-errors \
     https://raw.githubusercontent.com/rust-marker/marker/v0.3/scripts/release/install.sh \
     | bash
 ```
@@ -128,14 +138,17 @@ curl.exe `
     --fail `
     --show-error `
     --retry 5 `
-    --retry-connrefused `
+    --retry-all-errors `
     https://raw.githubusercontent.com/rust-marker/marker/v0.3/scripts/release/install.ps1 `
     | powershell -command -
 ```
 
 <!-- endregion replace marker version stable -->
 
+Both of these scripts are configurable. See the [environment variables](#environment-variables) for details on what's available.
+
 The available version git tags that you may use in the URL are described in the [git tags](#git-tags) paragraph of the Github Action.
 
+[`RUSTUP_MAX_RETRIES`]: https://github.com/rust-lang/rustup/blob/5af4bc4a0d4bc69ea9091a7935fb3783c5fb508e/doc/dev-guide/src/tips-and-tricks.md#rustup_max_retries
 [new issue]: https://gitHub.com/rust-marker/marker/issues/new/choose
 [OS images supported by managed GitHub Actions runners]: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

--- a/scripts/download/lib.sh
+++ b/scripts/download/lib.sh
@@ -75,6 +75,9 @@ function try_download_and_decompress {
     rm $archive
 }
 
+# Be careful to use this only for HTTP GET requests! This script does aggressive
+# retries, so if you use it for a non-readonly HTTP method that doesn't use any
+# idempotency token validation mechanism you might end up with duplicate modifications.
 function curl_with_retry {
     with_log curl \
         --location \
@@ -82,7 +85,7 @@ function curl_with_retry {
         --show-error \
         --fail \
         --retry 5 \
-        --retry-connrefused \
+        --retry-all-errors \
         "$@"
 }
 

--- a/scripts/release/qemu-setup.sh
+++ b/scripts/release/qemu-setup.sh
@@ -23,7 +23,7 @@ function curl_with_retry {
         --show-error \
         --fail \
         --retry 5 \
-        --retry-connrefused \
+        --retry-all-errors \
         "$@"
 }
 

--- a/scripts/release/set-version.diff
+++ b/scripts/release/set-version.diff
@@ -131,11 +131,11 @@
 -      - uses: rust-marker/marker@vX.Y
 +      - uses: rust-marker/marker@v0.1
          with:
-     --retry-connrefused \
+     --retry-all-errors \
 -    https://raw.githubusercontent.com/rust-marker/marker/vX.Y/scripts/release/install.sh \
 +    https://raw.githubusercontent.com/rust-marker/marker/v0.1/scripts/release/install.sh \
      | bash
-     --retry-connrefused `
+     --retry-all-errors `
 -    https://raw.githubusercontent.com/rust-marker/marker/vX.Y/scripts/release/install.ps1 `
 +    https://raw.githubusercontent.com/rust-marker/marker/v0.1/scripts/release/install.ps1 `
      | powershell -command -


### PR DESCRIPTION
Today on our CI the installation of marker randomly failed:
<img width="856" alt="image" src="https://github.com/rust-marker/marker/assets/36276403/88813cc6-10ea-4fe5-b921-e79ece97d3fa">

GitHub returned 403 due to some internal bugs I suppose. To fix this I added `--retry-all-errors` which should retry in such cases and added more configurations for retries. This way on CI we use the retry config that gives up in 30 minutes. This solves the problem of red master CI when doing a release (part of #274).