### PR TITLE
Rustc: Simplify `--sysroot` code after `rust#103660` and prepare `0.4.3-rc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-[Unreleased]: https://github.com/rust-marker/marker/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/rust-marker/marker/compare/v0.4.3-rc...HEAD
+[0.4.3-rc]: https://github.com/rust-marker/marker/releases/tag/v0.4.3-rc
+[0.4.2]: https://github.com/rust-marker/marker/releases/tag/v0.4.2
+[0.4.1]: https://github.com/rust-marker/marker/releases/tag/v0.4.1
 [0.4.0]: https://github.com/rust-marker/marker/releases/tag/v0.4.0
 [0.3.0]: https://github.com/rust-marker/marker/releases/tag/v0.3.0
 [0.2.1]: https://github.com/rust-marker/marker/releases/tag/v0.2.1
@@ -24,9 +27,19 @@ The following components are considered to be internal and they are excluded fro
 
 ## [Unreleased]
 
+## [0.4.3-rc] - 2023-12-02
+
+[#326]: https://github.com/rust-marker/marker/pull/326
+
+### Fixed
+
+- [#326]: Use rustc's default way of discovering the system root directory, unless `MARKER_SYSROOT` is specified
+
 ## [0.4.2] - 2023-11-25
 
 [#320]: https://github.com/rust-marker/marker/pull/320
+
+### Fixed
 
 - [#320]: Disable LTO on release builds to fix the crash on Windows with `exit code: 0xc0000005, STATUS_ACCESS_VIOLATION`
 
@@ -37,7 +50,6 @@ The following components are considered to be internal and they are excluded fro
 ### Fixed
 
 - [#319]: Fix compiling driver from sources outside of the marker repo on Windows
-
 
 ## [0.4.0] - 2023-11-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "cargo_marker"
-version = "0.4.2"
+version = "0.4.3-dev"
 dependencies = [
  "camino",
  "cargo_metadata 0.18.0",
@@ -566,7 +566,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "marker_adapter"
-version = "0.4.2"
+version = "0.4.3-dev"
 dependencies = [
  "camino",
  "itertools",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "marker_api"
-version = "0.4.2"
+version = "0.4.3-dev"
 dependencies = [
  "expect-test",
  "typed-builder",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "marker_error"
-version = "0.4.2"
+version = "0.4.3-dev"
 dependencies = [
  "miette",
  "thiserror",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "marker_lints"
-version = "0.4.2"
+version = "0.4.3-dev"
 dependencies = [
  "marker_api",
  "marker_uitest",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "marker_rustc_driver"
-version = "0.4.2"
+version = "0.4.3-dev"
 dependencies = [
  "bumpalo",
  "camino",
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "marker_uilints"
-version = "0.4.2"
+version = "0.4.3-dev"
 dependencies = [
  "marker_api",
  "marker_uitest",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "marker_uitest"
-version = "0.4.2"
+version = "0.4.3-dev"
 dependencies = [
  "semver",
  "ui_test",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "marker_utils"
-version = "0.4.2"
+version = "0.4.3-dev"
 dependencies = [
  "marker_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ license    = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-marker/marker"
 
 # region replace marker version dev
-version = "0.4.2"
+version = "0.4.3-dev"
 # endregion replace marker version dev
 
 # The MSRV is applied to the public library crates published to crates.io
@@ -34,11 +34,11 @@ rust-version = "1.66"
 
 [workspace.dependencies]
 # region replace marker version dev
-marker_adapter = { path = "./marker_adapter", version = "0.4.2" }
-marker_api     = { path = "./marker_api", version = "0.4.2" }
-marker_error   = { path = "./marker_error", version = "0.4.2" }
+marker_adapter = { path = "./marker_adapter", version = "0.4.3-dev" }
+marker_api     = { path = "./marker_api", version = "0.4.3-dev" }
+marker_error   = { path = "./marker_error", version = "0.4.3-dev" }
 marker_uitest  = { path = "./marker_uitest", features = ["dev-build"] }
-marker_utils   = { path = "./marker_utils", version = "0.4.2" }
+marker_utils   = { path = "./marker_utils", version = "0.4.3-dev" }
 # endregion replace marker version dev
 
 bumpalo            = "3.14"

--- a/cargo-marker/src/backend/driver.rs
+++ b/cargo-marker/src/backend/driver.rs
@@ -21,8 +21,8 @@ pub(crate) fn default_driver_info() -> DriverVersionInfo {
         toolchain: "nightly-2023-11-16".to_string(),
         // endregion replace rust toolchain dev
         // region replace marker version dev
-        version: "0.4.2".to_string(),
-        api_version: "0.4.2".to_string(),
+        version: "0.4.3-dev".to_string(),
+        api_version: "0.4.3-dev".to_string(),
         // endregion replace marker version dev
     }
 }


### PR DESCRIPTION
The first commit is the same as rust-marker/marker#325