### PR TITLE
Fix qemu setup using too new curl options

### DIFF
--- a/scripts/release/qemu-setup.sh
+++ b/scripts/release/qemu-setup.sh
@@ -17,13 +17,15 @@ apt-get-install \
     curl
 
 function curl_with_retry {
+    # FIXME: replace `--retry-connrefused` with `--retry-all-errors` when we
+    # remove support for ubuntu20.04 which has an old curl version.
     with_log curl \
         --location \
         --silent \
         --show-error \
         --fail \
         --retry 5 \
-        --retry-all-errors \
+        --retry-connrefused \
         "$@"
 }
 


### PR DESCRIPTION
The build failed in driver ARM build due to the usage of `--retry-all-errors`.

The build on master also failed, because we don't use this option on `ubuntu20.04`. I think we'll need to add a manual retry loop there as a crutch for old systems with old curl.

As for now I'll move the `v0`, `v0.4` and `v0.4.0` tags manually to this new commit in a `hotfix/0.4` branch and this will trigger the "release-on-tag" workflow again and it should update the GH release :crossed_fingers: 