### PR TITLE
Remove params that aren't supported by `cargo release publish`

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -199,6 +199,6 @@ jobs:
       # No idea why this happens, but let's just keep a single cargo release
       # to avoid this issue and to simplify the workflow, because the problem
       # we tried to protect against is not that likely to happen anyway.
-      - run: cargo release publish --no-confirm --no-verify --no-push --no-tag --allow-branch '*'
+      - run: cargo release publish --no-confirm --no-verify --allow-branch '*'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/scripts/download/cargo-release.sh
+++ b/scripts/download/cargo-release.sh
@@ -6,7 +6,7 @@ script_dir=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 
 . $script_dir/lib.sh
 
-version=0.24.11
+version=0.25.0
 
 base_url=https://github.com/crate-ci/cargo-release/releases/download/v$version
 


### PR DESCRIPTION
I was confused by [this warning on CI](https://github.com/rust-marker/marker/actions/runs/6984551469/job/19007537021#step:6:14)

It looked to me as if cargo release wanted to do a commit and push changes to the remote. I still don't understand why that warning is emitted because `cargo release` is used only for publishing. Maybe that's a micro-bug in `cargo-release`. Anyway, this time it was me who broke crates publishing. Hopefully, this was the last obstacle