### PR TITLE
Action: Run cargo marker with `--all-targets --all-features [--locked]` in GitHub action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,14 @@ runs:
     - run: ${GITHUB_ACTION_PATH:?}/scripts/release/install.${{ runner.os == 'Windows' && 'ps1' || 'sh' }}
       shell: bash
 
-    - run: cargo marker
+    # Run the check with `--locked` only if there is a `Cargo.lock` file present in the
+    # repository. Not everyone checks in the `Cargo.lock` file into the version control,
+    # but if they do they would want this command to run with `--locked` to ensure that
+    # the lock file is up to date.
+    - run: |
+        cargo marker -- --all-targets --all-features${{
+          hashFiles('./Cargo.lock') != '' && ' --locked' || ''
+        }}
+
       if: ${{ inputs.install-only == 'false' }}
       shell: bash


### PR DESCRIPTION
It looks like this is the default way linting should be run.
Tested it in https://github.com/rust-marker/lint-crate-template/pull/9