### PR TITLE
Cargo: Fix compiling driver from sources outside of the marker repo on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,14 @@ The following components are considered to be internal and they are excluded fro
 
 ## [Unreleased]
 
-The [v0.5.0 milestone] contains a list of planned changes.
+## [0.4.1] - 2023-11-24
 
-[v0.5.0 milestone]: https://github.com/rust-marker/marker/milestone/5
+[#319]: https://github.com/rust-marker/marker/pull/319
+
+### Fixed
+
+- [#319]: Fix compiling driver from sources outside of the marker repo on Windows
+
 
 ## [0.4.0] - 2023-11-16
 

--- a/cargo-marker/src/backend/driver.rs
+++ b/cargo-marker/src/backend/driver.rs
@@ -7,6 +7,7 @@ use crate::{utils::is_local_driver, Result};
 use camino::Utf8Path;
 use std::process::Command;
 use yansi::Paint;
+use super::cargo::Cargo;
 
 pub fn marker_driver_bin_name() -> String {
     format!("marker_rustc_driver{}", std::env::consts::EXE_SUFFIX)
@@ -140,11 +141,10 @@ fn build_driver(toolchain: &str, version: &str, mut additional_rustc_flags: Opti
     }
 
     // Build driver
-    let mut cmd = Command::new("cargo");
+    let mut cmd = Cargo::with_toolchain(toolchain).command();
     if is_local_driver() {
         cmd.args(["build", "--bin", "marker_rustc_driver"]);
     } else {
-        cmd.env("RUSTUP_TOOLCHAIN", toolchain);
         cmd.args(["install", "marker_rustc_driver", "--version", version, "--force"]);
 
         *additional_rustc_flags.get_or_insert_with(Default::default) += " --cap-lints=allow";

--- a/cargo-marker/src/backend/driver.rs
+++ b/cargo-marker/src/backend/driver.rs
@@ -1,3 +1,4 @@
+use super::cargo::Cargo;
 use super::toolchain::{get_toolchain_folder, rustup_which, Toolchain};
 use crate::error::prelude::*;
 use crate::observability::display::print_stage;
@@ -7,7 +8,6 @@ use crate::{utils::is_local_driver, Result};
 use camino::Utf8Path;
 use std::process::Command;
 use yansi::Paint;
-use super::cargo::Cargo;
 
 pub fn marker_driver_bin_name() -> String {
     format!("marker_rustc_driver{}", std::env::consts::EXE_SUFFIX)


### PR DESCRIPTION
Closes https://github.com/rust-marker/marker/issues/318

I immediately identified the problem by the [logs](https://github.com/rust-marker/marker/issues/318#issuecomment-1825917130) because this bug is specific to Windows only.


It was described as "Problem 2" in the description of the PR https://github.com/rust-marker/marker/pull/217, although that appeared in a bit different place at that moment.

This is just a quick fix, it doesn't setup testing on CI. I just reproduced the problem manually on my windows laptop and fixed it.