### PR TITLE
Release: Take important changes from `hotfix/0.4`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-[Unreleased]: https://github.com/rust-marker/marker/compare/v0.4.2...HEAD
+[Unreleased]: https://github.com/rust-marker/marker/compare/v0.4.3...HEAD
+[0.4.3]: https://github.com/rust-marker/marker/releases/tag/v0.4.3
 [0.4.2]: https://github.com/rust-marker/marker/releases/tag/v0.4.2
 [0.4.1]: https://github.com/rust-marker/marker/releases/tag/v0.4.1
 [0.4.0]: https://github.com/rust-marker/marker/releases/tag/v0.4.0
@@ -38,6 +39,14 @@ The following components are considered to be internal and they are excluded fro
 - [#322]: Renamed `sem::TyKind::ClosureTy` -> `sem::TyKind::Closure`
 - [#322]: Renamed `sem::ClosureTy::closure_ty_id` -> `sem::ClosureTy::def_id`
 
+## [0.4.3] - 2023-12-02
+
+[#326]: https://github.com/rust-marker/marker/pull/326
+
+### Fixed
+
+- [#326]: Use rustc's default way of discovering the system root directory, unless `MARKER_SYSROOT` is specified
+
 ## [0.4.2] - 2023-11-25
 
 [#320]: https://github.com/rust-marker/marker/pull/320
@@ -53,7 +62,6 @@ The following components are considered to be internal and they are excluded fro
 ### Fixed
 
 - [#319]: Fix compiling driver from sources outside of the marker repo on Windows
-
 
 ## [0.4.0] - 2023-11-16
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ The following is a small collection of ways you can test Marker right now:
 
 <!-- region replace marker version stable -->
     ```sh
-    cargo marker --lints "marker_lints = '0.4.2'"
+    cargo marker --lints "marker_lints = '0.4.3'"
     ```
 <!-- endregion replace marker version stable -->
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ curl -fsSL https://raw.githubusercontent.com/rust-marker/marker/v0.4/scripts/rel
 curl.exe -fsSL https://raw.githubusercontent.com/rust-marker/marker/v0.4/scripts/release/install.ps1 | powershell -command -
 ```
 
-The provided scripts use a sliding git tag `v0.4`, to allow for automatic patch version updates, however a fixed tag `v0.4.2` is also available.
+The provided scripts use a sliding git tag `v0.4`, to allow for automatic patch version updates, however a fixed tag `v0.4.3` is also available.
 
 <!-- endregion replace marker version stable -->
 
@@ -111,7 +111,7 @@ marker_lints = { path = './marker_lints' }
 # An external crate via git
 marker_lints = { git = "https://github.com/rust-marker/marker" }
 # An external crate from a registry
-marker_lints = "0.4.2"
+marker_lints = "0.4.3"
 ```
 <!-- endregion replace marker version stable -->
 

--- a/cargo-marker/src/error.rs
+++ b/cargo-marker/src/error.rs
@@ -70,9 +70,9 @@ marker_lints = { path = './marker_lints' }
 # An external crate via git
 marker_lints = { git = "https://github.com/rust-marker/marker" }
 # An external crate from a registry
-marker_lints = "0.4.2""#
+marker_lints = "0.4.3""#
         ),
-        cli_example = display::cli(r#"cargo marker --lints "marker_lints = '0.4.2'""#),
+        cli_example = display::cli(r#"cargo marker --lints "marker_lints = '0.4.3'""#),
         lints = "--lints".blue(),
     )
 }

--- a/docs/book/src/usage/ci.md
+++ b/docs/book/src/usage/ci.md
@@ -22,7 +22,7 @@ The git tag specified in the GitHub Action indicates which version of Marker sho
 
   Use this to get automatic patch updates.
 
-- **Fixed tags, like `v0.4.2`:**
+- **Fixed tags, like `v0.4.3`:**
 
   Use this to pin a specific patch version. If you find a regression in a patch version, please create a [new issue]. Patch versions must never break anything!
 

--- a/docs/book/src/usage/installation.md
+++ b/docs/book/src/usage/installation.md
@@ -31,7 +31,7 @@ curl -fsSL https://raw.githubusercontent.com/rust-marker/marker/v0.4/scripts/rel
 curl.exe -fsSL https://raw.githubusercontent.com/rust-marker/marker/v0.4/scripts/release/install.ps1 | powershell -command -
 ```
 
-The provided scripts use a sliding git tag `v0.4`, to allow for automatic patch version updates, however a fixed tag `v0.4.2` is also available.
+The provided scripts use a sliding git tag `v0.4`, to allow for automatic patch version updates, however a fixed tag `v0.4.3` is also available.
 
 <!-- endregion replace marker version stable -->
 

--- a/docs/book/src/usage/lint-crate-declaration.md
+++ b/docs/book/src/usage/lint-crate-declaration.md
@@ -12,7 +12,7 @@ The main way to declare lint crates, is to add them to the `Cargo.toml` file und
 ```toml
 [workspace.metadata.marker.lints]
 # An external crate from a registry
-marker_lints = "0.4.2"
+marker_lints = "0.4.3"
 
 # An external crate from git
 marker_lints = { git = "https://github.com/rust-marker/marker" }
@@ -31,7 +31,7 @@ A lint crate can be specified with the `--lints` option. The string is expected 
 <!-- region replace marker version stable -->
 ```sh
 # An external crate from a registry
-cargo marker --lint "marker_lints = '0.4.2'"
+cargo marker --lint "marker_lints = '0.4.3'"
 
 # An external crate from git
 cargo marker --lint "marker_lints = { git = 'https://github.com/rust-marker/marker' }"

--- a/docs/internal/release.md
+++ b/docs/internal/release.md
@@ -31,7 +31,7 @@ GitHub is very generous with the releases storage limits. They are [almost unlim
 The `sha256` sum is a small file that users may optionally download together with the archive itself to verify the integrity of the archive. It serves as a signature of the artifact to make sure it was downloaded as expected bit-by-bit with what was published effectively detecting corruptions during the download and making it harder to forge artifacts for malicious actors.
 
 <!-- region replace marker version stable -->
-This [`install.sh`](https://raw.githubusercontent.com/rust-marker/marker/v0.4.2/scripts/release/install.sh) script, can be used to automatically download and verify Marker's binaries.
+This [`install.sh`](https://raw.githubusercontent.com/rust-marker/marker/v0.4.3/scripts/release/install.sh) script, can be used to automatically download and verify Marker's binaries.
 <!-- endregion replace marker version stable -->
 
 ### Operating system versions coverage

--- a/marker_api/README.md
+++ b/marker_api/README.md
@@ -46,8 +46,8 @@ To get started, create a new Rust crate that compiles to a library (`cargo init 
 crate-type = ["cdylib"]
 
 [dependencies]
-marker_api = "0.4.2"
-marker_utils = "0.4.2"
+marker_api = "0.4.3"
+marker_utils = "0.4.3"
 ```
 <!-- endregion replace marker version stable -->
 

--- a/marker_lints/README.md
+++ b/marker_lints/README.md
@@ -28,7 +28,7 @@ To use `marker_lints` in your project, simply add it to your `Cargo.toml` under 
 <!-- region replace marker version stable -->
 ```toml
 [workspace.metadata.marker.lints]
-marker_lints = "0.4.2"
+marker_lints = "0.4.3"
 ```
 <!-- endregion replace marker version stable -->
 

--- a/marker_uitest/README.md
+++ b/marker_uitest/README.md
@@ -31,7 +31,7 @@ First add `marker_utils` to the dev-dependencies of the lint crate, and specify 
 <!-- region replace marker version stable -->
 ```toml
 [dev-dependencies]
-marker_uitest = "0.4.2"
+marker_uitest = "0.4.3"
 
 [[test]]
 name = "uitest"

--- a/marker_utils/README.md
+++ b/marker_utils/README.md
@@ -22,14 +22,14 @@ To get started, just include *marker_utils* as a dependency:
 <!-- region replace marker version stable -->
 ```toml
 [dependencies]
-marker_api = "0.4.2"
+marker_api = "0.4.3"
 ```
 
 You can also add [marker_lints] as a lint crate, designed for this crate:
 
 ```toml
 [workspace.metadata.marker.lints]
-marker_lints = "0.4.2"
+marker_lints = "0.4.3"
 ```
 <!-- endregion replace marker version stable -->
 

--- a/scripts/release/install.ps1
+++ b/scripts/release/install.ps1
@@ -68,7 +68,7 @@ Using config env vars (override these if needed):
 # This script isn't meant to be run from `master`, but if it is, then
 # it will install the latest version be it a stable version or a pre-release.
 # region replace marker version unstable
-$version = "0.4.2"
+$version = "0.4.3"
 # endregion replace marker version unstable
 
 # region replace rust toolchain release

--- a/scripts/release/install.sh
+++ b/scripts/release/install.sh
@@ -24,7 +24,7 @@ echo "Bash version: $BASH_VERSION" >&2
 # This script isn't meant to be run from `master`, but if it is, then
 # it will install the latest version be it a stable version or a pre-release.
 # region replace marker version unstable
-version=0.4.2
+version=0.4.3
 # endregion replace marker version unstable
 
 # region replace rust toolchain release


### PR DESCRIPTION
The main bug fix has already landed on master in #325. This pulls the necessary version changes for the CI test to master.

I've tried cherry-picking the release commits, but they had too many conflicts. Manually updating all `0.4.2` -> `0.4.3` was the most reasonable solution.