### PR TITLE
Fix marker_rustc_driver build ARM just one more time

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -146,7 +146,7 @@ jobs:
         with:
           arch: aarch64
           distro: ubuntu20.04
-          dockerRunArgs: --volume .:/artifacts
+          dockerRunArgs: --volume ./artifacts:/artifacts
           setup: mkdir -p artifacts
           install: ${{ env.install_script }}
           env: |
@@ -158,7 +158,8 @@ jobs:
             cargo build -p marker_rustc_driver --release
             cp target/release/marker_rustc_driver /artifacts/marker_rustc_driver
 
-      - run: ./scripts/release/upload.sh ${{ github.ref_name }} marker_rustc_driver ${{ env.artifact }}
+      - run: ../scripts/release/upload.sh ${{ github.ref_name }} marker_rustc_driver ${{ env.artifact }}
+        working-directory: artifacts
         env:
           GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
When last time I fixed the build of marker_rustc_driver on ARM I tested my changes only locally in an isolated folder where I manually "unit-tested" the `upload.sh` script. Of course, when the build happens on CI the folders layout is entirely different. That's why the ARM packaging script broke but in other way.

On CI we mount the `.` fodler as `/artifacts` in `quemu`, but `.` folder includes the `marker_rustc_driver` crate source code folder. So when we do `cp target/release/marker_rustc_driver /artifacts/marker_rustc_driver` we copy the binary inside of that folder...

I fixed this by mounting `./artifacts` which is guaranteed to be an empty folder.

Also manually fixed and reuploaded the artifacts in 0.4:
<img width="900" alt="image" src="https://github.com/rust-marker/marker/assets/36276403/bf7a97ca-0e34-4d3b-a5bf-0736a8770e08">

This time I tested it end-to-end in my fork repo