### PR TITLE
API: Rename `CallExpr::operand` -> `CallExpr::func`;  `*::pattern` -> `*::pat`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,33 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo fmt --check
 
+  # This check is allowed to fail, while Marker is still unstable. It's mostly
+  # a sanity check, to make sure we don't have any unintentional API breakage :)
+  semver-checks:
+    runs-on: ubuntu-latest
+    # This CI check isn't required to pass just yet.
+    # Marker isn't stable so semver breaking changes are allowed.
+    continue-on-error: true
+    if: ${{ github.event.pull_request }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          path: './upstream'
+      - uses: actions/checkout@v4
+        with:
+          path: './downstream'
+      - run: downstream/scripts/download/cargo-semver-checks.sh
+      - run: >-
+          cargo semver-checks
+          --manifest-path './downstream/Cargo.toml'
+          --package marker_api
+          --package marker_utils
+          --package marker_uitest
+          --baseline-root './upstream'
+          --default-features
+          --release-type minor
+
   # This job ensures required packages can be built with a stable toolchain
   # except for some special ones that require nightly
   rust-check-on-stable:
@@ -138,33 +165,6 @@ jobs:
 
       # Check that the release automation works as expected
       - run: scripts/release/test.sh
-
-  # This check is allowed to fail, while Marker is still unstable. It's mostly
-  # a sanity check, to make sure we don't have any unintentional API breakage :)
-  semver-checks:
-    runs-on: ubuntu-latest
-    # This CI check isn't required to pass just yet.
-    # Marker isn't stable so semver breaking changes are allowed.
-    continue-on-error: true
-    if: ${{ github.event.pull_request }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.base_ref }}
-          path: './upstream'
-      - uses: actions/checkout@v4
-        with:
-          path: './downstream'
-      - run: downstream/scripts/download/cargo-semver-checks.sh
-      - run: >-
-          cargo semver-checks
-          --manifest-path './downstream/Cargo.toml'
-          --package marker_api
-          --package marker_utils
-          --package marker_uitest
-          --baseline-root './upstream'
-          --default-features
-          --release-type minor
 
   # Check that the Github Action works
   github-action-test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The [v0.4.0 milestone] contains a list of planned changes.
 [#288]: https://github.com/rust-marker/marker/pull/288
 [#294]: https://github.com/rust-marker/marker/pull/294
 [#306]: https://github.com/rust-marker/marker/pull/306
+[#309]: https://github.com/rust-marker/marker/pull/309
 
 ### Added
 - [#306]: The `LintPass` trait now as a new `check_crate` method.
@@ -44,6 +45,9 @@ The [v0.4.0 milestone] contains a list of planned changes.
 - [#278]: All public methods that took `&Span` as a parameter now take `impl HasSpan`. This is a minor breaking change, as `&Span` implements `HasSpan`, but if you relied on type inference based on the function parameter type, then making a method generic may break your code.
 - [#288]: Lint identifiers use the lint crate name as a new infix, to prevent name collisions across lint crates.
 - [#306]: The items of a `Crate` are now wrapped in a `ModItem`, that is the root module of the crate.
+- [#309]: Renamed `CallExpr::operand` to `CallExpr::func`
+- [#309]: Renamed `RefPat::pattern()` -> `RefPat::pat()`
+- [#309]: Renamed `OrPat::patterns()` -> `RefPat::pats()`
 
 ## [0.3.0] - 2023-10-05
 

--- a/marker_api/src/ast/expr/call_exprs.rs
+++ b/marker_api/src/ast/expr/call_exprs.rs
@@ -22,17 +22,19 @@ use super::{CommonExprData, ExprKind};
 /// ```
 #[repr(C)]
 #[derive(Debug)]
+#[cfg_attr(feature = "driver-api", derive(typed_builder::TypedBuilder))]
 pub struct CallExpr<'ast> {
     data: CommonExprData<'ast>,
-    operand: ExprKind<'ast>,
+    func: ExprKind<'ast>,
+    #[cfg_attr(feature = "driver-api", builder(setter(into)))]
     args: FfiSlice<'ast, ExprKind<'ast>>,
 }
 
 impl<'ast> CallExpr<'ast> {
     /// The expression identifying what will be called. This will often be a
     /// [`PathExpr`](super::PathExpr).
-    pub fn operand(&self) -> ExprKind<'ast> {
-        self.operand
+    pub fn func(&self) -> ExprKind<'ast> {
+        self.func
     }
 
     /// The arguments given to the operand.
@@ -42,17 +44,6 @@ impl<'ast> CallExpr<'ast> {
 }
 
 super::impl_expr_data!(CallExpr<'ast>, Call);
-
-#[cfg(feature = "driver-api")]
-impl<'ast> CallExpr<'ast> {
-    pub fn new(data: CommonExprData<'ast>, operand: ExprKind<'ast>, args: &'ast [ExprKind<'ast>]) -> Self {
-        Self {
-            data,
-            operand,
-            args: args.into(),
-        }
-    }
-}
 
 #[repr(C)]
 #[derive(Debug)]

--- a/marker_api/src/ast/pat/or_pat.rs
+++ b/marker_api/src/ast/pat/or_pat.rs
@@ -4,14 +4,17 @@ use super::{CommonPatData, PatKind};
 
 #[repr(C)]
 #[derive(Debug)]
+#[cfg_attr(feature = "driver-api", derive(typed_builder::TypedBuilder))]
 pub struct OrPat<'ast> {
     data: CommonPatData<'ast>,
-    patterns: FfiSlice<'ast, PatKind<'ast>>,
+    #[cfg_attr(feature = "driver-api", builder(setter(into)))]
+    pats: FfiSlice<'ast, PatKind<'ast>>,
 }
 
 impl<'ast> OrPat<'ast> {
-    pub fn patterns(&self) -> &[PatKind<'ast>] {
-        (&self.patterns).into()
+    /// The patterns, which are considered by this or pattern.
+    pub fn pats(&self) -> &[PatKind<'ast>] {
+        (&self.pats).into()
     }
 }
 
@@ -22,7 +25,7 @@ impl<'ast> OrPat<'ast> {
     pub fn new(data: CommonPatData<'ast>, patterns: &'ast [PatKind<'ast>]) -> Self {
         Self {
             data,
-            patterns: patterns.into(),
+            pats: patterns.into(),
         }
     }
 }

--- a/marker_api/src/ast/pat/ref_pat.rs
+++ b/marker_api/src/ast/pat/ref_pat.rs
@@ -4,16 +4,17 @@ use super::{CommonPatData, PatKind};
 
 #[repr(C)]
 #[derive(Debug)]
+#[cfg_attr(feature = "driver-api", derive(typed_builder::TypedBuilder))]
 pub struct RefPat<'ast> {
     data: CommonPatData<'ast>,
-    pattern: PatKind<'ast>,
+    pat: PatKind<'ast>,
     mutability: Mutability,
 }
 
 impl<'ast> RefPat<'ast> {
     /// Returns the pattern, that is behind this reference pattern.
-    pub fn pattern(&self) -> PatKind<'ast> {
-        self.pattern
+    pub fn pat(&self) -> PatKind<'ast> {
+        self.pat
     }
 
     pub fn mutability(&self) -> Mutability {
@@ -25,11 +26,7 @@ super::impl_pat_data!(RefPat<'ast>, Ref);
 
 #[cfg(feature = "driver-api")]
 impl<'ast> RefPat<'ast> {
-    pub fn new(data: CommonPatData<'ast>, pattern: PatKind<'ast>, mutability: Mutability) -> Self {
-        Self {
-            data,
-            pattern,
-            mutability,
-        }
+    pub fn new(data: CommonPatData<'ast>, pat: PatKind<'ast>, mutability: Mutability) -> Self {
+        Self { data, pat, mutability }
     }
 }

--- a/marker_rustc_driver/src/conversion/marker/ast/expr.rs
+++ b/marker_rustc_driver/src/conversion/marker/ast/expr.rs
@@ -114,7 +114,15 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                     ExprKind::Ctor(self.alloc(CtorExpr::new(data, self.to_qpath_from_expr(qpath, expr), fields, None)))
                 },
 
-                _ => ExprKind::Call(self.alloc(CallExpr::new(data, self.to_expr(operand), self.to_exprs(args)))),
+                _ => ExprKind::Call(
+                    self.alloc(
+                        CallExpr::builder()
+                            .data(data)
+                            .func(self.to_expr(operand))
+                            .args(self.to_exprs(args))
+                            .build(),
+                    ),
+                ),
             },
             hir::ExprKind::MethodCall(method, receiver, args, _span) => ExprKind::Method(self.alloc({
                 MethodExpr::new(

--- a/marker_rustc_driver/src/conversion/marker/ast/pat.rs
+++ b/marker_rustc_driver/src/conversion/marker/ast/pat.rs
@@ -84,10 +84,14 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                     ddpos.is_some(),
                 )))
             },
-            hir::PatKind::Or(pats) => PatKind::Or(self.alloc(OrPat::new(
-                data,
-                self.alloc_slice(pats.iter().map(|rpat| self.to_pat_with_hls(rpat, lhs_map))),
-            ))),
+            hir::PatKind::Or(pats) => PatKind::Or(
+                self.alloc(
+                    OrPat::builder()
+                        .data(data)
+                        .pats(self.alloc_slice(pats.iter().map(|rpat| self.to_pat_with_hls(rpat, lhs_map))))
+                        .build(),
+                ),
+            ),
             hir::PatKind::Tuple(pats, dotdot) => {
                 let pats = if let Some(rest_pos) = dotdot.as_opt_usize() {
                     let (start, end) = pats.split_at(rest_pos);
@@ -99,11 +103,15 @@ impl<'ast, 'tcx> MarkerConverterInner<'ast, 'tcx> {
                 PatKind::Tuple(self.alloc(TuplePat::new(data, pats)))
             },
             hir::PatKind::Box(_) => PatKind::Unstable(self.alloc(UnstablePat::new(data))),
-            hir::PatKind::Ref(pat, muta) => PatKind::Ref(self.alloc(RefPat::new(
-                data,
-                self.to_pat_with_hls(pat, lhs_map),
-                self.to_mutability(*muta),
-            ))),
+            hir::PatKind::Ref(pat, muta) => PatKind::Ref(
+                self.alloc(
+                    RefPat::builder()
+                        .data(data)
+                        .pat(self.to_pat_with_hls(pat, lhs_map))
+                        .mutability(self.to_mutability(*muta))
+                        .build(),
+                ),
+            ),
             hir::PatKind::Slice(start, wild, end) => {
                 let elements = if let Some(wild) = wild {
                     self.chain_pats(start, self.new_rest_pat(wild.span), end, lhs_map)

--- a/marker_uilints/tests/ui/expr/print_await_expr.stderr
+++ b/marker_uilints/tests/ui/expr/print_await_expr.stderr
@@ -18,7 +18,7 @@ warning: print test
                               id: ExprId(..),
                               span: SpanId(..),
                           },
-                          operand: Path(
+                          func: Path(
                               PathExpr {
                                   data: CommonExprData {
                                       _lifetime: PhantomData<&()>,

--- a/marker_uilints/tests/ui/item/print_async_fn.stderr
+++ b/marker_uilints/tests/ui/item/print_async_fn.stderr
@@ -190,7 +190,7 @@ warning: printing item with body
                                                           id: ExprId(..),
                                                           span: SpanId(..),
                                                       },
-                                                      operand: Path(
+                                                      func: Path(
                                                           PathExpr {
                                                               data: CommonExprData {
                                                                   _lifetime: PhantomData<&()>,
@@ -274,7 +274,7 @@ warning: printing item with body
                                                           id: ExprId(..),
                                                           span: SpanId(..),
                                                       },
-                                                      operand: Path(
+                                                      func: Path(
                                                           PathExpr {
                                                               data: CommonExprData {
                                                                   _lifetime: PhantomData<&()>,
@@ -358,7 +358,7 @@ warning: printing item with body
                                                           id: ExprId(..),
                                                           span: SpanId(..),
                                                       },
-                                                      operand: Path(
+                                                      func: Path(
                                                           PathExpr {
                                                               data: CommonExprData {
                                                                   _lifetime: PhantomData<&()>,

--- a/marker_uilints/tests/ui/print_assign_expr.stderr
+++ b/marker_uilints/tests/ui/print_assign_expr.stderr
@@ -76,7 +76,7 @@ warning: print test
                                                    id: ExprId(..),
                                                    span: SpanId(..),
                                                },
-                                               operand: Path(
+                                               func: Path(
                                                    PathExpr {
                                                        data: CommonExprData {
                                                            _lifetime: PhantomData<&()>,
@@ -497,7 +497,7 @@ warning: print test
                                                    id: ExprId(..),
                                                    span: SpanId(..),
                                                },
-                                               operand: Path(
+                                               func: Path(
                                                    PathExpr {
                                                        data: CommonExprData {
                                                            _lifetime: PhantomData<&()>,

--- a/marker_uilints/tests/ui/print_cond_expr.stderr
+++ b/marker_uilints/tests/ui/print_cond_expr.stderr
@@ -607,7 +607,7 @@ warning: print test
                                            id: ExprId(..),
                                            span: SpanId(..),
                                        },
-                                       operand: Path(
+                                       func: Path(
                                            PathExpr {
                                                data: CommonExprData {
                                                    _lifetime: PhantomData<&()>,

--- a/marker_uilints/tests/ui/print_ctor.stderr
+++ b/marker_uilints/tests/ui/print_ctor.stderr
@@ -483,7 +483,7 @@ warning: print test
                                    id: ExprId(..),
                                    span: SpanId(..),
                                },
-                               operand: Path(
+                               func: Path(
                                    PathExpr {
                                        data: CommonExprData {
                                            _lifetime: PhantomData<&()>,
@@ -753,7 +753,7 @@ warning: print test
                                    id: ExprId(..),
                                    span: SpanId(..),
                                },
-                               operand: Path(
+                               func: Path(
                                    PathExpr {
                                        data: CommonExprData {
                                            _lifetime: PhantomData<&()>,

--- a/marker_uilints/tests/ui/print_path_expr.stderr
+++ b/marker_uilints/tests/ui/print_path_expr.stderr
@@ -11,7 +11,7 @@ warning: print test
                        id: ExprId(..),
                        span: SpanId(..),
                    },
-                   operand: Path(
+                   func: Path(
                        PathExpr {
                            data: CommonExprData {
                                _lifetime: PhantomData<&()>,
@@ -70,7 +70,7 @@ warning: print test
                        id: ExprId(..),
                        span: SpanId(..),
                    },
-                   operand: Path(
+                   func: Path(
                        PathExpr {
                            data: CommonExprData {
                                _lifetime: PhantomData<&()>,
@@ -182,7 +182,7 @@ warning: print test
                        id: ExprId(..),
                        span: SpanId(..),
                    },
-                   operand: Path(
+                   func: Path(
                        PathExpr {
                            data: CommonExprData {
                                _lifetime: PhantomData<&()>,
@@ -313,7 +313,7 @@ warning: print test
                        id: ExprId(..),
                        span: SpanId(..),
                    },
-                   operand: Path(
+                   func: Path(
                        PathExpr {
                            data: CommonExprData {
                                _lifetime: PhantomData<&()>,

--- a/marker_utils/src/visitor.rs
+++ b/marker_utils/src/visitor.rs
@@ -258,7 +258,7 @@ pub fn traverse_expr<'ast, B>(
             traverse_expr(cx, visitor, e.expr())?;
         },
         ExprKind::Call(e) => {
-            traverse_expr(cx, visitor, e.operand())?;
+            traverse_expr(cx, visitor, e.func())?;
             for arg in e.args() {
                 traverse_expr(cx, visitor, *arg)?;
             }


### PR DESCRIPTION
Some smaller breaking changes before `v0.4.0` probably best summarized by the changelog entry:

- Renamed `CallExpr::operand` to `CallExpr::func`
- Renamed `RefPat::pattern()` -> `RefPat::pat()`
- Renamed `OrPat::patterns()` -> `RefPat::pats()`

Yeah, and that's it :D

---

I also moved the semver check higher in our CI file. I thought about making it the first item, but I feel like the others are still more important and should be the first visible CI checks. Having semver higher up is already a nice change :)

---

Closes https://github.com/rust-marker/marker/issues/297

Closes https://github.com/rust-marker/marker/issues/295